### PR TITLE
Fix bugs from Nationals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1122,7 +1122,7 @@ dependencies = [
 
 [[package]]
 name = "fonts"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "embedded-graphics",
 ]
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "uwh-common"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.2",
@@ -3483,7 +3483,7 @@ dependencies = [
 
 [[package]]
 name = "uwh-matrix-drawing"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.2",

--- a/README.md
+++ b/README.md
@@ -2,7 +2,21 @@
 
 The main software component here is the [`uwh-refbox`](uwh-refbox) crate. The other crates are support crates that are also used by other binaries, not included here.
 
-# Running
+# Running the Binary
+
+On Windows and Mac the app can be run by downloading the latest relase from GitHub and following the bundled instructions.
+
+If you want to change the size of the simulated panels, you will need to run via the command line:
+
+## Windows
+
+1. Open `PowerShell` (to open `PowerShell`, start by typing "PowerShell" into the search bar by the windows icon, then clicking the app)
+2. Drag the `.exe` from `File Explorer` into the `PowerShell` window (this will insert the location of the `.exe` into the command line)
+3. Add the following to the command line: `-s N` (with a space before `-s`) where `N` is any positive decimal number (`4` and `4.0` are both acceptable). `N` sets the size of the panels, the default value is `4`
+4. Confrim that the command line now looks something like this: `'<PATH TO EXE>' -s 5.5`
+5. Press `enter` to start the program
+
+# Running From Source
 
 1. You will need to [Install Rust](https://rustup.rs/)
 2. Ensure that you have the following libraries installed: 

--- a/fonts/Cargo.toml
+++ b/fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fonts"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Atlantis Sports <maintainers@atlantissports.org>"]
 edition = "2021"
 

--- a/uwh-common/Cargo.toml
+++ b/uwh-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uwh-common"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Atlantis Sports <maintainers@atlantissports.org>"]
 edition = "2021"
 
@@ -14,7 +14,7 @@ arrayvec = { version = "0.7.2", default-features = false, features = ["serde"] }
 defmt = "0.3.1"
 derivative = { version = "2.2.0", features = ["use_core"] }
 displaydoc = { version = "0.2.3", default-features = false }
-fonts = { version = "0.1.0", path = "../fonts" }
+fonts = { version = "0.1.1", path = "../fonts" }
 log = "0.4.16"
 serde = { version = "1.0", default-features = false }
 serde_derive = "1.0"

--- a/uwh-common/src/config.rs
+++ b/uwh-common/src/config.rs
@@ -84,7 +84,7 @@ impl Default for Game {
             pre_overtime_break: Duration::from_secs(180),
             overtime_break_duration: Duration::from_secs(60),
             pre_sudden_death_duration: Duration::from_secs(60),
-            post_game_duration: Duration::from_secs(60),
+            post_game_duration: Duration::from_secs(120),
             nominal_break: Duration::from_secs(900),
             minimum_break: Duration::from_secs(240),
         }
@@ -169,7 +169,7 @@ mod test {
            pre_sudden_death_duration = 60
            sudden_death_allowed = true
            team_timeouts_per_half = 1
-           post_game_duration = 60
+           post_game_duration = 120
            nominal_break = 900
            minimum_break = 240"#
     );

--- a/uwh-common/src/game_snapshot.rs
+++ b/uwh-common/src/game_snapshot.rs
@@ -15,8 +15,8 @@ use serde_derive::{Deserialize, Serialize};
 const PANEL_PENALTY_COUNT: usize = 3;
 
 /// Game snapshot information that the LED matrices need. Excludes some fields, limits to three
-/// penalties (the three with the lowest remaining time), and places the penalties on a stack based
-/// `ArrayVec`, instead of the heap based `Vec`
+/// penalties (the three with the lowest remaining time), and places the penalties on a stack-based
+/// `ArrayVec`, instead of the heap-based `Vec`
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct GameSnapshotNoHeap {
     pub current_period: GamePeriod,

--- a/uwh-common/src/lib.rs
+++ b/uwh-common/src/lib.rs
@@ -4,3 +4,9 @@ pub mod game_snapshot;
 
 #[cfg(feature = "std")]
 pub mod config;
+
+pub mod drawing_support {
+    pub const MAX_STRINGABLE_SECS: u16 = 5999;
+    pub const MAX_LONG_STRINGABLE_SECS: u32 = 5_999_999;
+    pub const MAX_SHORT_STRINGABLE_SECS: u8 = 99;
+}

--- a/uwh-matrix-drawing/Cargo.toml
+++ b/uwh-matrix-drawing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uwh-matrix-drawing"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Atlantis Sports <maintainers@atlantissports.org>"]
 edition = "2021"
 
