### PR TITLE
feat: translate to Spanish

### DIFF
--- a/refbox/translations/es/refbox.ftl
+++ b/refbox/translations/es/refbox.ftl
@@ -1,0 +1,246 @@
+# Definitions for the translation file to use
+-dark-team-name = Negro
+dark-team-name-caps = NEGRO
+-light-team-name = Blanco
+light-team-name-caps = BLANCO
+
+# Multipage
+done = HECHO
+cancel = CANCELAR
+delete = ELIMINAR
+back = ATRÁS
+new = NUEVO
+
+# Penalty Edit
+total-dismissial = T
+
+# Team Timeout Edit
+timeout-length = DURACIÓN DEL TIEMPO DE ESPERA
+
+# Warning Add
+team-warning = AVISO
+    DE EQUIPO
+team = EQUIPO
+warning = AVISO
+
+# Configuration
+none-selected = Ninguno seleccionado
+loading = Cargando...
+game = Juego:
+tournament-options = OPCIONES DE TORNEO
+app-mode = MODO DE
+    LA APLICACIÓN
+hide-time-for-last-15-seconds = OCULTAR TIEMPO PARA
+    LOS ÚLTIMOS 15 SEGUNDOS
+track-cap-number-of-scorer = SEGUIR NÚMERO DE
+    GORRO DEL ANOTADOR
+tournament = TORNEO:
+court = CANCHA:
+half-length-full = DURACIÓN DE LA MITAD:
+overtime-allowed = TIEMPO EXTRA
+    PERMITIDO:
+sudden-death-allowed = MUERTE SÚBITA
+    PERMITIDA:
+half-time-length = DURACIÓN DEL MEDIO
+    TIEMPO:
+pre-ot-break-length = DURACIÓN DEL DESCANSO
+    PREVIO AL TIEMPO EXTRA:
+pre-sd-break-length = DURACIÓN DEL DESCANSO
+    PREVIO A MUERTE SÚBITA:
+nominal-break-between-games = DESCANSO
+    ENTRE JUEGOS:
+ot-half-length = DURACIÓN DE LA
+    MITAD DEL T/O:
+num-team-tos-allowed-per-half = NÚMERO DE T/O
+    PERMITIDOS POR MITAD:
+minimum-brk-btwn-games = DESCANSO MÍNIMO
+    ENTRE JUEGOS:
+ot-half-time-length = DURACIÓN DEL MEDIO
+    TIEMPO DE PRORROGA
+using-uwh-portal = USANDO UWHPORTAL:
+starting-sides = LADOS INICIALES
+sound-enabled = SONIDO
+    HABILITADO:
+whistle-volume = VOLUMEN
+    DEL SILBATO:
+manage-remotes = GESTIONAR REMOTOS
+whistle-enabled = SILBATO
+    HABILITADO:
+above-water-volume = VOLUMEN
+    SOBRE EL AGUA:
+auto-sound-start-play = INICIO AUTOMÁTICO
+    DE SONIDO AL JUGAR:
+buzzer-sound = SONIDO
+    DEL ALTAVOZ:
+underwater-volume = VOLUMEN
+    BAJO EL AGUA:
+auto-sound-stop-play = SONIDO AUTOMÁTICO
+    AL PARAR:
+remotes = REMOTOS
+default = POR DEFECTO
+sound = SONIDO: { $sound_text }
+
+waiting = EN ESPERA
+add = AÑADIR
+half-length = DURACIÓN DE LA MITAD
+length-of-half-during-regular-play = La duración de una mitad durante el juego regular
+half-time-lenght = DURACIÓN DEL MEDIO TIEMPO
+length-of-half-time-period = La duración del período de medio tiempo
+nom-break = DESCANSO NOMINAL
+system-will-keep-game-times-spaced = El sistema intentará mantener los tiempos de inicio de los juegos espaciados uniformemente, con el tiempo total de uno al siguiente siendo 2 * [Duración de la Mitad] + [Duración del Medio Tiempo] + [Tiempo Nominal Entre Juegos] (ejemplo: si los juegos tienen [Duración de la Mitad] = 15m, [Duración del Medio Tiempo] = 3m, y [Tiempo Nominal Entre Juegos] = 12m, el tiempo desde el inicio de un juego al siguiente será de 45m. Cualquier tiempo de espera tomado, u otras paradas de reloj, reducirán el tiempo de 12m hasta alcanzar el tiempo mínimo entre juegos).
+min-break = DESCANSO MÍNIMO
+min-time-btwn-games = Si un juego dura más de lo programado, este es el tiempo mínimo entre juegos que el sistema asignará. Si los juegos se retrasan, el sistema intentará automáticamente ponerse al día después de los juegos subsecuentes, siempre respetando este tiempo mínimo entre juegos.
+pre-ot-break-abreviated = DESCANSO PREVIO A LA PRORROGA
+pre-sd-brk = Si se habilita el tiempo extra y es necesario, esta es la duración del descanso entre la segunda y la primera mitad del tiempo extra
+ot-half-len = DURACIÓN DE LA MITAD DEL TIEMPO EXTRA
+time-during-ot = La duración de una mitad durante el tiempo extra
+ot-half-tm-len = DURACIÓN DEL MEDIO TIEMPO DEL TIEMPO EXTRA
+len-of-overtime-halftime = La duración del medio tiempo durante el tiempo extra
+pre-sd-break = DESCANSO PREVIO A MUERTE SÚBITA
+pre-sd-len = La duración del descanso entre el período de juego precedente y la muerte súbita
+help = AYUDA:
+
+# Confirmation
+game-configuration-can-not-be-changed = La configuración del juego no se puede cambiar mientras un juego está en progreso.
+
+    ¿Qué te gustaría hacer?
+apply-this-game-number-change = ¿Cómo te gustaría aplicar este cambio de número de juego?
+UWHScores-enabled = Cuando UWHScores está habilitado, todos los campos deben ser completados.
+go-back-to-editor = VOLVER AL EDITOR
+discard-changes = DESCARTAR CAMBIOS
+end-current-game-and-apply-changes = TERMINAR EL JUEGO ACTUAL Y APLICAR CAMBIOS
+end-current-game-and-apply-change = TERMINAR EL JUEGO ACTUAL Y APLICAR CAMBIO
+keep-current-game-and-apply-change = MANTENER EL JUEGO ACTUAL Y APLICAR CAMBIO
+ok = OK
+confirm-score = ¿Es correcto este puntaje?
+    Confirma con el árbitro principal.
+
+    Negro: { $score_black }        Blanco: { $score_white }
+yes = SI
+no = NO
+
+# Fouls
+equal = IGUAL
+
+# Game Info
+settings = CONFIGURACIÓN
+none = Ninguno
+game-number-error = Error ({ $game_number })
+next-game-number-error = Error ({ $next_game_number })
+last-game-next-game = Último partido: { $prev_game },
+    Próximo Juego: { $next_game }
+black-team-white-team = Equipo Negro: { $black_team }
+    Equipo Blanco: { $white_team }
+game-length-ot-allowed = Duración de una mitad: { $half_length }
+         Duración del medio tiempo: { $half_time_length }
+         Tiempo extra habilitado: { $overtime }
+overtime-details = Duración del descanso previo al tiempo extra: { $pre_overtime }
+             Duración de la mitad del tiempo extra: { $overtime_len }
+             Duración del medio tiempo extra: { $overtime_half_time_len }
+sd-allowed = Muerte súbita habilitada: { $sd }
+pre-sd = Duración del descanso previo a la muerte súbita: { $pre_sd_len }
+team-tos-per-half = Tiempos muertos permitidos por mitad: { $to_num }
+team-to-len = Duración del tiempo muerto de equipo: { $to_len }
+time-btwn-games = Tiempo nominal entre partidos: { $time_btwn }
+min-brk-btwn-games = Tiempo mínimo entre partidos: { $min_brk_time }
+stop-clock-last-2-min = Detener reloj en los últimos 2 minutos: Desconocido
+refs = Árbitro principal: Desconocido
+        Timer: Desconocido
+        Árbitro de agua 1: Desconocido
+        Árbitro de agua 2: Desconocido
+        Árbitro de agua 3: Desconocido
+
+
+# List Selecters
+select-tournament = SELECCIONAR TORNEO
+select-court = SELECCIONAR CANCHA
+select-game = SELECCIONAR PARTIDO
+
+# Main View
+add-warning = AÑADIR AVISO
+add-foul = AÑADIR FALTA
+start-now = EMPEZAR AHORA
+end-timeout = TERMINAR TIEMPO DE ESPERA
+warnings = AVISOS
+penalties = PENALIZACIONES
+score = PUNTUACIÓN
+
+# Penalties
+penalty_color = { $color } PENALIZACIONES
+
+# Score edit
+final-score = Por favor ingrese la puntuación final
+
+# Shared Elements
+## Timeout ribbon
+end-timeout-line-1 = TERMINAR
+end-timeout-line-2 = TIEMPO MUERTO
+switch-to = CAMBIAR A
+ref = ÁRBITRO
+penalty = PENALIZACIÓN
+shot = TIRO
+pen-shot = TIRO PENAL
+## Penalty string
+served = Servido
+dismissed = DESCARTADO
+## Config String
+error = Error ({ $number })
+none = Ninguno
+two-games = Último partido: { $prev_game }, Próximo partido: { $next_game }
+one-game = Juego: { $game }
+teams = { -dark-team-name } Equipo: { $dark_team }
+    { -light-team-name } Equipo: { $light_team }
+game-config = Duración de la mitad: { $half_len },  Duración del medio tiempo: { $half_time_len }
+    Muerte súbita permitida: { $sd_allowed },  Tiempo Extra Permitido: { $ot_allowed }
+    Tiempos muertos de equipo permitidos por mitad: { $team_timeouts }
+    Detener reloj en los Últimos 2 minutos: { $stop_clock_last_2 }
+ref-list = Árbitro principal: { $chief_ref }
+    Timer: { $timer }
+    Árbitro de agua 1: { $water_ref_1 }
+    Árbitro de agua 2: { $water_ref_2 }
+    Árbitro de agua 3: { $water_ref_3 }
+## Game time button
+next-game = PRÓXIMO JUEGO
+first-half = PRIMERA MITAD
+half-time = MEDIO TIEMPO
+second-half = SEGUNDA MITAD
+pre-ot-break-full = DESCANSO PREVIO AL TIEMPO EXTRA
+overtime-first-half = PRIMERA MITAD DEL TIEMPO EXTRA
+overtime-half-time = MEDIO TIEMPO DEL TIEMPO EXTRA
+overtime-second-half = SEGUNDA MITAD DEL TIEMPO EXTRA
+pre-sudden-death-break = DESCANSO PREVIO A MUERTE SÚBITA
+sudden-death = MUERTE SÚBITA
+ot-first-half = PRIMERA MITAD DEL TIEMPO EXTRA
+ot-half-time = MEDIO TIEMPO DEL TIEMPO EXTRA
+ot-2nd-half = SEGUNDA MITAD DEL TIEMPO EXTRA
+white-timeout-short = T/M BLANCO
+white-timeout-full = TIEMPO MUERTO BLANCO
+black-timeout-short = T/M NEGRO
+black-timeout-full = TIEMPO MUERTO NEGRO
+ref-timeout-short = T/M ÁRBITRO
+penalty-shot-short = TIRO PENAL
+## Make penalty dropdown
+infraction = INFRACCIÓN
+## Make warning container
+team-warning-abreviation = A
+
+# Time edit
+game-time = TIEMPO DE JUEGO
+timeout = TIEMPO MUERTO
+Note-Game-time-is-paused = Nota: El tiempo de juego está pausado mientras está en esta pantalla
+
+# Warning Fouls Summary
+fouls = FALTAS
+edit-warnings = EDITAR AVISO
+edit-fouls = EDITAR FALTAS
+
+# Warnings
+color-warnings = { $color } AVISOS
+
+# Message
+player-number = NÚMERO
+    DE JUGADOR:
+game-number = NÚMERO
+    DE JUEGO:
+num-tos-per-half = NÚMERO DE T/Ms
+    POR MITAD:

