### PR TITLE
chore(ci): fix Raspberry Pi cross-compile with Ubuntu 22.04 custom Dockerfile

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,6 +1,2 @@
 [target.aarch64-unknown-linux-gnu]
-pre-build = [
-    "dpkg --add-architecture $CROSS_DEB_ARCH",
-    "apt-get update",
-    "apt-get install -y --no-install-recommends libssl-dev:$CROSS_DEB_ARCH pkg-config:$CROSS_DEB_ARCH libasound2-dev:$CROSS_DEB_ARCH"
-]
+dockerfile = "Dockerfile.aarch64-unknown-linux-gnu"

--- a/Dockerfile.aarch64-unknown-linux-gnu
+++ b/Dockerfile.aarch64-unknown-linux-gnu
@@ -1,0 +1,43 @@
+FROM ubuntu:22.04
+
+ARG CROSS_DEB_ARCH=arm64
+ARG CROSS_CMD
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Host toolchain (needed to run build scripts compiled by the host Rust compiler)
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+    gcc \
+    && rm -rf /var/lib/apt/lists/*
+
+# aarch64 cross-compilation toolchain
+RUN apt-get update && apt-get install -y \
+    gcc-aarch64-linux-gnu \
+    g++-aarch64-linux-gnu \
+    binutils-aarch64-linux-gnu \
+    && rm -rf /var/lib/apt/lists/*
+
+# Configure apt sources: restrict existing sources to amd64, add ports.ubuntu.com for arm64
+RUN sed -i 's/^deb /deb [arch=amd64] /' /etc/apt/sources.list \
+    && echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy main restricted universe multiverse" >> /etc/apt/sources.list.d/arm64-ports.list \
+    && echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-updates main restricted universe multiverse" >> /etc/apt/sources.list.d/arm64-ports.list \
+    && echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports jammy-security main restricted universe multiverse" >> /etc/apt/sources.list.d/arm64-ports.list
+
+# ARM64 native libraries required by the refbox build
+RUN dpkg --add-architecture arm64 \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libssl-dev:arm64 \
+        pkg-config \
+        libasound2-dev:arm64 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Tell cargo to use the aarch64 cross-linker
+ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+
+# Tell pkg-config to find arm64 libraries when cross-compiling
+ENV PKG_CONFIG_ALLOW_CROSS=1
+ENV PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig
+
+RUN eval "${CROSS_CMD}"


### PR DESCRIPTION
## What changed

Replaces the Raspberry Pi cross-compile Docker image with a custom Ubuntu 22.04 one. Two files touched:

- \`Cross.toml\` — points the \`aarch64-unknown-linux-gnu\` target at the new local Dockerfile instead of the old pre-built image.
- \`Dockerfile.aarch64-unknown-linux-gnu\` *(new)* — 43 lines. Based on Ubuntu 22.04, installs:
  - \`gcc-aarch64-linux-gnu\` as the cross-linker
  - \`libssl-dev:arm64\` and \`libasound2-dev:arm64\` from \`ports.ubuntu.com\` (the ARM64 dev libraries that \`openssl-sys\` and \`alsa-sys\` need at build time)
  - Environment variables so Cargo and \`pkg-config\` find the ARM64 linker and \`.pc\` files when cross-compiling from an x86 host

## Why

The previous Cross.toml pre-build pulled \`ghcr.io/cross-rs/aarch64-unknown-linux-gnu:0.2.5\`, which is Ubuntu 16.04 (glibc 2.23). Modern Rust build scripts — anything compiled by a recent host Rust toolchain — need glibc 2.34+ at runtime. On modern WSL, this meant the cross-build would fail immediately with a \"GLIBC_2.34 not found\" error before Rust could even start.

The new image is Ubuntu 22.04 (glibc 2.35), which matches the host's runtime expectation and makes \`just build-rpi\` work reliably again. This is a prerequisite for shipping v0.4.0 to the Pis.

## Scope

Two files at the repo root. No Rust source, no dependencies, no crate behaviour change. Pure CI/build-tooling.

## How to verify

- Run \`just build-rpi\` locally. It should produce an ARM64 binary without a glibc error.
- The release pipeline (coming in a later PR) will exercise the same Dockerfile on CI.
- The existing CI matrix on this PR still passes — clippy, audit, tests — since no Rust code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)