### PR TITLE
chore(workspace): gitignore local tournament artifacts and superpowers sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ refbox/Troubleshooting/
 schedule-processor/Mock Schedules for testing/
 schedule-processor/Test Scoresheets/
 uwhportal-schedule-json.md
+
+# Superpowers session files (per-agent working state, not shared)
+.superpowers/

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,9 @@ uwh-matrix-drawing/state.json
 
 # Mac BS
 .DS_Store
+
+# Local-only tournament artifacts and logs (not part of the repo)
+refbox/Troubleshooting/
+schedule-processor/Mock Schedules for testing/
+schedule-processor/Test Scoresheets/
+uwhportal-schedule-json.md


### PR DESCRIPTION
## What changed

Adds five new patterns to `.gitignore` so that local-only files no longer clutter \`git status\` or risk being accidentally committed:

- \`refbox/Troubleshooting/\` — refbox log captures used for diagnosing Henk's build
- \`schedule-processor/Mock Schedules for testing/\` — offline scheduler test inputs
- \`schedule-processor/Test Scoresheets/\` — generated PDF/HTML scoresheets
- \`uwhportal-schedule-json.md\` — Portal API schema reference (may be promoted to \`docs/\` later)
- \`.superpowers/\` — per-agent brainstorming and session state used by Claude Code's superpowers skills

No existing files are removed from the repo — these patterns simply prevent future additions of these paths.

## Why

These directories build up over the course of a tournament season (log captures, test PDFs, mock CSVs) and are currently showing up as untracked files every time we run \`git status\`. Ignoring them cleans up the day-to-day workflow and reduces the risk of accidentally committing something like an 800-line troubleshooting log into the repo.

## Scope

\`.gitignore\` only. No code, no dependencies, no behaviour change.

## How to verify

- Run \`git status\` from a working tree that contains any of these paths — the paths should no longer appear.
- The refbox, schedule-processor, overlay, and other binaries still build identically; nothing in these paths was ever part of the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)