--- a/refbox/translations/es/refbox.ftl
+++ b/refbox/translations/es/refbox.ftl
@@ -28,35 +28,41 @@ none-selected = Ninguno seleccionado
 loading = Cargando...
 game = Juego:
 tournament-options = OPCIONES DE TORNEO
+app-options = OPCIONES DE APP
+display-options = OPCIONES DE PANTALLA
+sound-options = OPCIONES DE SONIDO
 app-mode = MODO DE
     LA APLICACIÓN
 hide-time-for-last-15-seconds = OCULTAR TIEMPO PARA
     LOS ÚLTIMOS 15 SEGUNDOS
-track-cap-number-of-scorer = SEGUIR NÚMERO DE
-    GORRO DEL ANOTADOR
+track-cap-number-of-scorer = REGISTRAR NÚMERO
+    DEL ANOTADOR
+track-fouls-and-warnings = REGISTRAR FALTAS
+    Y ADVERTENCIAS
 tournament = TORNEO:
 court = CANCHA:
-half-length-full = DURACIÓN DE LA MITAD:
-overtime-allowed = TIEMPO EXTRA
+half-length-full = DURACIÓN DE
+    UNA MITAD:
+overtime-allowed = TIEMPO EXTRA (T/E)
     PERMITIDO:
-sudden-death-allowed = MUERTE SÚBITA
+sudden-death-allowed = MUERTE SÚBITA (M/S)
     PERMITIDA:
-half-time-length = DURACIÓN DEL MEDIO
-    TIEMPO:
-pre-ot-break-length = DURACIÓN DEL DESCANSO
-    PREVIO AL TIEMPO EXTRA:
-pre-sd-break-length = DURACIÓN DEL DESCANSO
-    PREVIO A MUERTE SÚBITA:
+half-time-length = DURACIÓN DEL
+    MEDIO TIEMPO:
+pre-ot-break-length = DURACIÓN
+    PREVIA AL T/E:
+pre-sd-break-length = DURACIÓN PREVIA
+    A LA M/S:
 nominal-break-between-games = DESCANSO
     ENTRE JUEGOS:
 ot-half-length = DURACIÓN DE LA
-    MITAD DEL T/O:
-num-team-tos-allowed-per-half = NÚMERO DE T/O
-    PERMITIDOS POR MITAD:
+    MITAD DEL T/M:
+num-team-tos-allowed-per-half = NÚMERO DE T/M
+    POR MITAD:
 minimum-brk-btwn-games = DESCANSO MÍNIMO
     ENTRE JUEGOS:
 ot-half-time-length = DURACIÓN DEL MEDIO
-    TIEMPO DE PRORROGA
+    TIEMPO DEL T/E
 using-uwh-portal = USANDO UWHPORTAL:
 starting-sides = LADOS INICIALES
 sound-enabled = SONIDO