@@ -12,8 +12,8 @@ std = ["arrayvec/std", "serde/std", "uwh-common/std"]
 arrayref = "0.3.6"
 arrayvec = { version = "0.7.2", default-features = false }
 embedded-graphics = "0.7.1"
-fonts = { version = "0.1.0", path = "../fonts" }
+fonts = { version = "0.1.1", path = "../fonts" }
 more-asserts = "0.2"
 serde = { version = "1.0", default-features = false }
 serde_derive = "1.0"
-uwh-common = { version = "0.1.0", path = "../uwh-common", default-features = false }
+uwh-common = { version = "0.1.1", path = "../uwh-common", default-features = false }

--- a/uwh-refbox/Cargo.toml
+++ b/uwh-refbox/Cargo.toml
@@ -35,8 +35,8 @@ time = { version = "0.3", features = ["local-offset", "macros", "serde", "serde-
 tokio = { version = "1.18", features = ["io-util", "macros", "net", "sync", "time"] }
 tokio-serial = "5.4"
 toml = "0.5"
-uwh-common = { version = "0.1.0", path = "../uwh-common"}
-uwh-matrix-drawing = { version = "0.1.0", path = "../uwh-matrix-drawing"}
+uwh-common = { version = "0.1.1", path = "../uwh-common"}
+uwh-matrix-drawing = { version = "0.1.1", path = "../uwh-matrix-drawing"}
 
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1"

--- a/uwh-refbox/src/app/mod.rs
+++ b/uwh-refbox/src/app/mod.rs
@@ -269,7 +269,7 @@ impl RefBoxApp {
     fn apply_snapshot(&mut self, mut new_snapshot: GameSnapshot) {
         if new_snapshot.current_period != self.snapshot.current_period {
             if new_snapshot.current_period == GamePeriod::BetweenGames {
-                self.handle_game_end();
+                self.handle_game_end(new_snapshot.next_game_number);
             } else if self.snapshot.current_period == GamePeriod::BetweenGames {
                 self.handle_game_start(new_snapshot.game_number);
             }
@@ -540,10 +540,10 @@ impl RefBoxApp {
         }
     }
 
-    fn handle_game_end(&self) {
+    fn handle_game_end(&self, next_game_num: u32) {
         if self.using_uwhscores {
             if let Some(tid) = self.current_tid {
-                self.request_game_details(tid, self.snapshot.game_number);
+                self.request_game_details(tid, next_game_num);
             } else {
                 error!("Missing current tid to request game info");
             }

--- a/uwh-refbox/src/app/mod.rs
+++ b/uwh-refbox/src/app/mod.rs
@@ -1171,7 +1171,11 @@ impl Application for RefBoxApp {
                                 start_time,
                             });
 
-                            tm.clear_scheduled_game_start();
+                            if edited_settings.using_uwhscores {
+                                tm.apply_next_game_start(Instant::now()).unwrap();
+                            } else {
+                                tm.clear_scheduled_game_start();
+                            }
 
                             let edited_settings = self.edited_settings.take().unwrap();
                             self.config.hardware.white_on_right = edited_settings.white_on_right;
@@ -1218,6 +1222,11 @@ impl Application for RefBoxApp {
                             };
 
                             tm.set_next_game(next_game_info);
+
+                            if edited_settings.using_uwhscores {
+                                tm.apply_next_game_start(Instant::now()).unwrap();
+                            }
+
                             AppState::MainPage
                         }
                     } else {
@@ -1276,8 +1285,14 @@ impl Application for RefBoxApp {
                             .map(|(i, _)| i)
                     }),
                     ListableParameter::Game => self.games.as_ref().and_then(|games| {
+                        let pool = self
+                            .edited_settings
+                            .as_ref()
+                            .and_then(|edit| edit.current_pool.clone())?;
+
                         games
                             .iter()
+                            .filter(|(_, game)| game.pool == pool)
                             .enumerate()
                             .find(|(_, (gid, _))| {
                                 **gid == self.edited_settings.as_ref().unwrap().game_number
@@ -1405,7 +1420,11 @@ impl Application for RefBoxApp {
                             start_time,
                         });
 
-                        tm.clear_scheduled_game_start();
+                        if edited_settings.using_uwhscores {
+                            tm.apply_next_game_start(Instant::now()).unwrap();
+                        } else {
+                            tm.clear_scheduled_game_start();
+                        }
 
                         self.config.hardware.white_on_right = edited_settings.white_on_right;
                         self.using_uwhscores = edited_settings.using_uwhscores;

--- a/uwh-refbox/src/app/mod.rs
+++ b/uwh-refbox/src/app/mod.rs
@@ -1072,6 +1072,8 @@ impl Application for RefBoxApp {
                                 start_time,
                             });
 
+                            tm.clear_scheduled_game_start();
+
                             let edited_settings = self.edited_settings.take().unwrap();
                             self.config.hardware.white_on_right = edited_settings.white_on_right;
                             self.using_uwhscores = edited_settings.using_uwhscores;
@@ -1303,6 +1305,8 @@ impl Application for RefBoxApp {
                             timing,
                             start_time,
                         });
+
+                        tm.clear_scheduled_game_start();
 
                         self.config.hardware.white_on_right = edited_settings.white_on_right;
                         self.using_uwhscores = edited_settings.using_uwhscores;

--- a/uwh-refbox/src/app/view_builders.rs
+++ b/uwh-refbox/src/app/view_builders.rs
@@ -29,7 +29,7 @@ use uwh_common::{
         Color as GameColor, GamePeriod, GameSnapshot, PenaltySnapshot, PenaltyTime, TimeoutSnapshot,
     },
 };
-use uwh_matrix_drawing::secs_to_time_string;
+use uwh_matrix_drawing::{secs_to_long_time_string, secs_to_time_string};
 
 pub(super) fn build_main_view<'a>(
     snapshot: &GameSnapshot,
@@ -1912,7 +1912,7 @@ fn make_game_time_button<'a>(
         TimeoutSnapshot::None => None,
     };
 
-    let time_text = secs_to_time_string(snapshot.secs_in_period);
+    let time_text = secs_to_long_time_string(snapshot.secs_in_period);
     let time_text = time_text.trim();
 
     if tall {
@@ -1959,6 +1959,8 @@ fn make_time_editor<'a, T: Into<String>>(
     time: Duration,
     timeout: bool,
 ) -> Container<'a, Message> {
+    let wide = time > Duration::from_secs(MAX_STRINGABLE_SECS as u64);
+
     container(
         column()
             .spacing(SPACING)
@@ -1994,7 +1996,7 @@ fn make_time_editor<'a, T: Into<String>>(
                         text(time_string(time))
                             .size(LARGE_TEXT)
                             .horizontal_alignment(Horizontal::Center)
-                            .width(Length::Units(200)),
+                            .width(Length::Units(if wide { 300 } else { 200 })),
                     )
                     .push(
                         column()
@@ -2025,7 +2027,7 @@ fn make_time_editor<'a, T: Into<String>>(
 }
 
 fn time_string(time: Duration) -> String {
-    secs_to_time_string(time.as_secs()).trim().to_string()
+    secs_to_long_time_string(time.as_secs()).trim().to_string()
 }
 
 fn timeout_time_string(snapshot: &GameSnapshot) -> String {

--- a/uwh-refbox/src/tournament_manager.rs
+++ b/uwh-refbox/src/tournament_manager.rs
@@ -659,19 +659,8 @@ impl TournamentManager {
         Ok(())
     }
 
-    fn end_game(&mut self, now: Instant) {
-        let was_running = self.clock_is_running();
-
-        self.current_period = GamePeriod::BetweenGames;
-
-        info!(
-            "{} Ending game {}. Score is B({}), W({})",
-            self.status_string(now),
-            self.game_number,
-            self.b_score,
-            self.w_score
-        );
-
+    fn calc_time_to_next_game(&self, now: Instant, from_time: Instant) -> Duration {
+        info!("Next game info is: {:?}", self.next_game);
         let scheduled_start =
             if let Some(start_time) = self.next_game.as_ref().and_then(|info| info.start_time) {
                 let cur_time = OffsetDateTime::now_utc().to_offset(self.timezone);
@@ -695,6 +684,60 @@ impl TournamentManager {
                     .unwrap_or(now + self.config.nominal_break)
             };
 
+        let time_remaining_at_start =
+            if let Some(time_until_start) = scheduled_start.checked_duration_since(from_time) {
+                max(time_until_start, self.config.minimum_break)
+            } else {
+                self.config.minimum_break
+            };
+
+        // Make sure the value isn't too big
+        min(time_remaining_at_start, MAX_TIME_VAL)
+    }
+
+    pub fn apply_next_game_start(&mut self, now: Instant) -> Result<()> {
+        if self.current_period != GamePeriod::BetweenGames {
+            return Err(TournamentManagerError::GameInProgress);
+        }
+
+        let next_game_info = if let Some(info) = self.next_game.as_ref() {
+            info
+        } else {
+            return Err(TournamentManagerError::NoNextGameInfo);
+        };
+
+        if let Some(ref timing) = next_game_info.timing {
+            self.config = timing.clone().into();
+        }
+
+        let time_remaining_at_start = self.calc_time_to_next_game(now, now);
+
+        info!(
+            "{} Setting between games time based on uwhscores info: {time_remaining_at_start:?}",
+            self.status_string(now),
+        );
+
+        self.clock_state = ClockState::CountingDown {
+            start_time: now,
+            time_remaining_at_start,
+        };
+
+        Ok(())
+    }
+
+    fn end_game(&mut self, now: Instant) {
+        let was_running = self.clock_is_running();
+
+        self.current_period = GamePeriod::BetweenGames;
+
+        info!(
+            "{} Ending game {}. Score is B({}), W({})",
+            self.status_string(now),
+            self.game_number,
+            self.b_score,
+            self.w_score
+        );
+
         let game_end = match self.clock_state {
             ClockState::CountingDown {
                 start_time,
@@ -703,15 +746,7 @@ impl TournamentManager {
             ClockState::CountingUp { .. } | ClockState::Stopped { .. } => now,
         };
 
-        let time_remaining_at_start =
-            if let Some(time_until_start) = scheduled_start.checked_duration_since(game_end) {
-                max(time_until_start, self.config.minimum_break)
-            } else {
-                self.config.minimum_break
-            };
-
-        // Make sure the value isn't too big
-        let time_remaining_at_start = min(time_remaining_at_start, MAX_TIME_VAL);
+        let time_remaining_at_start = self.calc_time_to_next_game(now, game_end);
 
         info!(
             "{} Entering between games, time to next game is {time_remaining_at_start:?}",
@@ -1639,6 +1674,8 @@ pub enum TournamentManagerError {
     InvalidIndex(Color, usize),
     #[error("Can't halt game from the current state")]
     InvalidState,
+    #[error("Next Game Info is needed to perform this action")]
+    NoNextGameInfo,
 }
 
 pub type Result<T> = std::result::Result<T, TournamentManagerError>;

--- a/uwh-refbox/src/tournament_manager.rs
+++ b/uwh-refbox/src/tournament_manager.rs
@@ -144,6 +144,10 @@ impl TournamentManager {
         Ok(())
     }
 
+    pub fn clear_scheduled_game_start(&mut self) {
+        self.next_scheduled_start = None;
+    }
+
     pub fn game_number(&self) -> u32 {
         self.game_number
     }

--- a/uwh-refbox/src/tournament_manager.rs
+++ b/uwh-refbox/src/tournament_manager.rs
@@ -13,6 +13,7 @@ use tokio::{
 };
 use uwh_common::{
     config::Game as GameConfig,
+    drawing_support::*,
     game_snapshot::{
         Color, GamePeriod, GameSnapshot, PenaltySnapshot, PenaltyTime, TimeoutSnapshot,
     },
@@ -20,7 +21,7 @@ use uwh_common::{
 
 use crate::uwhscores::TimingRules;
 
-const MAX_TIME_VAL: Duration = Duration::from_secs(5999); // 99:59 is the largest displayable value
+const MAX_TIME_VAL: Duration = Duration::from_secs(MAX_LONG_STRINGABLE_SECS as u64);
 
 #[derive(Debug)]
 pub struct TournamentManager {
@@ -1302,7 +1303,7 @@ impl TournamentManager {
             is_old_game: !self.has_reset,
             game_number: self.game_number(),
             next_game_number: self.next_game_number(),
-            tournament_id: 0, // TODO: placeholder
+            tournament_id: 0,
         })
     }
 


### PR DESCRIPTION
- Clear scheduled start time when timing parameters change (fixes #87)
- Fix refbox checking wrong game num from uwhscores at end of game
- Ignore duplicates of some messages
- Allow time between games to exceed 99:59 (fixes #76)
- Timeout HTTP requests after 10s, retry up to 6 times (fixes #85)
- Change default post-game duration to 120s
- Set time to next game with uwhscores start time when user switches game num (fixes #84)
- Add windows CLI running instructions to README