### PR TITLE
Fix errors and warnings without `std` feature

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,8 +23,10 @@ jobs:
       - run: cargo clippy -- --version
       - run: cargo fmt --all -- --check
       - run: cargo clippy --all -- --deny=warnings
+      - run: cargo clippy --all --no-default-features -- --deny=warnings
       - run: cargo audit --ignore RUSTSEC-2020-0056
       - run: cargo build --all
+      - run: cargo build --all --no-default-features
       - run: cargo test --all
       - run: ./ci/clean-cache.sh
       - save_cache:

--- a/uwh-common/src/game_snapshot.rs
+++ b/uwh-common/src/game_snapshot.rs
@@ -3,8 +3,10 @@ use crate::config::Game;
 use crate::drawing_support::*;
 use arrayref::array_ref;
 use arrayvec::ArrayVec;
+#[cfg(feature = "std")]
+use core::cmp::min;
 use core::{
-    cmp::{min, Ordering, PartialOrd},
+    cmp::{Ordering, PartialOrd},
     time::Duration,
 };
 #[cfg(not(target_os = "windows"))]

--- a/uwh-common/src/game_snapshot.rs
+++ b/uwh-common/src/game_snapshot.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "std")]
-use crate::{config::Game, drawing_support::*};
+use crate::config::Game;
+use crate::drawing_support::*;
 use arrayref::array_ref;
 use arrayvec::ArrayVec;
 use core::{


### PR DESCRIPTION
Building `uwh-common` without the `std` feature cause errors and warnings. This fixes the problems and adds those checks to CI to avoid future issues