@@ -160,13 +166,14 @@ select-game = SELECCIONAR PARTIDO
 add-warning = AÑADIR AVISO
 add-foul = AÑADIR FALTA
 start-now = EMPEZAR AHORA
-end-timeout = TERMINAR TIEMPO DE ESPERA
+end-timeout = TERMINAR TIEMPO MUERTO
 warnings = AVISOS
-penalties = PENALIZACIONES
+penalties = EXPULSIONES
 score = PUNTUACIÓN
 
 # Penalties
-penalty_color = { $color } PENALIZACIONES
+black-penalties = EXPULSIONES E. NEGRO
+white-penalties = EXPULSIONES E. BLANCO
 
 # Score edit
 final-score = Por favor ingrese la puntuación final
@@ -177,7 +184,7 @@ end-timeout-line-1 = TERMINAR
 end-timeout-line-2 = TIEMPO MUERTO
 switch-to = CAMBIAR A
 ref = ÁRBITRO
-penalty = PENALIZACIÓN
+penalty = EXPULSIÓN
 shot = TIRO
 pen-shot = TIRO PENAL
 ## Penalty string
@@ -201,7 +208,7 @@ ref-list = Árbitro principal: { $chief_ref }
     Árbitro de agua 3: { $water_ref_3 }
 ## Game time button
 next-game = PRÓXIMO JUEGO
