### PR TITLE
Fix spelling of Chief

### DIFF
--- a/refbox/src/app/view_builders/game_info.rs
+++ b/refbox/src/app/view_builders/game_info.rs
@@ -206,7 +206,7 @@ fn details_strings(
 
     write!(
         &mut right_string,
-        "Cheif ref: UNKNOWN\n\
+        "Chief ref: UNKNOWN\n\
         Timer: UNKNOWN\n\
         Water ref 1: UNKNOWN\n\
         Water ref 2: UNKNOWN\n\

--- a/refbox/src/app/view_builders/shared_elements.rs
+++ b/refbox/src/app/view_builders/shared_elements.rs
@@ -748,7 +748,7 @@ pub(super) fn config_string(
     if !fouls_and_warnings {
         write!(
             &mut result,
-            "Cheif ref: \n\
+            "Chief ref: \n\
             Timer: \n\
             Water ref 1: \n\
             Water ref 2: \n\


### PR DESCRIPTION
Chief was misspelled as Cheif in two places