### PR TITLE
Change 0 to team

### DIFF
--- a/refbox/src/app/view_builders/keypad_pages/mod.rs
+++ b/refbox/src/app/view_builders/keypad_pages/mod.rs
@@ -17,6 +17,7 @@ use iced::{
     Alignment, Length,
 };
 
+use style::SMALL_PLUS_TEXT;
 use uwh_common::game_snapshot::GameSnapshot;
 
 mod score_add;
@@ -126,10 +127,17 @@ pub(in super::super) fn build_keypad_page<'a>(
                     ]
                     .spacing(SPACING),
                     row![
-                        setup_keypad_button(
-                            make_small_button("0", MEDIUM_TEXT),
-                            Message::KeypadButtonPress(KeypadButton::Zero,)
-                        ),
+                        if player_num == 0 {
+                            setup_keypad_button(
+                                make_small_button("TEAM", SMALL_PLUS_TEXT),
+                                Message::ToggleBoolParameter(BoolGameParameter::TeamWarning),
+                            )
+                        } else {
+                            setup_keypad_button(
+                                make_small_button("0", MEDIUM_TEXT),
+                                Message::KeypadButtonPress(KeypadButton::Zero),
+                            )
+                        },
                         setup_keypad_button(
                             button(
                                 container(

--- a/refbox/src/app/view_builders/keypad_pages/mod.rs
+++ b/refbox/src/app/view_builders/keypad_pages/mod.rs
@@ -17,7 +17,6 @@ use iced::{
     Alignment, Length,
 };
 
-use style::SMALL_PLUS_TEXT;
 use uwh_common::game_snapshot::GameSnapshot;
 
 mod score_add;
@@ -63,7 +62,7 @@ pub(in super::super) fn build_keypad_page<'a>(
 
     let text_displayed = match page {
         KeypadPage::WarningAdd { team_warning, .. } => {
-            if team_warning == true {
+            if team_warning {
                 "TEAM".to_string()
             } else {
                 player_num.to_string()
@@ -77,7 +76,7 @@ pub(in super::super) fn build_keypad_page<'a>(
             }
         }
         KeypadPage::FoulAdd { color, .. } => {
-            if color == None {
+            if color.is_none() {
                 "TEAM".to_string()
             } else {
                 player_num.to_string()

--- a/refbox/src/app/view_builders/keypad_pages/mod.rs
+++ b/refbox/src/app/view_builders/keypad_pages/mod.rs
@@ -61,6 +61,33 @@ pub(in super::super) fn build_keypad_page<'a>(
             button.style(ButtonStyle::Blue)
         };
 
+    let text_displayed = match page {
+        KeypadPage::WarningAdd { team_warning, .. } => {
+            if team_warning == true {
+                "TEAM".to_string()
+            } else {
+                player_num.to_string()
+            }
+        }
+        KeypadPage::AddScore(_) => {
+            if player_num == 0 {
+                "TEAM".to_string()
+            } else {
+                player_num.to_string()
+            }
+        }
+        KeypadPage::FoulAdd { color, .. } => {
+            if color == None {
+                "TEAM".to_string()
+            } else {
+                player_num.to_string()
+            }
+        }
+        KeypadPage::GameNumber
+        | KeypadPage::Penalty(_, _, _, _)
+        | KeypadPage::TeamTimeouts(_, _) => player_num.to_string(),
+    };
+
     column![
         make_game_time_button(snapshot, false, false, config.mode, clock_running),
         row![
@@ -71,8 +98,12 @@ pub(in super::super) fn build_keypad_page<'a>(
                             .line_height(LINE_HEIGHT)
                             .horizontal_alignment(Horizontal::Left)
                             .vertical_alignment(Vertical::Center),
-                        text(player_num.to_string())
-                            .size(LARGE_TEXT)
+                        text(&text_displayed)
+                            .size(if text_displayed == "TEAM" {
+                                MEDIUM_TEXT
+                            } else {
+                                LARGE_TEXT
+                            })
                             .line_height(LINE_HEIGHT)
                             .width(Length::Fill)
                             .horizontal_alignment(Horizontal::Right)
@@ -127,17 +158,10 @@ pub(in super::super) fn build_keypad_page<'a>(
                     ]
                     .spacing(SPACING),
                     row![
-                        if player_num == 0 {
-                            setup_keypad_button(
-                                make_small_button("TEAM", SMALL_PLUS_TEXT),
-                                Message::ToggleBoolParameter(BoolGameParameter::TeamWarning),
-                            )
-                        } else {
-                            setup_keypad_button(
-                                make_small_button("0", MEDIUM_TEXT),
-                                Message::KeypadButtonPress(KeypadButton::Zero),
-                            )
-                        },
+                        setup_keypad_button(
+                            make_small_button("0", MEDIUM_TEXT),
+                            Message::KeypadButtonPress(KeypadButton::Zero),
+                        ),
                         setup_keypad_button(
                             button(
                                 container(


### PR DESCRIPTION
Changed the keypad to show "TEAM" rather than 0 if the player number is zero. If the player number is not zero it still will show zero. 

fixes #436