### PR TITLE
Add auth status indicator and credential editing screen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2416,6 +2416,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ae10193d25051e74945f1ea2d0b42e03cc3b890f7e4cc5faa44997d808193f"
+dependencies = [
+ "base64 0.21.7",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "khronos-egl"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3006,6 +3021,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3395,6 +3421,16 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "pem"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
+dependencies = [
+ "base64 0.22.0",
+ "serde",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -4290,6 +4326,18 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+ "time",
+]
 
 [[package]]
 name = "simplecss"
@@ -5263,6 +5311,7 @@ dependencies = [
  "enum-iterator",
  "env_logger",
  "fonts",
+ "jsonwebtoken",
  "log",
  "macro-attr-2018",
  "reqwest",

--- a/refbox/src/app/message.rs
+++ b/refbox/src/app/message.rs
@@ -99,6 +99,7 @@ pub enum Message {
     RecvGame(GameInfo),
     StopClock,
     StartClock,
+    UwhScoresAuthChecked(Vec<u32>),
     NoAction, // TODO: Remove once UI is functional
 }
 
@@ -159,7 +160,8 @@ impl Message {
             | Self::ConfirmScores(_)
             | Self::ScoreConfirmation { .. }
             | Self::StopClock
-            | Self::StartClock => false,
+            | Self::StartClock
+            | Self::UwhScoresAuthChecked(_) => false,
         }
     }
 }

