### PR TITLE
Add next period duration to snapshot

### DIFF
--- a/uwh-common/src/game_snapshot.rs
+++ b/uwh-common/src/game_snapshot.rs
@@ -49,6 +49,7 @@ pub struct GameSnapshot {
     pub next_game_number: u32,
     pub tournament_id: u32,
     pub recent_goal: Option<(Color, u8)>,
+    pub next_period_len_secs: Option<u32>,
 }
 
 #[cfg(feature = "std")]
@@ -179,6 +180,52 @@ impl GamePeriod {
             Self::OvertimeHalfTime => Some(Self::OvertimeSecondHalf),
             Self::OvertimeSecondHalf => Some(Self::PreSuddenDeath),
             Self::PreSuddenDeath => Some(Self::SuddenDeath),
+            Self::SuddenDeath => None,
+        }
+    }
+
+    #[cfg(feature = "std")]
+    pub fn next_period_dur(self, config: &Game) -> Option<Duration> {
+        match self.next_period()? {
+            Self::BetweenGames => None,
+            Self::FirstHalf => Some(config.half_play_duration),
+            Self::HalfTime => Some(config.half_time_duration),
+            Self::SecondHalf => Some(config.half_play_duration),
+            Self::PreOvertime => {
+                if config.overtime_allowed {
+                    Some(config.pre_overtime_break)
+                } else {
+                    None
+                }
+            }
+            Self::OvertimeFirstHalf => {
+                if config.overtime_allowed {
+                    Some(config.ot_half_play_duration)
+                } else {
+                    None
+                }
+            }
+            Self::OvertimeHalfTime => {
+                if config.overtime_allowed {
+                    Some(config.ot_half_time_duration)
+                } else {
+                    None
+                }
+            }
+            Self::OvertimeSecondHalf => {
+                if config.overtime_allowed {
+                    Some(config.ot_half_play_duration)
+                } else {
+                    None
+                }
+            }
+            Self::PreSuddenDeath => {
+                if config.sudden_death_allowed {
+                    Some(config.pre_sudden_death_duration)
+                } else {
+                    None
+                }
+            }
             Self::SuddenDeath => None,
         }
     }
@@ -658,6 +705,87 @@ mod test {
             Some(Duration::from_secs(15))
         );
         assert_eq!(GamePeriod::SuddenDeath.duration(&config), None);
+    }
+
+    #[test]
+    fn test_next_period_duration() {
+        let config = Game {
+            half_play_duration: Duration::from_secs(5),
+            half_time_duration: Duration::from_secs(7),
+            pre_overtime_break: Duration::from_secs(9),
+            ot_half_play_duration: Duration::from_secs(11),
+            ot_half_time_duration: Duration::from_secs(13),
+            pre_sudden_death_duration: Duration::from_secs(15),
+            overtime_allowed: true,
+            sudden_death_allowed: true,
+            ..Default::default()
+        };
+
+        // Test once with all th egame periods enabled
+        assert_eq!(
+            GamePeriod::BetweenGames.next_period_dur(&config),
+            Some(Duration::from_secs(5))
+        );
+        assert_eq!(
+            GamePeriod::FirstHalf.next_period_dur(&config),
+            Some(Duration::from_secs(7))
+        );
+        assert_eq!(
+            GamePeriod::HalfTime.next_period_dur(&config),
+            Some(Duration::from_secs(5))
+        );
+        assert_eq!(
+            GamePeriod::SecondHalf.next_period_dur(&config),
+            Some(Duration::from_secs(9))
+        );
+        assert_eq!(
+            GamePeriod::PreOvertime.next_period_dur(&config),
+            Some(Duration::from_secs(11))
+        );
+        assert_eq!(
+            GamePeriod::OvertimeFirstHalf.next_period_dur(&config),
+            Some(Duration::from_secs(13))
+        );
+        assert_eq!(
+            GamePeriod::OvertimeHalfTime.next_period_dur(&config),
+            Some(Duration::from_secs(11))
+        );
+        assert_eq!(
+            GamePeriod::OvertimeSecondHalf.next_period_dur(&config),
+            Some(Duration::from_secs(15))
+        );
+        assert_eq!(GamePeriod::PreSuddenDeath.next_period_dur(&config), None);
+        assert_eq!(GamePeriod::SuddenDeath.next_period_dur(&config), None);
+
+        let config = Game {
+            overtime_allowed: false,
+            sudden_death_allowed: false,
+            ..config
+        };
+
+        // Test again with only the minimal periods enabled
+        assert_eq!(
+            GamePeriod::BetweenGames.next_period_dur(&config),
+            Some(Duration::from_secs(5))
+        );
+        assert_eq!(
+            GamePeriod::FirstHalf.next_period_dur(&config),
+            Some(Duration::from_secs(7))
+        );
+        assert_eq!(
+            GamePeriod::HalfTime.next_period_dur(&config),
+            Some(Duration::from_secs(5))
+        );
+        assert_eq!(GamePeriod::SecondHalf.next_period_dur(&config), None);
+        assert_eq!(GamePeriod::PreOvertime.next_period_dur(&config), None);
+        assert_eq!(GamePeriod::OvertimeFirstHalf.next_period_dur(&config), None);
+        assert_eq!(GamePeriod::OvertimeHalfTime.next_period_dur(&config), None);
+        assert_eq!(
+            GamePeriod::OvertimeSecondHalf.next_period_dur(&config),
+            None
+        );
+        assert_eq!(GamePeriod::PreSuddenDeath.next_period_dur(&config), None);
+        assert_eq!(GamePeriod::SuddenDeath.next_period_dur(&config), None);
     }
 
     #[test]

--- a/uwh-refbox/src/app/update_sender.rs
+++ b/uwh-refbox/src/app/update_sender.rs
@@ -408,6 +408,7 @@ mod test {
             next_game_number: 28,
             tournament_id: 1,
             recent_goal: None,
+            next_period_len_secs: Some(180),
         };
 
         let json_expected = serde_json::to_string(&snapshot).unwrap().into_bytes();

--- a/uwh-refbox/src/tournament_manager.rs
+++ b/uwh-refbox/src/tournament_manager.rs
@@ -1343,6 +1343,11 @@ impl TournamentManager {
             }
         }
 
+        let next_period_len_secs = self
+            .current_period
+            .next_period_dur(&self.config)
+            .map(|dur| dur.as_secs().try_into().unwrap_or(0));
+
         Some(GameSnapshot {
             current_period: self.current_period,
             secs_in_period,
@@ -1356,6 +1361,7 @@ impl TournamentManager {
             next_game_number: self.next_game_number(),
             tournament_id: 0,
             recent_goal: self.recent_goal.map(|(c, n, _, _)| (c, n)),
+            next_period_len_secs,
         })
     }
 


### PR DESCRIPTION
The value will be `None` if the next period does not have a defined length, or if the next period in the default order is disabled. For example, if the current period is `SecondHalf`, but overtime and sudden death are not allowed, the value will be `None` instead of the length of `PreOvertime`.

Known Issue: If sudden death is allowed, but overtime is not, the next period value will be `None` instead of the expected `Some(<dur of PreSuddenDeath>)`
Opens #105