### PR TITLE
fix(refbox): end confirm pause before starting clock when confirm scores is off

### DIFF
--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -1830,6 +1830,7 @@ impl RefBoxApp {
                 } else {
                     let mut tm = self.tm.lock().unwrap();
                     let now = Instant::now();
+                    tm.end_confirm_pause(now).unwrap();
                     tm.start_clock(now);
                     tm.update(now + Duration::from_millis(2)).unwrap(); // Need to update after game ends
                     self.app_state = AppState::MainPage;

--- a/refbox/src/tournament_manager/mod.rs
+++ b/refbox/src/tournament_manager/mod.rs
@@ -1891,8 +1891,13 @@ impl TournamentManager {
                         GamePeriod::BetweenGames
                     }
                 }
-                _ => {
-                    unreachable!()
+                other => {
+                    warn!(
+                        "end_confirm_pause called while in unexpected period {:?}, clearing pause state",
+                        other
+                    );
+                    self.time_pause_confirmation = None;
+                    return Ok(());
                 }
             };
 

--- a/refbox/tests/features/README.md
+++ b/refbox/tests/features/README.md
@@ -1,0 +1,27 @@
+# Feature Specifications
+
+This directory contains Gherkin-style (`.feature`) specifications of
+observable behavior in the refbox crate. Each file describes a feature
+in plain-English scenarios, following the same style used in
+`uwh-portal` (Reqnroll/Cucumber).
+
+## Status: documentation-only
+
+These files are currently **documentation**, not runnable tests. The
+Rust `cucumber` crate that would turn them into executable tests has
+not yet been wired up in this workspace.
+
+They are committed alongside each feature so that:
+
+1. The intended behavior of each feature is recorded in one place, in
+   language a tournament organiser can read without knowing Rust.
+2. They are ready to become runnable tests when the cucumber harness
+   is added in a later release.
+
+## When these become runnable
+
+Standing up the cucumber harness (adding the dev-dependency, the test
+runner, and step definitions) is tracked as a post-v0.4.0 follow-up.
+For UI-layout scenarios (see `manual_alarm.feature`), additional UI
+testing infrastructure will also be needed, since this crate currently
+has no UI-layer tests.

--- a/refbox/tests/features/confirm_score_timing.feature
+++ b/refbox/tests/features/confirm_score_timing.feature
@@ -1,0 +1,15 @@
+Feature: Confirm-Score Timing Fix
+  # Tests for the tournament manager state machine around score confirmation.
+  # Bug observed 6 times at tournaments (Jan 13, Jan 19, Feb 24 2026):
+  # when "confirm scores" is turned OFF, the refbox would become unresponsive
+  # ~90 seconds after the second half ended, requiring a restart.
+
+  Background:
+    Given a game is configured with "confirm scores" turned off
+
+  Scenario: Confirm-pause state is cleared when the second half ends
+    Given the tournament is set up with score confirmation turned off
+    And the second half is in progress
+    When the second half ends
+    Then the refbox moves normally to the between-games period
+    And remains fully responsive


### PR DESCRIPTION
## What changed

Fixes a bug that made the refbox become unresponsive about 90 seconds after the end of the second half of a game — but only when the "confirm scores" option is turned **off**. The problem was observed 6 times across tournaments on Jan 13, Jan 19, and Feb 24 2026, and each time the only recovery was to restart the refbox.

Two changes, both in `refbox/src/`:

1. **Primary fix** — when the operator hits "Confirm Scores" with `confirm_score` disabled, the code now clears the internal pause state *before* starting the game clock again. Previously it only started the clock, which left the pause state hanging. Ninety seconds later a background timer tried to clean that state up, hit an `unreachable!()` branch (because the game was no longer in the second half), and panicked — which poisoned a shared lock and froze the UI.

2. **Defensive fix** — that same `unreachable!()` in `tournament_manager/mod.rs` now logs a warning and clears the pause state gracefully instead of crashing. So even if some future code path produces a similar mismatch, the operator won't lose the refbox mid-game.

Also adds a Gherkin-style feature specification (`refbox/tests/features/confirm_score_timing.feature`) documenting the observable behaviour this fix guarantees. The Gherkin files are documentation-only for now — the cucumber test harness isn't wired up in this workspace yet, which is tracked as a post-v0.4.0 follow-up. A README alongside the feature file explains this.

## Why

This is the highest-impact bug on the v0.4.0 list. It has already affected six real tournament games, and every occurrence forced a restart mid-session. The fix is small but the observable improvement is large: the refbox will now transition cleanly from the second half to the between-games period when score confirmation is turned off.

## Scope

Two source files in `refbox/` and two new documentation files under `refbox/tests/features/`. No changes to `uwh-common`, `overlay`, `schedule-processor`, or any other crate.

## How to verify

- Set up a game with "confirm scores" turned off in the refbox settings.
- Let the second half run to the end.
- The refbox should transition cleanly to the between-games period and remain fully responsive (not freeze ~90 seconds later).
- Before this fix, the refbox would lock up and require a restart.
- On the automated side: all 83 refbox tests still pass (`cargo test -p refbox`). No existing test was altered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)