### PR TITLE
Pause during score confirm and autoconfirm

### DIFF
--- a/refbox/src/app/message.rs
+++ b/refbox/src/app/message.rs
@@ -98,6 +98,7 @@ pub enum Message {
     ScoreConfirmation {
         correct: bool,
     },
+    AutoConfirmScores(GameSnapshot),
     RecvEventList(Vec<Event>),
     RecvTeamsList(EventId, TeamList),
     RecvSchedule(EventId, Schedule),
@@ -165,6 +166,7 @@ impl Message {
             | Self::EndTimeout
             | Self::ConfirmScores(_)
             | Self::ScoreConfirmation { .. }
+            | Self::AutoConfirmScores(_)
             | Self::StopClock
             | Self::StartClock => false,
         }
@@ -281,6 +283,7 @@ impl PartialEq for Message {
             (Self::ScoreConfirmation { correct: a }, Self::ScoreConfirmation { correct: b }) => {
                 a == b
             }
+            (Self::AutoConfirmScores(a), Self::AutoConfirmScores(b)) => a == b,
             (Self::EditParameter(a), Self::EditParameter(b)) => a == b,
             (Self::SelectParameter(a), Self::SelectParameter(b)) => a == b,
             (
@@ -353,6 +356,7 @@ impl PartialEq for Message {
             | (Self::EndTimeout, _)
             | (Self::ConfirmScores(_), _)
             | (Self::ScoreConfirmation { .. }, _)
+            | (Self::AutoConfirmScores(_), _)
             | (Self::RecvEventList(_), _)
             | (Self::RecvTeamsList(_, _), _)
             | (Self::RecvSchedule(_, _), _)

--- a/refbox/src/app/view_builders/configuration.rs
+++ b/refbox/src/app/view_builders/configuration.rs
@@ -201,7 +201,7 @@ fn make_main_config_page<'a>(
     };
 
     column![
-        make_game_time_button(snapshot, false, false, mode, clock_running,),
+        make_game_time_button(snapshot, false, false, mode, clock_running),
         make_value_button(
             fl!("game-select"),
             game_label,

--- a/refbox/src/app/view_builders/game_info.rs
+++ b/refbox/src/app/view_builders/game_info.rs
@@ -43,7 +43,7 @@ pub(in super::super) fn build_game_info_page<'a>(
     let (left_details, right_details) =
         details_strings(snapshot, config, using_uwhportal, games, teams);
     column![
-        make_game_time_button(snapshot, false, false, mode, clock_running,),
+        make_game_time_button(snapshot, false, false, mode, clock_running),
         row![
             text(left_details)
                 .size(SMALL_TEXT)

--- a/refbox/src/app/view_builders/shared_elements.rs
+++ b/refbox/src/app/view_builders/shared_elements.rs
@@ -420,6 +420,7 @@ pub(super) fn make_game_time_button<'a>(
     });
 
     let time_text = secs_to_long_time_string(snapshot.secs_in_period);
+
     let time_text = time_text.trim().to_owned();
 
     if tall {

--- a/refbox/src/app/view_builders/warnings_fouls_summary.rs
+++ b/refbox/src/app/view_builders/warnings_fouls_summary.rs
@@ -85,7 +85,7 @@ pub(in super::super) fn build_warnings_summary_page<'a>(
     .width(Length::Fill);
 
     column![
-        make_game_time_button(snapshot, false, false, mode, clock_running,),
+        make_game_time_button(snapshot, false, false, mode, clock_running),
         warnings_and_fouls_row.height(Length::Fill),
         row![
             make_button(fl!("back"))


### PR DESCRIPTION
Clock will keep track of time elapsed while confirming scores, and will take that time from the next period duration. Score confirmation is called anytime the game could possibly end (such as if it is tied, it will automatically go to overtime, but will still confirm that the tied score is correct). 

fixes #78 