--- a/refbox/src/app/message.rs
+++ b/refbox/src/app/message.rs
@@ -81,6 +81,8 @@ pub enum Message {
     ParameterSelected(ListableParameter, usize),
     ToggleBoolParameter(BoolGameParameter),
     CycleParameter(CyclingParameter),
+    TextParameterChanged(TextParameter, String),
+    ApplyAuthChanges,
     RequestRemoteId,
     GotRemoteId(u32),
     DeleteRemote(usize),
@@ -149,6 +151,8 @@ impl Message {
             | Self::SelectParameter(_)
             | Self::ParameterEditComplete { .. }
             | Self::ParameterSelected(_, _)
+            | Self::TextParameterChanged(_, _)
+            | Self::ApplyAuthChanges
             | Self::RequestRemoteId
             | Self::GotRemoteId(_)
             | Self::DeleteRemote(_)
@@ -173,6 +177,7 @@ pub enum ConfigPage {
     Sound,
     Display,
     App,
+    Credentials,
     Remotes(usize, bool),
 }
 
@@ -220,6 +225,13 @@ pub enum CyclingParameter {
     AboveWaterVol,
     UnderWaterVol,
     Mode,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TextParameter {
+    UwhscoresEmail,
+    UwhscoresPassword,
+    UwhportalToken,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -404,16 +404,19 @@ impl RefBoxApp {
             task::spawn(async move {
                 let token = uwhscores_token.lock().unwrap().clone();
 
-                let mut token = if token.is_none() || token.as_ref().unwrap().is_empty() {
-                    login_request.await;
-                    if let Some(t) = uwhscores_token.lock().unwrap().as_deref() {
-                        t.to_string()
-                    } else {
-                        error!("Failed to get uwhscores token. Aborting post score: {post_data:?}");
-                        return;
+                let mut token = match token {
+                    Some(t) if !t.is_empty() => t,
+                    _ => {
+                        login_request.await;
+                        if let Some(t) = uwhscores_token.lock().unwrap().as_deref() {
+                            t.to_string()
+                        } else {
+                            error!(
+                                "Failed to get uwhscores token. Aborting post score: {post_data:?}"
+                            );
+                            return;
+                        }
                     }
-                } else {
-                    token.unwrap()
                 };
 
                 info!("Posting score: {post_data:?}");
@@ -489,16 +492,17 @@ impl RefBoxApp {
             task::spawn(async move {
                 let token = uwhscores_token.lock().unwrap().clone();
 
-                let mut token = if token.is_none() || token.as_ref().unwrap().is_empty() {
-                    login_request.await;
-                    if let Some(t) = uwhscores_token.lock().unwrap().as_deref() {
-                        t.to_string()
-                    } else {
-                        error!("Failed to get uwhscores token. Aborting uwhscores auth check");
-                        return;
+                let mut token = match token {
+                    Some(t) if !t.is_empty() => t,
+                    _ => {
+                        login_request.await;
+                        if let Some(t) = uwhscores_token.lock().unwrap().as_deref() {
+                            t.to_string()
+                        } else {
+                            error!("Failed to get uwhscores token. Aborting uwhscores auth check");
+                            return;
+                        }
                     }
-                } else {
-                    token.unwrap()
                 };
 
                 for _ in 0..MAX_RETRIES {

--- a/refbox/src/app/style.rs
+++ b/refbox/src/app/style.rs
@@ -205,6 +205,8 @@ pub enum ContainerStyle {
     Black,
     White,
     Blue,
+    Green,
+    Red,
     ScrollBar,
     Disabled,
     Transparent,
@@ -220,6 +222,8 @@ impl container::StyleSheet for ApplicationTheme {
             ContainerStyle::Black => cont_style(BLACK, WHITE),
             ContainerStyle::White => cont_style(WHITE, BLACK),
             ContainerStyle::Blue => cont_style(BLUE, WHITE),
+            ContainerStyle::Green => cont_style(GREEN, BLACK),
+            ContainerStyle::Red => cont_style(RED, BLACK),
             ContainerStyle::ScrollBar => cont_style(WINDOW_BACKGROUND, BLACK),
             ContainerStyle::Disabled => container::Appearance {
                 text_color: Some(DISABLED_COLOR),

--- a/refbox/src/app/style.rs
+++ b/refbox/src/app/style.rs
@@ -1,6 +1,6 @@
 use iced::{
     application,
-    widget::{self, button, container, scrollable, svg, text},
+    widget::{self, button, container, scrollable, svg, text, text_input},
     Background, BorderRadius, Color, Vector,
 };
 use iced_core::text::LineHeight;
@@ -328,6 +328,56 @@ impl scrollable::StyleSheet for ApplicationTheme {
         _is_mouse_over_scrollbar: bool,
     ) -> scrollable::Scrollbar {
         self.active(style)
+    }
+}
+
+impl text_input::StyleSheet for ApplicationTheme {
+    type Style = ();
+
+    fn active(&self, _style: &Self::Style) -> text_input::Appearance {
+        text_input::Appearance {
+            background: Background::Color(WINDOW_BACKGROUND),
+            border_radius: BorderRadius::from(BORDER_RADIUS),
+            border_width: 0.5,
+            border_color: GRAY,
+            icon_color: BLACK,
+        }
+    }
+
+    fn focused(&self, _style: &Self::Style) -> text_input::Appearance {
+        text_input::Appearance {
+            background: Background::Color(WINDOW_BACKGROUND),
+            border_radius: BorderRadius::from(BORDER_RADIUS),
+            border_width: 0.5,
+            border_color: BLACK,
+            icon_color: BLACK,
+        }
+    }
+
+    fn disabled(&self, _style: &Self::Style) -> text_input::Appearance {
+        text_input::Appearance {
+            background: Background::Color(WINDOW_BACKGROUND),
+            border_radius: BorderRadius::from(BORDER_RADIUS),
+            border_width: 1.0,
+            border_color: DISABLED_COLOR,
+            icon_color: BLACK,
+        }
+    }
+
+    fn placeholder_color(&self, _style: &Self::Style) -> Color {
+        GRAY
+    }
+
+    fn value_color(&self, _style: &Self::Style) -> Color {
+        BLACK
+    }
+
+    fn selection_color(&self, _style: &Self::Style) -> Color {
+        BLUE
+    }
+
+    fn disabled_color(&self, _style: &Self::Style) -> Color {
+        BLACK
     }
 }
 

--- a/refbox/src/app/view_builders/configuration.rs
+++ b/refbox/src/app/view_builders/configuration.rs
@@ -100,6 +100,7 @@ impl Cyclable for Mode {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(in super::super) fn build_game_config_edit_page<'a>(
     snapshot: &GameSnapshot,
     settings: &EditableSettings,
@@ -243,6 +244,7 @@ fn make_main_config_page<'a>(
     .into()
 }
 
+#[allow(clippy::too_many_arguments)]
 fn make_tournament_config_page<'a>(
     snapshot: &GameSnapshot,
     settings: &EditableSettings,
@@ -960,7 +962,7 @@ fn make_credential_config_page<'a>(
                 .line_height(LINE_HEIGHT)
                 .vertical_alignment(Vertical::Center)
                 .height(Length::Fill),
-            TextInput::new("", &uwhscores_email,)
+            TextInput::new("", uwhscores_email,)
                 .on_input(|s| Message::TextParameterChanged(TextParameter::UwhscoresEmail, s))
                 .width(Length::Fill)
         ]
@@ -972,7 +974,7 @@ fn make_credential_config_page<'a>(
                 .line_height(LINE_HEIGHT)
                 .vertical_alignment(Vertical::Center)
                 .height(Length::Fill),
-            TextInput::new("", &uwhscores_password,)
+            TextInput::new("", uwhscores_password,)
                 .on_input(|s| Message::TextParameterChanged(TextParameter::UwhscoresPassword, s))
                 .password()
                 .width(Length::Fill)
@@ -985,7 +987,7 @@ fn make_credential_config_page<'a>(
                 .line_height(LINE_HEIGHT)
                 .vertical_alignment(Vertical::Center)
                 .height(Length::Fill),
-            TextInput::new("", &uwhportal_token,)
+            TextInput::new("", uwhportal_token,)
                 .on_input(|s| Message::TextParameterChanged(TextParameter::UwhportalToken, s))
                 .password()
                 .width(Length::Fill)

--- a/refbox/src/main.rs
+++ b/refbox/src/main.rs
@@ -82,6 +82,10 @@ struct Cli {
     all_tournaments: bool,
 
     #[clap(long)]
+    /// Don't allow views that require a keyboard
+    touchscreen: bool,
+
+    #[clap(long)]
     /// Directory within which log files will be placed, default is platform dependent
     log_location: Option<PathBuf>,
 
@@ -318,6 +322,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         require_https: !args.allow_http,
         fullscreen: args.fullscreen,
         list_all_tournaments: args.all_tournaments,
+        touchscreen: args.touchscreen,
     };
 
     let mut settings = Settings::with_flags(flags);

--- a/uwh-common/Cargo.toml
+++ b/uwh-common/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [features]
 default = ["std"]
-std = ["arrayvec/std", "displaydoc/std", "enum-derive-2018", "reqwest", "serde/std", "time", "toml"]
+std = ["arrayvec/std", "displaydoc/std", "enum-derive-2018", "jsonwebtoken", "reqwest", "serde/std", "time", "toml"]
 
 [dependencies]
 arrayref = "0.3"
@@ -28,6 +28,7 @@ time = { version = "0.3", features = [
 ], optional = true }
 toml = { version = "0.8", optional = true }
 enum-iterator = "2.1.0"
+jsonwebtoken = { version = "9.3.0", optional = true }
 
 [dev-dependencies]
 env_logger = "0.10"

--- a/uwh-common/src/uwhportal.rs
+++ b/uwh-common/src/uwhportal.rs
@@ -1,12 +1,19 @@
 use core::time::Duration;
+use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
 use log::{info, warn};
 use reqwest::header::{HeaderValue, AUTHORIZATION};
 use reqwest::{Client, ClientBuilder, Method, RequestBuilder, StatusCode};
-use std::error::Error;
+use serde::{Deserialize, Serialize};
+use std::{
+    error::Error,
+    sync::{Arc, Mutex},
+};
 
 pub struct UwhPortalClient {
     base_url: String,
     access_token: Option<String>,
+    token_validity: Arc<Mutex<TokenValidity>>,
+    event: Option<String>,
     client: Client,
 }
 
@@ -21,11 +28,101 @@ impl UwhPortalClient {
             .https_only(require_https)
             .timeout(timeout)
             .build()?;
-        Ok(Self {
-            base_url: base_url.trim_end_matches('/').to_string(),
+
+        let base_url = base_url.trim_end_matches('/').to_string();
+
+        let mut ret = Self {
+            base_url,
             access_token: access_token.map(|s| s.to_string()),
+            token_validity: Arc::new(Mutex::new(TokenValidity::Unknown)),
+            event: None,
             client,
-        })
+        };
+
+        ret.check_token();
+
+        Ok(ret)
+    }
+
+    /// Returns the current token validity state and the event name if
+    /// for which the token is valid. If the event name is None, the token
+    /// is valid for all events.
+    pub fn token_validity(&self) -> (TokenValidity, Option<String>) {
+        (*self.token_validity.lock().unwrap(), self.event.clone())
+    }
+
+    pub fn set_token(&mut self, token: &str) {
+        self.access_token = Some(token.to_string());
+
+        self.check_token();
+    }
+
+    fn check_token(&mut self) {
+        if let Some(token) = &self.access_token {
+            let mut issuer = self.base_url.clone();
+            if issuer.starts_with("https://api.") {
+                issuer = issuer.replacen("https://api.", "https://", 1);
+            } else if issuer.starts_with("http://api.") {
+                issuer = issuer.replacen("http://api.", "http://", 1);
+            }
+
+            let mut val = Validation::new(Algorithm::RS256);
+            val.set_required_spec_claims(&["exp", "iss"]);
+            val.set_audience(&["API"]);
+            val.set_issuer(&[issuer]);
+            val.reject_tokens_expiring_in_less_than = 60;
+            val.validate_exp = true;
+            val.validate_nbf = true;
+            val.insecure_disable_signature_validation();
+
+            // Garbage, but we need a key to compile
+            let decoder = DecodingKey::from_secret(b"secret");
+            let ret = decode::<PortalToken>(token, &decoder, &val);
+            match ret {
+                Ok(t) => {
+                    self.event = t.claims.entity.map(|s| s.replacen("events/", "", 1));
+                    *self.token_validity.lock().unwrap() = TokenValidity::LocallyChecked;
+                }
+                Err(e) => {
+                    warn!("uwhportal token validation failed: {e:?}");
+                    *self.token_validity.lock().unwrap() = TokenValidity::Invalid;
+                }
+            }
+        } else {
+            *self.token_validity.lock().unwrap() = TokenValidity::Invalid;
+        }
+    }
+
+    /// Calling this with any token validity other than `LocallyChecked` is a no-op.
+    pub fn verify_token(&self) -> impl std::future::Future<Output = Result<(), Box<dyn Error>>> {
+        let request = self.event.as_ref().map(|e| {
+            let url = format!("{}/api/admin/events/{e}/access-keys/verify", self.base_url);
+            authenticated_request(&self.client, Method::GET, &url, &self.access_token)
+        });
+
+        let token_validity = self.token_validity.clone();
+        async move {
+            if *token_validity.lock().unwrap() != TokenValidity::LocallyChecked {
+                info!("uwhportal token validation skipped");
+                return Ok(());
+            }
+
+            let response = if let Some(request) = request {
+                request.send().await?
+            } else {
+                return Ok(());
+            };
+
+            if response.status() == StatusCode::OK {
+                info!("uwhportal token validation successful");
+                *token_validity.lock().unwrap() = TokenValidity::Valid;
+                Ok(())
+            } else {
+                warn!("uwhportal token validation failed, response: {response:?}");
+                let body = response.text().await?;
+                Err(Box::new(ApiError::new(body)))?
+            }
+        }
     }
 
     pub fn post_game_stats(
@@ -93,3 +190,24 @@ impl std::fmt::Display for ApiError {
 }
 
 impl Error for ApiError {}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct PortalToken {
+    aud: String,
+    entity: Option<String>,
+    exp: u64,
+    iat: u64,
+    iss: String,
+    jti: String,
+    nbf: u64,
+    scope: String,
+    sub: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TokenValidity {
+    Invalid,
+    LocallyChecked,
+    Valid,
+    Unknown,
+}

--- a/uwh-common/src/uwhscores.rs
+++ b/uwh-common/src/uwhscores.rs
@@ -179,6 +179,26 @@ impl GameScorePostData {
     }
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+pub struct UserInfo {
+    pub active: bool,
+    pub admin: bool,
+    #[serde(with = "rfc3339_no_subsec_no_offest")]
+    pub date_created: PrimitiveDateTime,
+    pub email: String,
+    #[serde(with = "rfc3339_no_subsec_no_offest")]
+    pub last_login: PrimitiveDateTime,
+    pub short_name: String,
+    pub site_admin: bool,
+    pub tournaments: Vec<u32>,
+    pub user_id: String,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+pub struct UserResponse {
+    pub user: UserInfo,
+}
+
 #[cfg(test)]
 mod test {
     use super::*;


### PR DESCRIPTION
A new button in the tournament config shows whether uwhscores and uwhportal are authenticated. The button currently only shows some failures for uwhportal, and never shows success. Fixing this is blocked on the switch to uwhportal based schedules.

If not in touchscreen mode, clicking the button will open a new config page that allows editing the uwhscores email and password, as well as the uwhportal token