-first-half = PRIMERA MITAD
+first-half = 1a MITAD
 half-time = MEDIO TIEMPO
 second-half = SEGUNDA MITAD
 pre-ot-break-full = DESCANSO PREVIO AL TIEMPO EXTRA
@@ -235,7 +242,8 @@ edit-warnings = EDITAR AVISO
 edit-fouls = EDITAR FALTAS
 
 # Warnings
-color-warnings = { $color } AVISOS
+black-warnings = AVISOS E. NEGRO
+white-warnings = AVISOS E. BLANCO
 
 # Message
 player-number = NÚMERO
@@ -244,3 +252,14 @@ game-number = NÚMERO
     DE JUEGO:
 num-tos-per-half = NÚMERO DE T/Ms
     POR MITAD:
+
+# Sound Controller - mod
+off = APAGADO
+low = BAJO
+medium = MEDIO
+high = ALTO
+max = MÁXIMO
+# Config
+hockey6v6 = HOCKEY 6vs6
+hockey3v3 = HOCKEY 3vs3
+rugby = RUGBY

--- a/refbox/translations/es/refbox.ftl
+++ b/refbox/translations/es/refbox.ftl
@@ -15,7 +15,8 @@ new = NUEVO
 total-dismissial = T
 
 # Team Timeout Edit
-timeout-length = DURACIÓN DEL TIEMPO DE ESPERA
+timeout-length = DURACIÓN DEL
+    TIEMPO DE ESPERA
 
 # Warning Add
 team-warning = AVISO
@@ -61,7 +62,7 @@ num-team-tos-allowed-per-half = NÚMERO DE T/M
     POR MITAD:
 minimum-brk-btwn-games = DESCANSO MÍNIMO
     ENTRE JUEGOS:
-ot-half-time-length = DURACIÓN DEL MEDIO
+ot-half-time-length = DUR. MEDIO
     TIEMPO DEL T/E
 using-uwh-portal = USANDO UWHPORTAL:
 starting-sides = LADOS INICIALES
@@ -88,21 +89,27 @@ sound = SONIDO: { $sound_text }
 
 waiting = EN ESPERA
 add = AÑADIR
-half-length = DURACIÓN DE LA MITAD
+half-length = DURACIÓN DE
+    UNA MITAD
 length-of-half-during-regular-play = La duración de una mitad durante el juego regular
-half-time-lenght = DURACIÓN DEL MEDIO TIEMPO
+half-time-lenght = DURACIÓN DEL
+    MEDIO TIEMPO
 length-of-half-time-period = La duración del período de medio tiempo
 nom-break = DESCANSO NOMINAL
