### PR TITLE
chore(ci): fix release pipeline for v0.4.0 tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
     - uses: actions/upload-artifact@v4
       with:
         name: refbox-macos-arm
-        path: target/release/bundle/osx/refbox.app
+        path: target/aarch64-apple-darwin/release/bundle/osx/refbox.app
 
   build-macos-x86:
     name: Build release on macos-latest for x86 target
@@ -53,6 +53,7 @@ jobs:
         crate: cargo-bundle
     - name: Versions
       run: cargo --version && rustc --version && cargo fmt -- --version && cargo clippy -- --version && cargo bundle --version
+    - run: rustup target add x86_64-apple-darwin
     - run: cargo bundle --release --target x86_64-apple-darwin -p refbox
     - uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         crate: cargo-bundle
     - name: Versions
       run: cargo --version && rustc --version && cargo fmt -- --version && cargo clippy -- --version && cargo bundle --version
-    - run: cargo bundle --release --target aarch64-apple-darwin
+    - run: cargo bundle --release --target aarch64-apple-darwin -p refbox
     - uses: actions/upload-artifact@v4
       with:
         name: refbox-macos-arm
@@ -53,7 +53,7 @@ jobs:
         crate: cargo-bundle
     - name: Versions
       run: cargo --version && rustc --version && cargo fmt -- --version && cargo clippy -- --version && cargo bundle --version
-    - run: cargo bundle --release --target x86_64-apple-darwin
+    - run: cargo bundle --release --target x86_64-apple-darwin -p refbox
     - uses: actions/upload-artifact@v4
       with:
         name: refbox-macos-x86

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,30 +79,12 @@ jobs:
       with:
         name: refbox-macos-x86
         path: release/Mac\ (Intel processor)/refbox.app
-    - name: Add english getting started guide
-      uses: k0staa/download-gdrive-file-action@v1
-      with:
-        service-account-key-json: ${{ secrets.SERVICE_ACCOUNT_AUTH_JSON }}
-        download-file-name: Getting Started Guide - English.pdf
-        download-to: release/
-    - name: Add spanish getting started guide
-      uses: k0staa/download-gdrive-file-action@v1
-      with:
-        service-account-key-json: ${{ secrets.SERVICE_ACCOUNT_AUTH_JSON }}
-        download-file-name: Getting Started Guide - Spanish (Guía de Inicio).pdf
-        download-to: release/
-    - name: Add manual
-      uses: k0staa/download-gdrive-file-action@v1
-      with:
-        service-account-key-json: ${{ secrets.SERVICE_ACCOUNT_AUTH_JSON }}
-        download-file-name: Refbox User Manual.pdf
-        download-to: release/
-    - name: Add manual with fouls
-      uses: k0staa/download-gdrive-file-action@v1
-      with:
-        service-account-key-json: ${{ secrets.SERVICE_ACCOUNT_AUTH_JSON }}
-        download-file-name: Refbox User Manual with Fouls.pdf
-        download-to: release/
+    - name: Download PDFs from Google Drive
+      run: |
+        curl -L "https://drive.usercontent.google.com/download?id=1Momxds_2oyPTEZHgcuSxnTxI_HbGeaN8&export=download" -o "release/Getting Started Guide - English.pdf"
+        curl -L "https://drive.usercontent.google.com/download?id=13eHCCmBH-IEUwIODaqpbbz_LiZQBBh0p&export=download" -o "release/Getting Started Guide - Spanish (Guía de Inicio).pdf"
+        curl -L "https://drive.usercontent.google.com/download?id=1skrUYTEYBgHs4T-dl3AobwklfJR3ZGE1&export=download" -o "release/Refbox User Manual.pdf"
+        curl -L "https://drive.usercontent.google.com/download?id=1FLtJwc8gb5vuSRVPUNLxKhT1ufcOSa-w&export=download" -o "release/Refbox User Manual with Fouls.pdf"
     - name: Zip release
       run: cd release && zip -r ../refbox.zip .
     - uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## What changed
Three fixes to the release workflow (`.github/workflows/release.yml`) so that tagging v0.4.0 will actually produce working release artifacts.

## Why
The release workflow has been broken since at least v0.3.0:
1. Mac builds fail because `cargo bundle` can't find the root package in a workspace
2. Mac artifact upload paths were wrong once `--target` started being passed
3. `macos-latest` is now ARM, so Intel (x86_64) builds need the target explicitly installed
4. The old Google Drive service-account download was fragile; direct curl is simpler

## Scope
Changes are limited to `.github/workflows/release.yml` (one file, 3 commits).

## How to verify
- PR CI won't exercise this workflow (it only runs on tag push).
- Real test is tagging v0.4.0 after merge and watching the release workflow succeed — Mac ARM, Mac Intel, and Linux artifacts all produced and uploaded.
- If it still fails at tag time, we delete the tag, fix, and re-tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)