### PR TITLE
Small text fixes

### DIFF
--- a/refbox/src/app/view_builders/configuration.rs
+++ b/refbox/src/app/view_builders/configuration.rs
@@ -396,7 +396,7 @@ fn make_tournament_config_page<'a>(
         .push(make_game_time_button(snapshot, false, true).on_press(Message::EditTime))
         .push(
             make_value_button(
-                "USING UWHSCORES:",
+                "USING UWHPORTAL:",
                 bool_string(using_uwhscores),
                 (true, true),
                 Some(Message::ToggleBoolParameter(

--- a/refbox/src/app/view_builders/shared_elements.rs
+++ b/refbox/src/app/view_builders/shared_elements.rs
@@ -638,10 +638,14 @@ pub(super) fn config_string(
     } else {
         String::new()
     };
+    if !using_uwhscores {
+        result += &format!(
+            "Nominal Time Between Games: {}\n",
+            time_string(config.nominal_break),
+        );
+    }
     result += &format!(
-        "Nominal Time Between Games: {}\n\
-         Minimum Time Between Games: {}\n",
-        time_string(config.nominal_break),
+        "Minimum Time Between Games: {}\n",
         time_string(config.minimum_break),
     );
     result


### PR DESCRIPTION
- Update display text from `UWHSCORES` to `UWHPORTAL` (Fixes #126)
- Don't show nominal time between games if uwhscores is in use (Fixes #136)