-system-will-keep-game-times-spaced = El sistema intentará mantener los tiempos de inicio de los juegos espaciados uniformemente, con el tiempo total de uno al siguiente siendo 2 * [Duración de la Mitad] + [Duración del Medio Tiempo] + [Tiempo Nominal Entre Juegos] (ejemplo: si los juegos tienen [Duración de la Mitad] = 15m, [Duración del Medio Tiempo] = 3m, y [Tiempo Nominal Entre Juegos] = 12m, el tiempo desde el inicio de un juego al siguiente será de 45m. Cualquier tiempo de espera tomado, u otras paradas de reloj, reducirán el tiempo de 12m hasta alcanzar el tiempo mínimo entre juegos).
+system-will-keep-game-times-spaced = El sistema intentará mantener los tiempos de inicio de los juegos espaciados uniformemente, con el tiempo total de un juego al siguiente siendo 2 * [Duración de la Mitad] + [Duración del Medio Tiempo] + [Tiempo Nominal Entre Juegos] (ejemplo: si los juegos tienen [Duración de la Mitad] = 15m, [Duración del Medio Tiempo] = 3m, y [Tiempo Nominal Entre Juegos] = 12m, el tiempo desde el inicio de un juego al siguiente será de 45m. Cualquier tiempo de espera tomado, u otras paradas de reloj, reducirán el tiempo de 12m hasta alcanzar el tiempo mínimo entre juegos).
 min-break = DESCANSO MÍNIMO
-min-time-btwn-games = Si un juego dura más de lo programado, este es el tiempo mínimo entre juegos que el sistema asignará. Si los juegos se retrasan, el sistema intentará automáticamente ponerse al día después de los juegos subsecuentes, siempre respetando este tiempo mínimo entre juegos.
-pre-ot-break-abreviated = DESCANSO PREVIO A LA PRORROGA
+min-time-btwn-games = Si un juego dura más de lo programado, este es el tiempo mínimo entre juegos que el sistema asignará. Si los juegos se retrasan, el sistema intentará automáticamente reajustarse después de los juegos subsecuentes, siempre respetando este tiempo mínimo entre juegos.
+pre-ot-break-abreviated = DESCANSO PREVIO
+    A LA PRORROGA
 pre-sd-brk = Si se habilita el tiempo extra y es necesario, esta es la duración del descanso entre la segunda y la primera mitad del tiempo extra
-ot-half-len = DURACIÓN DE LA MITAD DEL TIEMPO EXTRA
+ot-half-len = DURACIÓN DE LA
+    MITAD DEL T/E
 time-during-ot = La duración de una mitad durante el tiempo extra
-ot-half-tm-len = DURACIÓN DEL MEDIO TIEMPO DEL TIEMPO EXTRA
+ot-half-tm-len = DURACIÓN DEL MEDIO
+    TIEMPO DEL T/E
 len-of-overtime-halftime = La duración del medio tiempo durante el tiempo extra
-pre-sd-break = DESCANSO PREVIO A MUERTE SÚBITA
+pre-sd-break = DESCANSO PREVIO
+    A MUERTE SÚBITA
 pre-sd-len = La duración del descanso entre el período de juego precedente y la muerte súbita
 help = AYUDA:
 
@@ -165,7 +172,7 @@ select-game = SELECCIONAR PARTIDO
 # Main View
 add-warning = AÑADIR AVISO
 add-foul = AÑADIR FALTA
-start-now = EMPEZAR AHORA
+start-now = EMPEZAR
 end-timeout = TERMINAR TIEMPO MUERTO
 warnings = AVISOS
 penalties = EXPULSIONES
@@ -254,11 +261,11 @@ num-tos-per-half = NÚMERO DE T/Ms
     POR MITAD:
 
 # Sound Controller - mod
-off = APAGADO
+off = NO
 low = BAJO
 medium = MEDIO
 high = ALTO
-max = MÁXIMO
+max = MÁX
 # Config
 hockey6v6 = HOCKEY 6vs6
 hockey3v3 = HOCKEY 3vs3


### PR DESCRIPTION
This PR adds the translations for the uwh-ref-box in Spanish. 

I've reviewed few times the whole file, and I think most of them make sense but it will require further iterations to adjust some regional meanings ( `es-AR` != `es-CO` != `es-ES` ) and the length of some texts. 
I tried to keep all the same `\n` (new line chars) except for the long descriptions. 

Also compared with the original final (engliosh version), I tried to respect all the spaces and titles in comments to make easier the comparisson of both files. 