### PR TITLE
More space for warnings

### DIFF
--- a/refbox/src/app/view_builders/game_info.rs
+++ b/refbox/src/app/view_builders/game_info.rs
@@ -202,17 +202,21 @@ fn details_strings(
     )
     .unwrap();
 
-    writeln!(&mut left_string, "Stop clock in last 2 minutes: UNKNOWN").unwrap();
+    if using_uwhscores {
+        writeln!(&mut left_string, "Stop clock in last 2 minutes: UNKNOWN").unwrap();
+    }
 
-    write!(
-        &mut right_string,
-        "Chief ref: UNKNOWN\n\
+    if using_uwhscores {
+        write!(
+            &mut right_string,
+            "Chief ref: UNKNOWN\n\
         Timer: UNKNOWN\n\
         Water ref 1: UNKNOWN\n\
         Water ref 2: UNKNOWN\n\
         Water ref 3: UNKNOWN",
-    )
-    .unwrap();
+        )
+        .unwrap();
+    }
 
     (left_string, right_string)
 }

--- a/refbox/src/app/view_builders/game_info.rs
+++ b/refbox/src/app/view_builders/game_info.rs
@@ -64,63 +64,11 @@ fn details_strings(
     games: &Option<BTreeMap<u32, GameInfo>>,
 ) -> (String, String) {
     const TEAM_NAME_LEN_LIMIT: usize = 40;
-    let mut left_string = String::new();
     let mut right_string = String::new();
-    let game_number = if snapshot.current_period == GamePeriod::BetweenGames {
-        let prev_game;
-        let next_game;
-        if using_uwhscores {
-            if let Some(games) = games {
-                prev_game = match games.get(&snapshot.game_number) {
-                    Some(game) => game_string_short(game),
-                    None if snapshot.game_number == 0 => "None".to_string(),
-                    None => format!("Error ({})", snapshot.game_number),
-                };
-                next_game = match games.get(&snapshot.next_game_number) {
-                    Some(game) => game_string_short(game),
-                    None => format!("Error ({})", snapshot.next_game_number),
-                };
-            } else {
-                prev_game = if snapshot.game_number == 0 {
-                    "None".to_string()
-                } else {
-                    format!("Error ({})", snapshot.game_number)
-                };
-                next_game = format!("Error ({})", snapshot.next_game_number);
-            }
-        } else {
-            prev_game = if snapshot.game_number == 0 {
-                "None".to_string()
-            } else {
-                snapshot.game_number.to_string()
-            };
-            next_game = snapshot.next_game_number.to_string();
-        }
-
-        write!(
-            &mut left_string,
-            "Last Game: {}, \nNext Game: {}\n",
-            prev_game, next_game
-        )
-        .unwrap();
-        snapshot.next_game_number
-    } else {
-        let game;
-        if using_uwhscores {
-            if let Some(games) = games {
-                game = match games.get(&snapshot.game_number) {
-                    Some(game) => game_string_short(game),
-                    None => format!("Error ({})", snapshot.game_number),
-                };
-            } else {
-                game = format!("Error ({})", snapshot.game_number);
-            }
-        } else {
-            game = snapshot.game_number.to_string();
-        }
-        writeln!(&mut left_string, "Game: {}", game).unwrap();
-        snapshot.game_number
-    };
+    let (result_string, _) = config_string_game_num(snapshot, using_uwhscores, games);
+    let mut left_string = result_string;
+    let (_, result_u32) = config_string_game_num(snapshot, using_uwhscores, games);
+    let game_number = result_u32;
 
     if using_uwhscores {
         if let Some(games) = games {

--- a/refbox/src/app/view_builders/main_view.rs
+++ b/refbox/src/app/view_builders/main_view.rs
@@ -103,7 +103,10 @@ pub(in super::super) fn build_main_view<'a>(
         }
     };
 
-    center_col = center_col.push(
+    let num_warns_b = snapshot.b_warnings.len();
+    let num_warns_w = snapshot.w_warnings.len();
+
+    center_col = center_col.push(if num_warns_b | num_warns_w < 4 {
         button(
             text(config_string(
                 snapshot,
@@ -119,10 +122,22 @@ pub(in super::super) fn build_main_view<'a>(
         )
         .padding(PADDING)
         .style(ButtonStyle::LightGray)
-        .width(Length::Fill)
         .height(Length::FillPortion(2))
-        .on_press(Message::ShowGameDetails),
-    );
+        .width(Length::Fill)
+        .on_press(Message::ShowGameDetails)
+    } else {
+        button(
+            text(config_string_game_num(snapshot, using_uwhscores, games))
+                .size(SMALL_TEXT)
+                .line_height(LINE_HEIGHT)
+                .vertical_alignment(Vertical::Center)
+                .horizontal_alignment(Horizontal::Left),
+        )
+        .padding(PADDING)
+        .style(ButtonStyle::LightGray)
+        .width(Length::Fill)
+        .on_press(Message::ShowGameDetails)
+    });
 
     if config.track_fouls_and_warnings {
         center_col = center_col.push(
@@ -139,7 +154,7 @@ pub(in super::super) fn build_main_view<'a>(
                                 .b_warnings
                                 .iter()
                                 .rev()
-                                .take(3)
+                                .take(10)
                                 .map(|warning| make_warning_container(
                                     warning,
                                     Some(GameColor::Black)
@@ -155,7 +170,7 @@ pub(in super::super) fn build_main_view<'a>(
                                 .w_warnings
                                 .iter()
                                 .rev()
-                                .take(3)
+                                .take(10)
                                 .map(|warning| make_warning_container(
                                     warning,
                                     Some(GameColor::White)
@@ -174,7 +189,7 @@ pub(in super::super) fn build_main_view<'a>(
                 .height(Length::Fill),
             )
             .width(Length::Fill)
-            .height(Length::FillPortion(1))
+            .height(Length::Fill)
             .on_press(Message::NoAction)
             .style(ButtonStyle::LightGray)
             .on_press(Message::ShowWarnings),

--- a/refbox/src/app/view_builders/main_view.rs
+++ b/refbox/src/app/view_builders/main_view.rs
@@ -127,7 +127,7 @@ pub(in super::super) fn build_main_view<'a>(
         .on_press(Message::ShowGameDetails)
     } else {
         button(
-            text(config_string_game_num(snapshot, using_uwhscores, games))
+            text(config_string_game_num(snapshot, using_uwhscores, games).0)
                 .size(SMALL_TEXT)
                 .line_height(LINE_HEIGHT)
                 .vertical_alignment(Vertical::Center)

--- a/refbox/src/app/view_builders/shared_elements.rs
+++ b/refbox/src/app/view_builders/shared_elements.rs
@@ -643,75 +643,7 @@ pub(super) fn config_string_game_num(
     snapshot: &GameSnapshot,
     using_uwhscores: bool,
     games: &Option<BTreeMap<u32, GameInfo>>,
-) -> String {
-    let mut result = String::new();
-    if snapshot.current_period == GamePeriod::BetweenGames {
-        let prev_game;
-        let next_game;
-        if using_uwhscores {
-            if let Some(games) = games {
-                prev_game = match games.get(&snapshot.game_number) {
-                    Some(game) => game_string_short(game),
-                    None if snapshot.game_number == 0 => "None".to_string(),
-                    None => format!("Error ({})", snapshot.game_number),
-                };
-                next_game = match games.get(&snapshot.next_game_number) {
-                    Some(game) => game_string_short(game),
-                    None => format!("Error ({})", snapshot.next_game_number),
-                };
-            } else {
-                prev_game = if snapshot.game_number == 0 {
-                    "None".to_string()
-                } else {
-                    format!("Error ({})", snapshot.game_number)
-                };
-                next_game = format!("Error ({})", snapshot.next_game_number);
-            }
-        } else {
-            prev_game = if snapshot.game_number == 0 {
-                "None".to_string()
-            } else {
-                snapshot.game_number.to_string()
-            };
-            next_game = snapshot.next_game_number.to_string();
-        }
-
-        write!(
-            &mut result,
-            "Last Game: {},  Next Game: {}\n\n",
-            prev_game, next_game
-        )
-        .unwrap();
-        snapshot.next_game_number
-    } else {
-        let game;
-        if using_uwhscores {
-            if let Some(games) = games {
-                game = match games.get(&snapshot.game_number) {
-                    Some(game) => game_string_short(game),
-                    None => format!("Error ({})", snapshot.game_number),
-                };
-            } else {
-                game = format!("Error ({})", snapshot.game_number);
-            }
-        } else {
-            game = snapshot.game_number.to_string();
-        }
-        write!(&mut result, "Game: {}\n\n", game).unwrap();
-        snapshot.game_number
-    };
-
-    result
-}
-
-pub(super) fn config_string(
-    snapshot: &GameSnapshot,
-    config: &GameConfig,
-    using_uwhscores: bool,
-    games: &Option<BTreeMap<u32, GameInfo>>,
-    fouls_and_warnings: bool,
-) -> String {
-    const TEAM_NAME_LEN_LIMIT: usize = 40;
+) -> (String, u32) {
     let mut result = String::new();
     let game_number = if snapshot.current_period == GamePeriod::BetweenGames {
         let prev_game;
@@ -768,6 +700,22 @@ pub(super) fn config_string(
         write!(&mut result, "Game: {}\n\n", game).unwrap();
         snapshot.game_number
     };
+
+    (result, game_number)
+}
+
+pub(super) fn config_string(
+    snapshot: &GameSnapshot,
+    config: &GameConfig,
+    using_uwhscores: bool,
+    games: &Option<BTreeMap<u32, GameInfo>>,
+    fouls_and_warnings: bool,
+) -> String {
+    const TEAM_NAME_LEN_LIMIT: usize = 40;
+    let (result_string, _) = config_string_game_num(snapshot, using_uwhscores, games);
+    let mut result = result_string;
+    let (_, result_u32) = config_string_game_num(snapshot, using_uwhscores, games);
+    let game_number = result_u32;
 
     if using_uwhscores {
         if let Some(games) = games {

--- a/refbox/src/app/view_builders/shared_elements.rs
+++ b/refbox/src/app/view_builders/shared_elements.rs
@@ -639,6 +639,71 @@ pub(super) fn limit_team_name_len(name: &String, len_limit: usize) -> Cow<'_, St
     }
 }
 
+pub(super) fn config_string_game_num(
+    snapshot: &GameSnapshot,
+    using_uwhscores: bool,
+    games: &Option<BTreeMap<u32, GameInfo>>,
+) -> String {
+    let mut result = String::new();
+    if snapshot.current_period == GamePeriod::BetweenGames {
+        let prev_game;
+        let next_game;
+        if using_uwhscores {
+            if let Some(games) = games {
+                prev_game = match games.get(&snapshot.game_number) {
+                    Some(game) => game_string_short(game),
+                    None if snapshot.game_number == 0 => "None".to_string(),
+                    None => format!("Error ({})", snapshot.game_number),
+                };
+                next_game = match games.get(&snapshot.next_game_number) {
+                    Some(game) => game_string_short(game),
+                    None => format!("Error ({})", snapshot.next_game_number),
+                };
+            } else {
+                prev_game = if snapshot.game_number == 0 {
+                    "None".to_string()
+                } else {
+                    format!("Error ({})", snapshot.game_number)
+                };
+                next_game = format!("Error ({})", snapshot.next_game_number);
+            }
+        } else {
+            prev_game = if snapshot.game_number == 0 {
+                "None".to_string()
+            } else {
+                snapshot.game_number.to_string()
+            };
+            next_game = snapshot.next_game_number.to_string();
+        }
+
+        write!(
+            &mut result,
+            "Last Game: {},  Next Game: {}\n\n",
+            prev_game, next_game
+        )
+        .unwrap();
+        snapshot.next_game_number
+    } else {
+        let game;
+        if using_uwhscores {
+            if let Some(games) = games {
+                game = match games.get(&snapshot.game_number) {
+                    Some(game) => game_string_short(game),
+                    None => format!("Error ({})", snapshot.game_number),
+                };
+            } else {
+                game = format!("Error ({})", snapshot.game_number);
+            }
+        } else {
+            game = snapshot.game_number.to_string();
+        }
+        write!(&mut result, "Game: {}\n\n", game).unwrap();
+        snapshot.game_number
+    };
+
+    result
+}
+
 pub(super) fn config_string(
     snapshot: &GameSnapshot,
     config: &GameConfig,


### PR DESCRIPTION
Added more space for warnings on main page. If there are three or fewer warnings, it is still smaller and shows all the game info. If the number of warnings for a team is more than three, the warnings section will expand, only showing game number. 

Fixes #437 