### PR TITLE
Display infraction name

### DIFF
--- a/refbox/src/app/view_builders/keypad_pages/foul_add.rs
+++ b/refbox/src/app/view_builders/keypad_pages/foul_add.rs
@@ -80,7 +80,7 @@ pub(super) fn make_foul_add_page<'a>(
         ]
         .spacing(SPACING),
         vertical_space(Length::Fixed(SPACING)),
-        make_penalty_dropdown(foul),
+        make_penalty_dropdown(foul, true),
         vertical_space(Length::Fill),
         exit_row,
     ]

--- a/refbox/src/app/view_builders/keypad_pages/penalty_edit.rs
+++ b/refbox/src/app/view_builders/keypad_pages/penalty_edit.rs
@@ -133,7 +133,7 @@ pub(super) fn make_penalty_edit_page<'a>(
     .spacing(SPACING);
 
     if config.track_fouls_and_warnings {
-        content = content.push(make_penalty_dropdown(infraction));
+        content = content.push(make_penalty_dropdown(infraction, false));
     } else {
         content = content.push(vertical_space(Length::Fill));
     }

--- a/refbox/src/app/view_builders/keypad_pages/warning_add.rs
+++ b/refbox/src/app/view_builders/keypad_pages/warning_add.rs
@@ -73,7 +73,7 @@ pub(super) fn make_warning_add_page<'a>(
         ]
         .spacing(SPACING),
         vertical_space(Length::Fixed(SPACING)),
-        make_penalty_dropdown(foul),
+        make_penalty_dropdown(foul, true),
         vertical_space(Length::Fill),
         exit_row,
     ]

--- a/refbox/src/app/view_builders/shared_elements.rs
+++ b/refbox/src/app/view_builders/shared_elements.rs
@@ -878,7 +878,10 @@ pub(super) fn make_value_button<'a, Message: 'a + Clone, T: ToString, U: ToStrin
     button
 }
 
-pub(super) fn make_penalty_dropdown<'a>(infraction: Infraction) -> Element<'a, Message> {
+pub(super) fn make_penalty_dropdown<'a>(
+    infraction: Infraction,
+    display_infraction_name: bool,
+) -> Element<'a, Message> {
     const ROW_LEN: usize = 6;
 
     let foul_buttons = all::<Infraction>().map(|button_infraction| {
@@ -900,6 +903,14 @@ pub(super) fn make_penalty_dropdown<'a>(infraction: Infraction) -> Element<'a, M
         .on_press(Message::ChangeInfraction(button_infraction))
     });
 
+    let name: Container<'_, Message> = container(
+        row![text(format!("Infraction: {}", infraction))]
+            .spacing(0)
+            .align_items(Alignment::Center),
+    )
+    .style(ContainerStyle::Blue)
+    .width(Length::Fill);
+
     let mut first_row = row![].spacing(SPACING);
     for button in foul_buttons.clone().take(ROW_LEN) {
         first_row = first_row.push(button);
@@ -909,12 +920,23 @@ pub(super) fn make_penalty_dropdown<'a>(infraction: Infraction) -> Element<'a, M
         second_row = second_row.push(button);
     }
 
-    let open_button_content = column![
-        first_row,
-        vertical_space(Length::Fixed(SPACING)),
-        second_row,
-    ]
-    .padding(0);
+    let open_button_content = if display_infraction_name {
+        column![
+            name,
+            vertical_space(Length::Fixed(SPACING)),
+            first_row,
+            vertical_space(Length::Fixed(SPACING)),
+            second_row,
+        ]
+        .padding(0)
+    } else {
+        column![
+            first_row,
+            vertical_space(Length::Fixed(SPACING)),
+            second_row,
+        ]
+        .padding(0)
+    };
 
     container(open_button_content)
         .padding(PADDING)

--- a/refbox/src/app/view_builders/shared_elements.rs
+++ b/refbox/src/app/view_builders/shared_elements.rs
@@ -904,7 +904,7 @@ pub(super) fn make_penalty_dropdown<'a>(
     });
 
     let name: Container<'_, Message> = container(
-        row![text(format!("Infraction: {}", infraction))]
+        row![text(infraction)]
             .spacing(0)
             .align_items(Alignment::Center),
     )


### PR DESCRIPTION
Added a line to display the full infraction name on the warning and foul pages where there is space.

Fixes #435