### PR TITLE
feat(refbox): add manual alarm button

### DIFF
--- a/docs/superpowers/plans/2026-04-14-manual-alarm-button.md
+++ b/docs/superpowers/plans/2026-04-14-manual-alarm-button.md
@@ -1,0 +1,815 @@
+# Manual Alarm Button Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an opt-in on-screen alarm button and spacebar shortcut that lets the referee operator manually trigger the buzzer during live play, with a hold-to-test mode during the Between Games period.
+
+**Architecture:** A new boolean setting (`manual_alarm_enabled`) gates the entire feature. When on, the main screen's center column replaces the game info area with a compact "GAME INFO" button plus an alarm zone (split with the warnings panel when fouls/warnings tracking is active).
+
+A **uniform hold model** applies: every press schedules a fire timer (250ms during active play with no timeout, 1 second everywhere else). When the timer fires, the alarm starts in a continuous mode via `SoundController::start_manual_buzzer()`. Release stops further queueing via `stop_manual_buzzer()`, letting the currently playing tone finish its natural cycle. A generation counter on `RefBoxApp` invalidates pending timers on early release without needing task cancellation.
+
+The button visual state depends on the game state: red with "Alarm / Or press Spacebar" during active play (no timeout), blue with "Hold to Test / Or hold Spacebar" in every other state. The button is never greyed out while the feature is enabled.
+
+Spacebar events are added to the existing subscription.
+
+**Tech Stack:** Rust 2024, iced 0.13 (Elm-like UI), tokio async runtime, Fluent (`.ftl`) translations
+
+---
+
+## File Map
+
+| Action | File | What changes |
+|--------|------|-------------|
+| Modify | `refbox/src/sound_controller/mod.rs` | Add `manual_alarm_enabled` field and migration |
+| Modify | `refbox/src/app/message.rs` | Add `AlarmPressed`, `AlarmReleased`, `AlarmFired(u32)`, `BoolGameParameter::ManualAlarmEnabled` |
+| Verify | `refbox/translations/*/refbox.ftl` | All required keys (`alarm-button`, `alarm`, `hold-to-test`, `or-press-spacebar`, `or-hold-spacebar`, `game-info`) already exist across all 14 languages — no changes needed |
+| Modify | `refbox/src/app/view_builders/configuration.rs` | Add Alarm Button toggle row to sound settings page |
+| Modify | `refbox/src/app/mod.rs` | Add `alarm_hold_generation`, handle new messages, extend subscription, pass new param to `build_main_view` |
+| Modify | `refbox/src/app/view_builders/main_view.rs` | New layout with GAME INFO button and state-dependent alarm button (red/blue) |
+
+---
+
+### Task 1: Add `manual_alarm_enabled` to `SoundSettings`
+
+**Files:**
+- Modify: `refbox/src/sound_controller/mod.rs`
+
+- [ ] **Step 1: Add the field to `SoundSettings`**
+
+In `refbox/src/sound_controller/mod.rs`, add the new field to the `SoundSettings` struct. It goes after `auto_sound_stop_play` and before `remotes`:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Derivative)]
+#[derivative(Default)]
+pub struct SoundSettings {
+    #[derivative(Default(value = "true"))]
+    pub sound_enabled: bool,
+    #[derivative(Default(value = "true"))]
+    pub whistle_enabled: bool,
+    pub buzzer_sound: BuzzerSound,
+    #[derivative(Default(value = "Volume::Medium"))]
+    pub whistle_vol: Volume,
+    pub above_water_vol: Volume,
+    pub under_water_vol: Volume,
+    #[derivative(Default(value = "true"))]
+    pub auto_sound_start_play: bool,
+    #[derivative(Default(value = "true"))]
+    pub auto_sound_stop_play: bool,
+    pub manual_alarm_enabled: bool,   // <-- new field (defaults false)
+    pub remotes: Vec<RemoteInfo>,
+}
+```
+
+- [ ] **Step 2: Add migration support**
+
+In the `SoundSettings::migrate()` method, add handling for the new field after the `auto_sound_stop_play` block. Follow the exact same pattern as the existing fields:
+
+```rust
+// Add this block after the auto_sound_stop_play block:
+if let Some(old_manual_alarm_enabled) = old.get("manual_alarm_enabled") {
+    if let Some(old_manual_alarm_enabled) = old_manual_alarm_enabled.as_bool() {
+        manual_alarm_enabled = old_manual_alarm_enabled;
+    }
+}
+```
+
+Also add `mut manual_alarm_enabled` to the destructuring at the top of `migrate()`:
+
+```rust
+let Self {
+    mut sound_enabled,
+    mut whistle_enabled,
+    mut buzzer_sound,
+    mut whistle_vol,
+    mut above_water_vol,
+    mut under_water_vol,
+    mut auto_sound_start_play,
+    mut auto_sound_stop_play,
+    mut manual_alarm_enabled,   // <-- add this
+    mut remotes,
+} = Default::default();
+```
+
+And include it in the final `Self { ... }` construction:
+
+```rust
+Self {
+    sound_enabled,
+    whistle_enabled,
+    buzzer_sound,
+    whistle_vol,
+    above_water_vol,
+    under_water_vol,
+    auto_sound_start_play,
+    auto_sound_stop_play,
+    manual_alarm_enabled,   // <-- add this
+    remotes,
+}
+```
+
+- [ ] **Step 3: Update the existing serialization test**
+
+In the `#[cfg(test)]` block at the bottom of `refbox/src/sound_controller/mod.rs`, the `test_ser_sound_settings` test exercises the default `SoundSettings`. It will still pass because the new field defaults to `false` and round-trips correctly — but run it now to confirm:
+
+```bash
+cargo test -p refbox test_ser_sound_settings -- --nocapture
+```
+
+Expected: `test test_ser_sound_settings ... ok`
+
+- [ ] **Step 4: Update the migration test**
+
+The `test_migrate_sound_settings` test in the same file does not include the new field in the `old` table, which is correct (it tests migration from an old config without the field). Verify it still passes:
+
+```bash
+cargo test -p refbox test_migrate_sound_settings -- --nocapture
+```
+
+Expected: `test test_migrate_sound_settings ... ok`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add refbox/src/sound_controller/mod.rs
+git commit -m "feat(refbox): add manual_alarm_enabled field to SoundSettings"
+```
+
+---
+
+### Task 2: Add new `Message` variants
+
+**Files:**
+- Modify: `refbox/src/app/message.rs`
+
+- [ ] **Step 1: Add the three new `Message` variants**
+
+In `refbox/src/app/message.rs`, add to the `Message` enum after `StartClock`:
+
+```rust
+AlarmPressed,
+AlarmReleased,
+AlarmFired(u32),
+```
+
+- [ ] **Step 2: Add `ManualAlarmEnabled` to `BoolGameParameter`**
+
+In the same file, add to the `BoolGameParameter` enum after `ConfirmScore`:
+
+```rust
+ManualAlarmEnabled,
+```
+
+- [ ] **Step 3: Update `is_repeatable()`**
+
+`AlarmPressed`, `AlarmReleased`, and `AlarmFired` are not repeatable. Add them to the `false` arm of `is_repeatable()` alongside `StopClock` and `StartClock`:
+
+```rust
+| Self::StopClock
+| Self::StartClock
+| Self::AlarmPressed
+| Self::AlarmReleased
+| Self::AlarmFired(_) => false,
+```
+
+- [ ] **Step 4: Update `PartialEq`**
+
+In the hand-written `PartialEq` impl, add equality cases. In the `true` arm of the match, add (alongside `StopClock` and `StartClock`):
+
+```rust
+(Self::AlarmPressed, Self::AlarmPressed)
+| (Self::AlarmReleased, Self::AlarmReleased) => true,
+```
+
+Add a parametric case for `AlarmFired` (put it alongside the other parametric `true` cases such as `ChangeScore`):
+
+```rust
+(Self::AlarmFired(a), Self::AlarmFired(b)) => a == b,
+```
+
+Add the three variants to the catch-all `false` arm at the bottom (alongside `StartClock`):
+
+```rust
+| (Self::AlarmPressed, _)
+| (Self::AlarmReleased, _)
+| (Self::AlarmFired(_), _) => false,
+```
+
+- [ ] **Step 5: Verify compilation**
+
+```bash
+cargo check -p refbox
+```
+
+Expected: no errors. The new variants will produce `non-exhaustive patterns` warnings in the `update()` function — that is expected and will be resolved in Task 5.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add refbox/src/app/message.rs
+git commit -m "feat(refbox): add AlarmPressed/Released/Fired messages and ManualAlarmEnabled parameter"
+```
+
+---
+
+### Task 3: Verify translation strings already exist
+
+All six translation keys used by this feature (`alarm-button`, `alarm`, `hold-to-test`, `or-press-spacebar`, `or-hold-spacebar`, `game-info`) are already present in every supported language file. No edits are needed — just a verification pass.
+
+- [ ] **Step 1: Confirm all keys exist in all languages**
+
+```bash
+for lang in refbox/translations/*/refbox.ftl; do
+  for key in alarm-button alarm hold-to-test or-press-spacebar or-hold-spacebar game-info; do
+    grep -q "^${key}\s*=" "$lang" || echo "MISSING: $key in $lang"
+  done
+done
+```
+
+Expected: no output (every key is present in every file). If any key is reported missing, add it before proceeding.
+
+- [ ] **Step 2: No commit needed for this task**
+
+---
+
+### Task 4: Add the Alarm Button toggle to the Sound settings page
+
+**Files:**
+- Modify: `refbox/src/app/view_builders/configuration.rs`
+
+- [ ] **Step 1: Add a new row to `make_sound_config_page`**
+
+In `refbox/src/app/view_builders/configuration.rs`, find the `make_sound_config_page` function. After the third `row![ ... ].spacing(SPACING),` block (the one with `buzzer-sound`, `underwater-volume`, `auto-sound-stop-play`), add a new row and a divider before the remotes section. The existing remotes section starts with `make_scroll_list(...)` or similar — add the new row just before it:
+
+```rust
+row![
+    make_value_button(
+        fl!("alarm-button"),
+        bool_string(sound.manual_alarm_enabled),
+        (false, true),
+        if sound.sound_enabled {
+            Some(Message::ToggleBoolParameter(
+                BoolGameParameter::ManualAlarmEnabled,
+            ))
+        } else {
+            None
+        },
+    ),
+]
+.spacing(SPACING),
+```
+
+- [ ] **Step 2: Verify compilation**
+
+```bash
+cargo check -p refbox
+```
+
+Expected: `ManualAlarmEnabled` will still produce a non-exhaustive warning in `update()` — that is resolved in the next task.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add refbox/src/app/view_builders/configuration.rs
+git commit -m "feat(refbox): add Alarm Button toggle to sound settings page"
+```
+
+---
+
+### Task 5: Handle new messages in `app/mod.rs`
+
+**Files:**
+- Modify: `refbox/src/app/mod.rs`
+
+- [ ] **Step 1: Add `alarm_hold_generation` to `RefBoxApp`**
+
+In the `RefBoxApp` struct definition (around line 55), add the new field after `list_all_events`:
+
+```rust
+pub struct RefBoxApp {
+    tm: Arc<Mutex<TournamentManager>>,
+    config: Config,
+    edited_settings: Option<EditableSettings>,
+    snapshot: GameSnapshot,
+    pen_edit: ListEditor<Penalty, Color>,
+    warn_edit: ListEditor<InfractionDetails, Color>,
+    foul_edit: ListEditor<InfractionDetails, Option<Color>>,
+    app_state: AppState,
+    last_app_state: AppState,
+    last_message: Message,
+    update_sender: UpdateSender,
+    uwhportal_client: Option<UwhPortalClient>,
+    using_uwhportal: bool,
+    events: Option<BTreeMap<EventId, Event>>,
+    schedule: Option<Schedule>,
+    current_event_id: Option<EventId>,
+    current_court: Option<String>,
+    sound: SoundController,
+    sim_child: Option<Child>,
+    list_all_events: bool,
+    alarm_hold_generation: u32,   // <-- new field
+}
+```
+
+- [ ] **Step 2: Initialize the new field**
+
+Find where `RefBoxApp` is constructed (the `new()` or equivalent function — search for `list_all_events:` to find the construction site). Add:
+
+```rust
+alarm_hold_generation: 0,
+```
+
+- [ ] **Step 3: Handle `BoolGameParameter::ManualAlarmEnabled` in `update()`**
+
+Find the `ToggleBoolParameter` match arm in `update()` (around line 1640). Add the new case after `ConfirmScore`:
+
+```rust
+BoolGameParameter::ManualAlarmEnabled => {
+    edited_settings.sound.manual_alarm_enabled ^= true
+}
+```
+
+- [ ] **Step 4: Handle `AlarmPressed`, `AlarmReleased`, and `AlarmFired`**
+
+Under the uniform hold model: every press schedules a timer (250ms for active play with no timeout, 1 second everywhere else). When the timer fires, start the continuous manual buzzer. On release, invalidate any pending timer and stop the buzzer (which lets the currently playing tone finish its natural cycle before silence).
+
+Add handling for the three new message variants alongside `StopClock` and `StartClock` near the end of the message match:
+
+```rust
+Message::AlarmPressed => {
+    if self.config.sound.sound_enabled && self.config.sound.manual_alarm_enabled {
+        self.alarm_hold_generation = self.alarm_hold_generation.wrapping_add(1);
+        let gen = self.alarm_hold_generation;
+        let hold_duration = match (self.snapshot.current_period, self.snapshot.timeout) {
+            (
+                GamePeriod::FirstHalf
+                | GamePeriod::SecondHalf
+                | GamePeriod::OvertimeFirstHalf
+                | GamePeriod::OvertimeSecondHalf
+                | GamePeriod::SuddenDeath,
+                None,
+            ) => Duration::from_millis(250),
+            _ => Duration::from_secs(1),
+        };
+        return Task::future(async move {
+            tokio::time::sleep(hold_duration).await;
+            Message::AlarmFired(gen)
+        });
+    }
+    Task::none()
+}
+Message::AlarmFired(gen) => {
+    if gen == self.alarm_hold_generation
+        && self.config.sound.sound_enabled
+        && self.config.sound.manual_alarm_enabled
+    {
+        self.sound.start_manual_buzzer();
+    }
+    Task::none()
+}
+Message::AlarmReleased => {
+    self.alarm_hold_generation = self.alarm_hold_generation.wrapping_add(1);
+    self.sound.stop_manual_buzzer();
+    Task::none()
+}
+```
+
+Notes:
+- `start_manual_buzzer()` and `stop_manual_buzzer()` already exist in `SoundController`. `start_manual_buzzer()` pushes `ManualAlarm` to the front of the sound queue (continuous playback); `stop_manual_buzzer()` removes it from the queue, allowing the currently playing tone to finish naturally.
+- `stop_manual_buzzer()` is idempotent — it's safe to call on every `AlarmReleased` even if no alarm is playing.
+- No state check in `AlarmFired` beyond the generation counter and the feature flags. If the game state changes between press and fire, the operator's expressed intent (the hold) is still honoured.
+
+- [ ] **Step 5: Verify compilation**
+
+```bash
+cargo check -p refbox
+```
+
+Expected: no errors or warnings.
+
+- [ ] **Step 6: Run tests**
+
+```bash
+just test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add refbox/src/app/mod.rs
+git commit -m "feat(refbox): handle alarm messages and ManualAlarmEnabled toggle in app update"
+```
+
+---
+
+### Task 6: Extend `subscription()` for spacebar events
+
+**Files:**
+- Modify: `refbox/src/app/mod.rs`
+
+- [ ] **Step 1: Add keyboard imports**
+
+At the top of `refbox/src/app/mod.rs`, the existing iced import is:
+
+```rust
+use iced::{Element, Subscription, Task, Theme, application::Appearance, widget::column, window};
+```
+
+Extend it to include keyboard support:
+
+```rust
+use iced::{
+    Element, Subscription, Task, Theme,
+    application::Appearance,
+    keyboard::{self, Key, key::Named},
+    widget::column,
+    window,
+};
+```
+
+- [ ] **Step 2: Replace `subscription()`**
+
+Find the existing `subscription()` method (around line 2251):
+
+```rust
+pub(super) fn subscription(&self) -> Subscription<Message> {
+    Subscription::run(time_updater)
+}
+```
+
+Replace it with:
+
+```rust
+pub(super) fn subscription(&self) -> Subscription<Message> {
+    let time_sub = Subscription::run(time_updater);
+
+    if self.config.sound.sound_enabled && self.config.sound.manual_alarm_enabled {
+        let key_press = keyboard::on_key_press(|key, _modifiers| {
+            if matches!(key, Key::Named(Named::Space)) {
+                Some(Message::AlarmPressed)
+            } else {
+                None
+            }
+        });
+        let key_release = keyboard::on_key_release(|key, _modifiers| {
+            if matches!(key, Key::Named(Named::Space)) {
+                Some(Message::AlarmReleased)
+            } else {
+                None
+            }
+        });
+        Subscription::batch([time_sub, key_press, key_release])
+    } else {
+        time_sub
+    }
+}
+```
+
+- [ ] **Step 3: Verify compilation**
+
+```bash
+cargo check -p refbox
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add refbox/src/app/mod.rs
+git commit -m "feat(refbox): subscribe to spacebar events for manual alarm when enabled"
+```
+
+---
+
+### Task 7: Update the main view layout
+
+**Files:**
+- Modify: `refbox/src/app/view_builders/main_view.rs`
+
+- [ ] **Step 1: Add `mouse_area`, `container`, and `Padding` to imports**
+
+At the top of `refbox/src/app/view_builders/main_view.rs`, the existing iced import includes `button`, `column`, `row`, `text`. Add `mouse_area`, `container`, and `Padding`:
+
+```rust
+use iced::{
+    Alignment, Element, Length, Padding,
+    alignment::{Horizontal, Vertical},
+    widget::{Space, button, column, container, mouse_area, row, text},
+};
+```
+
+- [ ] **Step 2: Add `manual_alarm_enabled` parameter to `build_main_view`**
+
+Change the function signature from:
+
+```rust
+pub(in super::super) fn build_main_view<'a>(
+    data: ViewData<'_, '_>,
+    game_config: &GameConfig,
+    using_uwhportal: bool,
+    schedule: Option<&Schedule>,
+    track_fouls_and_warnings: bool,
+) -> Element<'a, Message>
+```
+
+To:
+
+```rust
+pub(in super::super) fn build_main_view<'a>(
+    data: ViewData<'_, '_>,
+    game_config: &GameConfig,
+    using_uwhportal: bool,
+    schedule: Option<&Schedule>,
+    track_fouls_and_warnings: bool,
+    manual_alarm_enabled: bool,
+) -> Element<'a, Message>
+```
+
+- [ ] **Step 3: Replace the game info / warnings section**
+
+Find the section in `build_main_view` that pushes the game info button and, conditionally, the warnings panel. It currently looks like:
+
+```rust
+center_col = center_col.push(if max_num_warns < 4 {
+    button(text(config_string(...))...)
+        .on_press(Message::ShowGameDetails)
+} else {
+    button(text(config_string_game_num(...))...)
+        .on_press(Message::ShowGameDetails)
+});
+
+if track_fouls_and_warnings {
+    center_col = center_col.push( /* warnings panel */ );
+}
+```
+
+Replace that entire block with the following:
+
+```rust
+if manual_alarm_enabled {
+    // Compact GAME INFO button
+    center_col = center_col.push(
+        button(
+            text(fl!("game-info"))
+                .size(SMALL_TEXT)
+                .align_y(Vertical::Center)
+                .align_x(Horizontal::Center),
+        )
+        .padding(PADDING)
+        .style(light_gray_button)
+        .width(Length::Fill)
+        .on_press(Message::ShowGameDetails),
+    );
+
+    // Determine whether we're in active play with no timeout.
+    // This drives both the colour scheme (red vs blue) and the button label.
+    // The button is always interactive while the feature is enabled — the
+    // minimum hold duration (handled in update()) gates whether a press fires.
+    let is_active_play = matches!(
+        (snapshot.current_period, snapshot.timeout),
+        (
+            GamePeriod::FirstHalf
+            | GamePeriod::SecondHalf
+            | GamePeriod::OvertimeFirstHalf
+            | GamePeriod::OvertimeSecondHalf
+            | GamePeriod::SuddenDeath,
+            None,
+        )
+    );
+
+    // Build the alarm button (visual only — mouse_area handles press/release)
+    let alarm_btn = if is_active_play {
+        button(
+            column![
+                text(fl!("alarm")).size(MEDIUM_TEXT),
+                text(fl!("or-press-spacebar")).size(SMALL_TEXT),
+            ]
+            .align_x(Alignment::Center),
+        )
+        .style(red_button)
+    } else {
+        button(
+            column![
+                text(fl!("hold-to-test")).size(MEDIUM_TEXT),
+                text(fl!("or-hold-spacebar")).size(SMALL_TEXT),
+            ]
+            .align_x(Alignment::Center),
+        )
+        .style(blue_button)
+    }
+    .width(Length::Fill)
+    .on_press(Message::NoAction);
+
+    // Alarm zone: container with padding so the button doesn't fill edge-to-edge.
+    // mouse_area always binds press/release — the feature is always interactive
+    // when enabled; state-specific behaviour is in the update() handler.
+    let alarm_zone = mouse_area(
+        container(alarm_btn)
+            .style(light_gray_container)
+            .padding(Padding::from([PADDING * 3.0, PADDING * 3.0]))
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .align_x(Horizontal::Center)
+            .align_y(Vertical::Center),
+    )
+    .on_press(Message::AlarmPressed)
+    .on_release(Message::AlarmReleased);
+
+    if track_fouls_and_warnings {
+        // Split the lower area: alarm left, warnings right
+        let warnings_zone = button(
+            column![
+                text(fl!("warnings"))
+                    .align_y(Vertical::Top)
+                    .align_x(Horizontal::Center)
+                    .width(Length::Fill),
+                row(snapshot.warnings.iter().map(|(color, warns)| column(
+                    warns
+                        .iter()
+                        .rev()
+                        .take(10)
+                        .map(|warning| make_warning_container(warning, Some(color)).into())
+                )
+                .spacing(1)
+                .width(Length::Fill)
+                .height(Length::Fill)
+                .into()))
+                .spacing(SPACING),
+            ]
+            .spacing(0)
+            .width(Length::Fill)
+            .height(Length::Fill),
+        )
+        .width(Length::Fill)
+        .height(Length::Fill)
+        .style(light_gray_button)
+        .on_press(Message::ShowWarnings);
+
+        center_col = center_col.push(
+            row![alarm_zone, warnings_zone]
+                .spacing(SPACING)
+                .height(Length::Fill),
+        );
+    } else {
+        center_col = center_col.push(alarm_zone);
+    }
+} else {
+    // Original behavior: game info area + optional warnings panel
+    center_col = center_col.push(if max_num_warns < 4 {
+        button(
+            text(config_string(
+                snapshot,
+                game_config,
+                using_uwhportal,
+                schedule,
+                teams,
+            ))
+            .size(SMALL_TEXT)
+            .align_y(Vertical::Center)
+            .align_x(Horizontal::Left),
+        )
+        .padding(PADDING)
+        .style(light_gray_button)
+        .height(Length::FillPortion(2))
+        .width(Length::Fill)
+        .on_press(Message::ShowGameDetails)
+    } else {
+        button(
+            text(config_string_game_num(snapshot, using_uwhportal, schedule.map(|s| &s.games)).0)
+                .size(SMALL_TEXT)
+                .align_y(Vertical::Center)
+                .align_x(Horizontal::Left),
+        )
+        .padding(PADDING)
+        .style(light_gray_button)
+        .width(Length::Fill)
+        .on_press(Message::ShowGameDetails)
+    });
+
+    if track_fouls_and_warnings {
+        center_col = center_col.push(
+            button(
+                column![
+                    text(fl!("warnings"))
+                        .align_y(Vertical::Top)
+                        .align_x(Horizontal::Center)
+                        .width(Length::Fill),
+                    row(snapshot.warnings.iter().map(|(color, warns)| column(
+                        warns
+                            .iter()
+                            .rev()
+                            .take(10)
+                            .map(|warning| make_warning_container(warning, Some(color)).into())
+                    )
+                    .spacing(1)
+                    .width(Length::Fill)
+                    .height(Length::Fill)
+                    .into()))
+                    .spacing(SPACING),
+                ]
+                .spacing(0)
+                .width(Length::Fill)
+                .height(Length::Fill),
+            )
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .on_press(Message::NoAction)
+            .style(light_gray_button)
+            .on_press(Message::ShowWarnings),
+        )
+    }
+}
+```
+
+- [ ] **Step 4: Verify compilation**
+
+```bash
+cargo check -p refbox
+```
+
+Expected: one error — the call site in `app/mod.rs` does not yet pass the new parameter. Fix that in the next task.
+
+---
+
+### Task 8: Pass `manual_alarm_enabled` at the call site
+
+**Files:**
+- Modify: `refbox/src/app/mod.rs`
+
+- [ ] **Step 1: Update the `build_main_view` call**
+
+Find the call to `build_main_view` at around line 2171:
+
+```rust
+build_main_view(
+    data,
+    game_config,
+    self.using_uwhportal,
+    self.schedule.as_ref(),
+    self.config.track_fouls_and_warnings,
+)
+```
+
+Add the new argument:
+
+```rust
+build_main_view(
+    data,
+    game_config,
+    self.using_uwhportal,
+    self.schedule.as_ref(),
+    self.config.track_fouls_and_warnings,
+    self.config.sound.sound_enabled && self.config.sound.manual_alarm_enabled,
+)
+```
+
+- [ ] **Step 2: Full compilation check**
+
+```bash
+cargo check -p refbox
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Run all tests**
+
+```bash
+just test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Run full validation**
+
+```bash
+just check
+```
+
+Expected: formatting clean, linter clean, tests pass, audit clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add refbox/src/app/view_builders/main_view.rs refbox/src/app/mod.rs
+git commit -m "feat(refbox): add manual alarm button to main view with spacebar support"
+```
+
+---
+
+## Manual Verification Checklist
+
+After `just check` passes, verify the following by running the app (`cargo run -p refbox` or the simulator):
+
+1. **Default state:** Open Sound settings — "ALARM BUTTON" toggle is present, shows "OFF", is greyed out if Sound is disabled.
+2. **Enable the feature:** Turn on Sound + Alarm Button. Return to main screen — game info area is replaced by "GAME INFO" + alarm zone.
+3. **GAME INFO button:** Tapping it opens the game details screen.
+4. **During live play (no timeout):** Alarm button is **red**, shows "Alarm / Or press Spacebar". Hold button (or spacebar) for 250ms → buzzer fires and continues while held. Release before 250ms → nothing fires. Release while playing → current tone finishes, then silence.
+5. **During a timeout in a play period:** Alarm button is **blue**, shows "Hold to Test / Or hold Spacebar". Hold button (or spacebar) for 1 second → buzzer fires and continues while held. Release before 1 second → nothing fires.
+6. **During Between Games:** Alarm button is **blue**, shows "Hold to Test / Or hold Spacebar". Same 1-second hold behaviour as item 5.
+7. **During Half Time / Pre-Overtime / Overtime Half Time / Pre-Sudden Death:** Alarm button is **blue**, shows "Hold to Test / Or hold Spacebar". Same 1-second hold behaviour as items 5 and 6.
+8. **Fouls & Warnings ON:** The lower area splits — alarm on the left, warnings panel on the right. Both work as expected.
+9. **Fouls & Warnings OFF:** Alarm zone takes full width.
+10. **Feature disabled:** Turn off Alarm Button in settings — main screen reverts to original game info layout with no alarm button.
+11. **On other screens:** Pressing spacebar on the configuration, penalties, or score edit screen does nothing.

--- a/docs/superpowers/plans/2026-04-17-manual-alarm-uniform-hold-delta.md
+++ b/docs/superpowers/plans/2026-04-17-manual-alarm-uniform-hold-delta.md
@@ -1,0 +1,315 @@
+# Manual Alarm — Uniform Hold Model (Delta Plan)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring the already-merged manual alarm button code into alignment with the approved uniform-hold design. See `docs/superpowers/specs/2026-04-14-manual-alarm-button-design.md` for the canonical design; see `refbox/tests/features/manual_alarm.feature` for the full scenario coverage.
+
+**Why this plan exists:** The manual alarm feature was implemented on branch `feat/refbox/manual-alarm-button` and merged into the current workspace. The original plan (`2026-04-14-manual-alarm-button.md`) encoded a mixed model (tap during active play; 1-second hold only during Between Games; disabled in other states). A subsequent design review replaced that with a **uniform hold model**: every press schedules a fire timer — 250ms during active play with no timeout, 1 second everywhere else. The button is never greyed out while the feature is enabled; colour (red/blue) and label ("Alarm" vs "Hold to Test") switch based on state.
+
+This plan is the targeted delta to get the code there.
+
+**Scope:** `refbox` crate only. Two files touch behaviour; one file updates the view.
+
+---
+
+## Summary of Behaviour Changes
+
+| Concern | Current code | Target design |
+|---|---|---|
+| Fire during active play (no timeout) | Immediate `start_manual_buzzer()` on press | Schedule 250ms delay → `start_manual_buzzer()` if still held |
+| Fire during Between Games | Schedule 1s delay → `start_manual_buzzer()` if still held | Unchanged |
+| Fire during Half Time / Pre-OT / OT Half / Pre-Sudden Death | Disabled / greyed — no fire | Schedule 1s delay → `start_manual_buzzer()` if still held |
+| Fire during a timeout in a play period | Disabled / greyed — no fire | Schedule 1s delay → `start_manual_buzzer()` if still held |
+| Button colour | Red in active play; blue in Between Games; greyed elsewhere | Red in active-play-no-timeout; blue everywhere else; never greyed |
+| Button label | "Alarm / Or press Spacebar" everywhere except Between Games (which shows "Hold to Test / Or hold Spacebar") | "Alarm / Or press Spacebar" in active-play-no-timeout; "Hold to Test / Or hold Spacebar" everywhere else |
+| Interactivity (mouse_area) | Wrapped conditionally — greyed states are non-interactive | Always wrapped — button is always interactive while the feature is enabled |
+| Pressed-state containers (`red_pressed_container`, `blue_pressed_container`) | Kept — visual feedback while held | Kept — logic needs to switch on `is_active_play` instead of `is_between_games` |
+| `start_manual_buzzer()` / `stop_manual_buzzer()` usage | Already in place | Unchanged — already correct |
+| Mouse-vs-spacebar independent hold tracking | Already in place | Unchanged — already correct |
+
+---
+
+## File Map
+
+| Action | File | What changes |
+|--------|------|-------------|
+| Modify | `refbox/src/app/mod.rs` | `AlarmPressed`, `SpacebarPressed`: always schedule a delay (duration depends on state, no immediate `start_manual_buzzer` branch). Drop the active-play-no-timeout fast path. Widen the state gate so all non-excluded states are eligible. |
+| Modify | `refbox/src/app/view_builders/main_view.rs` | Replace `is_between_games` with `is_active_play` for colour and label selection. Remove `alarm_available` / `disabled_container` path. Always wrap the alarm face in `mouse_area`. |
+| Verify | `refbox/tests/features/manual_alarm.feature` | No changes — the file already encodes the target design. Used to sanity-check behaviour after code changes. |
+
+---
+
+### Task 1: Unify the press handlers around a per-state delay
+
+**Files:**
+- Modify: `refbox/src/app/mod.rs`
+
+- [ ] **Step 1: Replace the `AlarmPressed` handler**
+
+In `refbox/src/app/mod.rs`, find the `Message::AlarmPressed` match arm (around line 2195). Replace its entire body with:
+
+```rust
+Message::AlarmPressed => {
+    // Mouse press on the alarm button.
+    // Uniform hold model: always schedule a delay; duration depends on game state.
+    if !(self.config.sound.sound_enabled && self.config.sound.manual_alarm_enabled) {
+        return Task::none();
+    }
+    if self.mouse_alarm_held {
+        return Task::none();
+    }
+    let was_active = self.spacebar_held;
+    self.mouse_alarm_held = true;
+    if was_active {
+        return Task::none();
+    }
+    let hold_duration = match (self.snapshot.current_period, self.snapshot.timeout) {
+        (
+            GamePeriod::FirstHalf
+            | GamePeriod::SecondHalf
+            | GamePeriod::OvertimeFirstHalf
+            | GamePeriod::OvertimeSecondHalf
+            | GamePeriod::SuddenDeath,
+            None,
+        ) => Duration::from_millis(250),
+        _ => Duration::from_secs(1),
+    };
+    self.alarm_delay_token += 1;
+    let token = self.alarm_delay_token;
+    info!("Manual alarm delay started (mouse), duration={hold_duration:?}, token={token}");
+    Task::future(async move {
+        sleep(hold_duration).await;
+        Message::AlarmDelayElapsed(token)
+    })
+}
+```
+
+Key differences from the current code:
+- No immediate `start_manual_buzzer()` branch — every press goes through `AlarmDelayElapsed`.
+- No early return when in a "disabled" state — every state that isn't fully blocked (i.e. feature enabled) schedules a timer.
+- Hold duration: 250ms for active play with no timeout; 1 second otherwise.
+
+- [ ] **Step 2: Replace the `SpacebarPressed` handler**
+
+Mirror the change in `Message::SpacebarPressed` (around line 2241). Swap the roles of `mouse_alarm_held` and `spacebar_held`:
+
+```rust
+Message::SpacebarPressed => {
+    // Keyboard press — spacebar_held guards against OS key-repeat.
+    if !(self.config.sound.sound_enabled && self.config.sound.manual_alarm_enabled) {
+        return Task::none();
+    }
+    if self.spacebar_held {
+        return Task::none();
+    }
+    let was_active = self.mouse_alarm_held;
+    self.spacebar_held = true;
+    if was_active {
+        return Task::none();
+    }
+    let hold_duration = match (self.snapshot.current_period, self.snapshot.timeout) {
+        (
+            GamePeriod::FirstHalf
+            | GamePeriod::SecondHalf
+            | GamePeriod::OvertimeFirstHalf
+            | GamePeriod::OvertimeSecondHalf
+            | GamePeriod::SuddenDeath,
+            None,
+        ) => Duration::from_millis(250),
+        _ => Duration::from_secs(1),
+    };
+    self.alarm_delay_token += 1;
+    let token = self.alarm_delay_token;
+    info!("Manual alarm delay started (spacebar), duration={hold_duration:?}, token={token}");
+    Task::future(async move {
+        sleep(hold_duration).await;
+        Message::AlarmDelayElapsed(token)
+    })
+}
+```
+
+- [ ] **Step 3: Leave `AlarmReleased`, `SpacebarReleased`, and `AlarmDelayElapsed` unchanged**
+
+The existing implementations are correct under the new model:
+- `AlarmReleased` and `SpacebarReleased` stop the manual buzzer when no other input is held — this gives the "let current tone finish naturally" behaviour via `stop_manual_buzzer()`.
+- `AlarmDelayElapsed` fires only if the token matches and at least one input is still held — this handles early-release cancellation.
+
+No edits needed.
+
+- [ ] **Step 4: Consider factoring the hold-duration match**
+
+The same match block now appears in both handlers. Extract a helper (private method on `RefBoxApp`) to avoid duplication:
+
+```rust
+fn manual_alarm_hold_duration(&self) -> Duration {
+    match (self.snapshot.current_period, self.snapshot.timeout) {
+        (
+            GamePeriod::FirstHalf
+            | GamePeriod::SecondHalf
+            | GamePeriod::OvertimeFirstHalf
+            | GamePeriod::OvertimeSecondHalf
+            | GamePeriod::SuddenDeath,
+            None,
+        ) => Duration::from_millis(250),
+        _ => Duration::from_secs(1),
+    }
+}
+```
+
+Use the helper in both press handlers. Optional but recommended for clarity.
+
+- [ ] **Step 5: Verify compilation and tests**
+
+```bash
+cargo check -p refbox
+just test
+```
+
+Expected: no errors; all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add refbox/src/app/mod.rs
+git commit -m "feat(refbox): unify manual alarm press handlers under uniform hold model"
+```
+
+---
+
+### Task 2: Switch the view between red/blue on active-play state
+
+**Files:**
+- Modify: `refbox/src/app/view_builders/main_view.rs`
+
+- [ ] **Step 1: Replace `alarm_available` and `is_between_games` logic**
+
+Find the alarm zone block in `build_main_view` (currently around lines 121–187). Replace the `alarm_available` computation, the `is_between_games` variable, the label selection, the container style selection, and the conditional `mouse_area` wrap with:
+
+```rust
+// Red + tap prompt during active play with no timeout; blue + hold prompt everywhere else.
+// The button is always interactive while the feature is enabled.
+let is_active_play = matches!(
+    (snapshot.current_period, snapshot.timeout),
+    (
+        GamePeriod::FirstHalf
+            | GamePeriod::SecondHalf
+            | GamePeriod::OvertimeFirstHalf
+            | GamePeriod::OvertimeSecondHalf
+            | GamePeriod::SuddenDeath,
+        None,
+    )
+);
+let alarm_label = if is_active_play {
+    fl!("alarm")
+} else {
+    fl!("hold-to-test")
+};
+let spacebar_label = if is_active_play {
+    fl!("or-press-spacebar")
+} else {
+    fl!("or-hold-spacebar")
+};
+let alarm_face_container = container(
+    column![
+        text(alarm_label)
+            .size(SMALL_PLUS_TEXT)
+            .align_x(Horizontal::Center)
+            .width(Length::Fill),
+        text(spacebar_label)
+            .size(SMALL_TEXT)
+            .align_x(Horizontal::Center)
+            .width(Length::Fill),
+    ]
+    .align_x(Alignment::Center)
+    .width(Length::Fill),
+)
+.style(match (is_active_play, alarm_held) {
+    (true, true) => red_pressed_container,
+    (true, false) => red_container,
+    (false, true) => blue_pressed_container,
+    (false, false) => blue_container,
+})
+.padding(PADDING)
+.width(Length::Fill)
+.height(Length::Fill)
+.align_x(Horizontal::Center)
+.align_y(Vertical::Center);
+
+let alarm_face: Element<'a, Message> = mouse_area(alarm_face_container)
+    .on_press(Message::AlarmPressed)
+    .on_release(Message::AlarmReleased)
+    .into();
+```
+
+Key differences from the current code:
+- Replaces `is_between_games` with `is_active_play` as the state predicate.
+- Removes `alarm_available` entirely — button is always interactive.
+- Removes the `disabled_container` branch — it is no longer reachable.
+- Always wraps the face in `mouse_area` (no conditional).
+
+- [ ] **Step 2: Remove unused imports**
+
+If `disabled_container` is no longer used anywhere in this file after Step 1, remove it from the imports at the top of `main_view.rs`. Check with:
+
+```bash
+grep -n disabled_container refbox/src/app/view_builders/main_view.rs
+```
+
+Expected: no matches after the change. If so, drop the import. If `disabled_container` is still used for another widget in this file, leave the import alone.
+
+- [ ] **Step 3: Verify compilation**
+
+```bash
+cargo check -p refbox
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Run all tests**
+
+```bash
+just test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add refbox/src/app/view_builders/main_view.rs
+git commit -m "feat(refbox): switch alarm button colour on active-play state, not BetweenGames"
+```
+
+---
+
+### Task 3: Full validation pass
+
+**Files:** None — verification only.
+
+- [ ] **Step 1: Run full workspace check**
+
+```bash
+just check
+```
+
+Expected: formatting clean, linter clean, tests pass, audit clean.
+
+- [ ] **Step 2: Manual verification**
+
+Run the refbox app (or simulator) and walk through the Manual Verification Checklist at the bottom of `docs/superpowers/plans/2026-04-14-manual-alarm-button.md`. All 11 items should pass.
+
+Particular attention:
+- Item 4 (active play, no timeout): a brief tap under 250ms does not fire; a deliberate hold past 250ms fires and continues.
+- Items 5, 6, 7 (all non-active-play states): button is blue with "Hold to Test / Or hold Spacebar"; 1-second hold fires; short press does not.
+- Items 8, 9 (layout): fouls/warnings split and full-width layouts still work.
+
+- [ ] **Step 3: Commit the combined change notes in the PR body, not in a separate commit**
+
+No separate commit for Task 3 — its work product is the verification pass itself, captured in the PR description.
+
+---
+
+## Follow-ups Not in Scope
+
+- The plan at `docs/superpowers/plans/2026-04-14-manual-alarm-button.md` has been updated to reflect the new design (Tasks 1–8 now describe the target state). That plan is now mostly a record of the feature's design; this delta plan is what should actually be executed.
+- If further refinements are needed (for example, tuning the 250ms threshold after real tournament use), track them separately — the constant is localised to `manual_alarm_hold_duration()` and can be adjusted without further structural change.

--- a/docs/superpowers/specs/2026-04-14-manual-alarm-button-design.md
+++ b/docs/superpowers/specs/2026-04-14-manual-alarm-button-design.md
@@ -69,12 +69,12 @@ The minimum hold duration differs by state:
 
 | Game state | Minimum hold | Behavior |
 |---|---|---|
-| First Half, Second Half, Overtime halves, Sudden Death — clock running, no timeout | **250ms** | Hold button (or spacebar) for at least 250ms → alarm fires and continues while held |
+| First Half, Second Half, Overtime halves, Sudden Death — clock running, no timeout | **150ms** | Hold button (or spacebar) for at least 150ms → alarm fires and continues while held |
 | Any of the above — timeout active | **1 second** | Hold button (or spacebar) for at least 1 second → alarm fires and continues while held |
 | Between Games, Half Time, Pre-Overtime, Overtime Half Time, Pre-Sudden Death | **1 second** | Hold button (or spacebar) for at least 1 second → alarm fires and continues while held |
 | Any other screen (config, penalties, score edit, etc.) | — | Spacebar has no effect |
 
-The 250ms active-play minimum is a debounce to reject stray/accidental taps. 250ms still feels
+The 150ms active-play minimum is a debounce to reject stray/accidental taps. 150ms still feels
 like a normal button press to an operator deliberately pressing it; it is not a "long press".
 The value is a single constant and can be tuned based on real-world use.
 
@@ -117,7 +117,7 @@ value).
 - Track `alarm_hold_generation: u32` to cancel stale hold timers without needing task
   cancellation
 - On `AlarmPressed`:
-  - Determine minimum hold duration from current state: 250ms for active play with no timeout,
+  - Determine minimum hold duration from current state: 150ms for active play with no timeout,
     1000ms for everything else (break periods or timeouts in play periods)
   - Increment generation, spawn `Task::future(sleep(duration))` returning
     `Message::AlarmFired(generation)`

--- a/docs/superpowers/specs/2026-04-14-manual-alarm-button-design.md
+++ b/docs/superpowers/specs/2026-04-14-manual-alarm-button-design.md
@@ -1,0 +1,171 @@
+# Manual Alarm Button — Design Spec
+
+**Date:** 2026-04-14
+**Scope:** `refbox` crate only
+**Branch type:** `feat/refbox/`
+
+---
+
+## Overview
+
+Add an on-screen alarm button and spacebar shortcut that allows the referee operator to manually
+trigger the buzzer sound. The feature is opt-in via the Sound settings page and is only active
+during specific game states.
+
+---
+
+## Main Screen Layout
+
+When the feature is enabled, the center column of the main game screen changes:
+
+**Before (current):**
+- Game clock
+- Context buttons (Start Now / Foul / Warning)
+- Large game info area (team names, game number, court)
+
+**After (with feature enabled):**
+- Game clock
+- Context buttons (Start Now, or Foul + Warning side-by-side) — **unchanged from today**
+- Compact **"GAME INFO"** button — same gray color scheme and border as the current info area;
+  tapping it opens the game details screen (same as tapping the info area today)
+- Lower area filling remaining space — layout depends on fouls & warnings tracking mode:
+
+  **Fouls & warnings tracking OFF:**
+  - Single gray bordered container, full width. The **"Alarm"** button is centered inside at
+    ~75% of the container width. Button label: "Alarm" (large), "Or Press Spacebar" (smaller,
+    below).
+
+  **Fouls & warnings tracking ON:**
+  - The lower area splits vertically into two equal halves:
+    - **Left half:** gray bordered container with the Alarm button centered inside (same
+      proportions and padding as the full-width version)
+    - **Right half:** the existing warnings summary panel (relocated here from its current
+      position below the game info area)
+
+When the feature is disabled, the main screen is unchanged from today.
+
+### Alarm button appearance
+
+The button has two visual states, both using colour schemes that already exist in the code:
+
+- **Active play, no timeout** (tap-to-fire): **red** colour scheme. Label: "Alarm" (large),
+  "Or press Spacebar" (smaller, below).
+- **All other states** (break periods and timeouts; hold-to-fire): **blue** colour scheme. Label:
+  "Hold to Test" (large), "Or hold Spacebar" (smaller, below).
+
+The button is never greyed out while the feature is enabled — it is always interactive, with the
+minimum hold duration determining whether a press fires the alarm.
+
+---
+
+## Alarm Behavior by Game State
+
+A uniform hold model applies across all game states: the button must be held for a minimum
+duration before the alarm fires. While held past that minimum, the alarm continues sounding. On
+release, no further tones are queued; the currently playing tone finishes its natural cycle,
+then the alarm stops.
+
+The minimum hold duration differs by state:
+
+| Game state | Minimum hold | Behavior |
+|---|---|---|
+| First Half, Second Half, Overtime halves, Sudden Death — clock running, no timeout | **250ms** | Hold button (or spacebar) for at least 250ms → alarm fires and continues while held |
+| Any of the above — timeout active | **1 second** | Hold button (or spacebar) for at least 1 second → alarm fires and continues while held |
+| Between Games, Half Time, Pre-Overtime, Overtime Half Time, Pre-Sudden Death | **1 second** | Hold button (or spacebar) for at least 1 second → alarm fires and continues while held |
+| Any other screen (config, penalties, score edit, etc.) | — | Spacebar has no effect |
+
+The 250ms active-play minimum is a debounce to reject stray/accidental taps. 250ms still feels
+like a normal button press to an operator deliberately pressing it; it is not a "long press".
+The value is a single constant and can be tuned based on real-world use.
+
+---
+
+## Settings Integration
+
+A new **"Alarm Button"** toggle is added to the Sound settings page (`ConfigPage::Sound`).
+
+**Placement:** New row below the existing three rows of sound settings, on the left column,
+above the Manage Remotes section. Matches the style of existing value buttons (label + On/Off
+value).
+
+**Dependencies:**
+- Greyed out (non-interactive) when Sound Enabled is Off — consistent with all other
+  sound-dependent toggles on this page.
+- Defaults to **Off**.
+
+**Effect:**
+- Off: main screen layout is unchanged; spacebar does nothing alarm-related.
+- On (and Sound Enabled On): main screen switches to the new layout; alarm is active per the
+  behavior table above.
+
+---
+
+## Implementation Touchpoints
+
+### New setting
+- Add `manual_alarm_enabled: bool` (default `false`) to `SoundSettings` in
+  `refbox/src/sound_controller/mod.rs`
+- Add migration support in `SoundSettings::migrate()`
+
+### New messages (`refbox/src/app/message.rs`)
+- `Message::AlarmPressed` — fired on button pointer-down or spacebar key-down
+- `Message::AlarmReleased` — fired on button pointer-up or spacebar key-up
+- `Message::AlarmFired` — the actual trigger; carries a generation counter to handle
+  the case where the user releases before the 1-second hold completes
+
+### App state (`refbox/src/app/mod.rs`)
+- Track `alarm_hold_generation: u32` to cancel stale hold timers without needing task
+  cancellation
+- On `AlarmPressed`:
+  - Determine minimum hold duration from current state: 250ms for active play with no timeout,
+    1000ms for everything else (break periods or timeouts in play periods)
+  - Increment generation, spawn `Task::future(sleep(duration))` returning
+    `Message::AlarmFired(generation)`
+  - Remember that the alarm is being held (so the release handler knows to stop the sound)
+- On `AlarmFired(gen)`: only start the alarm if `gen == alarm_hold_generation` (i.e. not
+  cancelled by an early release). Start the buzzer in a continuous mode so it keeps sounding
+  while the button is held.
+- On `AlarmReleased`:
+  - Increment generation (invalidates any pending hold timer that hasn't fired yet)
+  - If the alarm is currently sounding, stop queueing further tones but let the currently
+    playing tone finish its natural cycle
+
+### Keyboard subscription (`refbox/src/app/mod.rs`)
+- Extend `subscription()` to also subscribe to keyboard events
+- Map Space key-down → `Message::AlarmPressed`, Space key-up → `Message::AlarmReleased`
+- Only active when `manual_alarm_enabled && sound_enabled`
+
+### Main view (`refbox/src/app/view_builders/main_view.rs`)
+- When `manual_alarm_enabled && sound_enabled`:
+  - Replace the game info button with a stacked layout: GAME INFO button + alarm container
+  - Use `mouse_area` widget to capture pointer press and release on the alarm button
+    (iced's standard `button` only fires on release; press-down tracking requires `mouse_area`)
+  - Determine the button's colour scheme and label from the current game state:
+    - Active play with no timeout → red, "Alarm / Or press Spacebar"
+    - Any other state → blue, "Hold to Test / Or hold Spacebar"
+
+### Sound settings page (`refbox/src/app/view_builders/configuration.rs`)
+- Add a new row in `make_sound_config_page` with `BoolGameParameter::ManualAlarmEnabled`
+  in the left column
+- Grey it out when `!sound.sound_enabled`
+
+### New message variant (`refbox/src/app/message.rs`)
+- Add `BoolGameParameter::ManualAlarmEnabled`
+- Handle in `update()` to toggle `sound.manual_alarm_enabled`
+
+### Translations (`refbox/translations/`)
+- Required keys: `alarm-button` (settings label), `alarm` + `or-press-spacebar` (red-state
+  labels), `hold-to-test` + `or-hold-spacebar` (blue-state labels), `game-info` (GAME INFO
+  button label)
+- Add to every supported language file in `refbox/translations/` (not just English/Spanish/
+  French — the project currently supports ~13 languages)
+
+---
+
+## What Is Not Changing
+
+- The existing automatic buzzer (fires at end of game period) — unchanged
+- The wireless remote behaviour — unchanged
+- The wired button behaviour — unchanged
+- The Manage Remotes page — unchanged
+- All other screens and settings — unchanged

--- a/refbox/src/app/message.rs
+++ b/refbox/src/app/message.rs
@@ -112,7 +112,9 @@ pub enum Message {
     StartClock,
     AlarmPressed,
     AlarmReleased,
-    AlarmFired(u32),
+    SpacebarPressed,
+    SpacebarReleased,
+    AlarmDelayElapsed(u64),
     TimeUpdaterStarted(Sender<Arc<Mutex<TournamentManager>>>),
     NoAction,
 }
@@ -180,7 +182,9 @@ impl Message {
             | Self::StartClock
             | Self::AlarmPressed
             | Self::AlarmReleased
-            | Self::AlarmFired(_) => false,
+            | Self::SpacebarPressed
+            | Self::SpacebarReleased
+            | Self::AlarmDelayElapsed(_) => false,
         }
     }
 }
@@ -204,7 +208,10 @@ impl PartialEq for Message {
             | (Self::StartClock, Self::StartClock)
             | (Self::AlarmPressed, Self::AlarmPressed)
             | (Self::AlarmReleased, Self::AlarmReleased)
+            | (Self::SpacebarPressed, Self::SpacebarPressed)
+            | (Self::SpacebarReleased, Self::SpacebarReleased)
             | (Self::NoAction, Self::NoAction) => true,
+            (Self::AlarmDelayElapsed(a), Self::AlarmDelayElapsed(b)) => a == b,
 
             (Self::NewSnapshot(a), Self::NewSnapshot(b)) => a == b,
             (
@@ -306,7 +313,6 @@ impl PartialEq for Message {
             (Self::ParameterSelected(a, b), Self::ParameterSelected(c, d)) => a == c && b == d,
             (Self::ToggleBoolParameter(a), Self::ToggleBoolParameter(b)) => a == b,
             (Self::CycleParameter(a), Self::CycleParameter(b)) => a == b,
-            (Self::AlarmFired(a), Self::AlarmFired(b)) => a == b,
             (Self::GotRemoteId(a), Self::GotRemoteId(b)) => a == b,
             (Self::DeleteRemote(a), Self::DeleteRemote(b)) => a == b,
             (Self::ConfirmationSelected(a), Self::ConfirmationSelected(b)) => a == b,
@@ -377,7 +383,9 @@ impl PartialEq for Message {
             | (Self::StartClock, _)
             | (Self::AlarmPressed, _)
             | (Self::AlarmReleased, _)
-            | (Self::AlarmFired(_), _)
+            | (Self::SpacebarPressed, _)
+            | (Self::SpacebarReleased, _)
+            | (Self::AlarmDelayElapsed(_), _)
             | (Self::TimeUpdaterStarted(_), _)
             | (Self::NoAction, _) => false,
         }

--- a/refbox/src/app/message.rs
+++ b/refbox/src/app/message.rs
@@ -110,6 +110,9 @@ pub enum Message {
     RecvTokenValid(bool),
     StopClock,
     StartClock,
+    AlarmPressed,
+    AlarmReleased,
+    AlarmFired(u32),
     TimeUpdaterStarted(Sender<Arc<Mutex<TournamentManager>>>),
     NoAction,
 }
@@ -174,7 +177,10 @@ impl Message {
             | Self::ScoreConfirmation { .. }
             | Self::AutoConfirmScores(_)
             | Self::StopClock
-            | Self::StartClock => false,
+            | Self::StartClock
+            | Self::AlarmPressed
+            | Self::AlarmReleased
+            | Self::AlarmFired(_) => false,
         }
     }
 }
@@ -196,6 +202,8 @@ impl PartialEq for Message {
             | (Self::EndTimeout, Self::EndTimeout)
             | (Self::StopClock, Self::StopClock)
             | (Self::StartClock, Self::StartClock)
+            | (Self::AlarmPressed, Self::AlarmPressed)
+            | (Self::AlarmReleased, Self::AlarmReleased)
             | (Self::NoAction, Self::NoAction) => true,
 
             (Self::NewSnapshot(a), Self::NewSnapshot(b)) => a == b,
@@ -298,6 +306,7 @@ impl PartialEq for Message {
             (Self::ParameterSelected(a, b), Self::ParameterSelected(c, d)) => a == c && b == d,
             (Self::ToggleBoolParameter(a), Self::ToggleBoolParameter(b)) => a == b,
             (Self::CycleParameter(a), Self::CycleParameter(b)) => a == b,
+            (Self::AlarmFired(a), Self::AlarmFired(b)) => a == b,
             (Self::GotRemoteId(a), Self::GotRemoteId(b)) => a == b,
             (Self::DeleteRemote(a), Self::DeleteRemote(b)) => a == b,
             (Self::ConfirmationSelected(a), Self::ConfirmationSelected(b)) => a == b,
@@ -366,6 +375,9 @@ impl PartialEq for Message {
             | (Self::RecvTokenValid(_), _)
             | (Self::StopClock, _)
             | (Self::StartClock, _)
+            | (Self::AlarmPressed, _)
+            | (Self::AlarmReleased, _)
+            | (Self::AlarmFired(_), _)
             | (Self::TimeUpdaterStarted(_), _)
             | (Self::NoAction, _) => false,
         }
@@ -418,6 +430,7 @@ pub enum BoolGameParameter {
     TeamWarning,
     TimeoutsCountedPerHalf,
     ConfirmScore,
+    ManualAlarmEnabled,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -566,7 +566,7 @@ impl RefBoxApp {
                 | GamePeriod::OvertimeSecondHalf
                 | GamePeriod::SuddenDeath,
                 None,
-            ) => Duration::from_millis(250),
+            ) => Duration::from_millis(150),
             _ => Duration::from_secs(1),
         }
     }
@@ -2222,7 +2222,7 @@ impl RefBoxApp {
                 Task::none()
             }
             Message::AlarmDelayElapsed(token) => {
-                // Fires after the per-state hold delay (250ms in active play, 1s otherwise).
+                // Fires after the per-state hold delay (150ms in active play, 1s otherwise).
                 // Only start the sound if the token still matches (no newer press has
                 // superseded this one) and at least one input is still held.
                 if token == self.alarm_delay_token && (self.mouse_alarm_held || self.spacebar_held)

--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -2218,6 +2218,7 @@ impl RefBoxApp {
                     self.using_uwhportal,
                     self.schedule.as_ref().map(|s| &s.games),
                     self.config.track_fouls_and_warnings,
+                    self.config.sound.sound_enabled && self.config.sound.manual_alarm_enabled,
                 )
             }
             AppState::TimeEdit(_, time, timeout_time) =>

--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -10,7 +10,9 @@ use futures_lite::Stream;
 use iced::{
     Element, Subscription, Task, Theme,
     application::Appearance,
+    event,
     keyboard::{self, Key, key::Named},
+    mouse,
     widget::column,
     window,
 };
@@ -23,7 +25,7 @@ use std::{
 };
 use tokio::{
     sync::mpsc,
-    time::{Duration, Instant, timeout_at},
+    time::{Duration, Instant, sleep, timeout_at},
 };
 use tokio_serial::SerialPortBuilder;
 use uwh_common::{
@@ -79,7 +81,9 @@ pub struct RefBoxApp {
     sound: SoundController,
     sim_child: Option<Child>,
     list_all_events: bool,
-    alarm_hold_generation: u32,
+    mouse_alarm_held: bool,
+    spacebar_held: bool,
+    alarm_delay_token: u64,
 }
 
 #[derive(Debug)]
@@ -536,7 +540,9 @@ impl RefBoxApp {
             sound,
             sim_child,
             list_all_events,
-            alarm_hold_generation: 0,
+            mouse_alarm_held: false,
+            spacebar_held: false,
+            alarm_delay_token: 0,
         };
 
         let task = Task::batch(vec![
@@ -2131,50 +2137,105 @@ impl RefBoxApp {
                 Task::none()
             }
             Message::AlarmPressed => {
-                if self.config.sound.sound_enabled && self.config.sound.manual_alarm_enabled {
-                    match (self.snapshot.current_period, self.snapshot.timeout) {
+                // Mouse press on the alarm button.
+                let alarm_condition = self.config.sound.sound_enabled
+                    && self.config.sound.manual_alarm_enabled
+                    && matches!(
+                        (self.snapshot.current_period, self.snapshot.timeout),
                         (
                             GamePeriod::FirstHalf
-                            | GamePeriod::SecondHalf
-                            | GamePeriod::OvertimeFirstHalf
-                            | GamePeriod::OvertimeSecondHalf
-                            | GamePeriod::SuddenDeath,
+                                | GamePeriod::SecondHalf
+                                | GamePeriod::OvertimeFirstHalf
+                                | GamePeriod::OvertimeSecondHalf
+                                | GamePeriod::SuddenDeath,
                             None,
-                        ) => {
-                            info!("Manual alarm triggered during active play");
-                            self.sound.trigger_buzzer();
-                        }
-                        (GamePeriod::BetweenGames, _) => {
-                            // wrapping_add: overflow would require ~4 billion presses per second, impossible.
-                            self.alarm_hold_generation = self.alarm_hold_generation.wrapping_add(1);
-                            let generation = self.alarm_hold_generation;
+                        ) | (GamePeriod::BetweenGames, _)
+                    );
+                if !self.mouse_alarm_held && alarm_condition {
+                    let was_active = self.spacebar_held;
+                    self.mouse_alarm_held = true;
+                    if !was_active {
+                        if self.snapshot.current_period == GamePeriod::BetweenGames {
+                            self.alarm_delay_token += 1;
+                            let token = self.alarm_delay_token;
+                            info!("Test alarm delay started (mouse), token={token}");
                             return Task::future(async move {
-                                tokio::time::sleep(Duration::from_secs(1)).await;
-                                Message::AlarmFired(generation)
+                                sleep(Duration::from_secs(1)).await;
+                                Message::AlarmDelayElapsed(token)
                             });
+                        } else {
+                            info!("Manual alarm started (mouse)");
+                            self.sound.start_manual_buzzer();
                         }
-                        _ => {} // no alarm during non-play breaks (HalfTime, PreOvertime, etc.)
                     }
                 }
                 Task::none()
             }
             Message::AlarmReleased => {
-                // Only cancel a pending delayed-fire if we are in BetweenGames,
-                // since that is the only period where an async task was started.
-                if self.snapshot.current_period == GamePeriod::BetweenGames {
-                    self.alarm_hold_generation = self.alarm_hold_generation.wrapping_add(1);
+                // Mouse release — stop alarm only when spacebar is also not held.
+                if self.mouse_alarm_held {
+                    self.mouse_alarm_held = false;
+                    if !self.spacebar_held {
+                        info!("Manual alarm released (mouse)");
+                        self.sound.stop_manual_buzzer();
+                    }
                 }
                 Task::none()
             }
-            Message::AlarmFired(generation) => {
-                if generation == self.alarm_hold_generation
-                    && self.snapshot.current_period == GamePeriod::BetweenGames
-                    && self.snapshot.timeout.is_none()
-                    && self.config.sound.sound_enabled
+            Message::SpacebarPressed => {
+                // Keyboard press — spacebar_held guards against OS key-repeat.
+                let alarm_condition = self.config.sound.sound_enabled
                     && self.config.sound.manual_alarm_enabled
+                    && matches!(
+                        (self.snapshot.current_period, self.snapshot.timeout),
+                        (
+                            GamePeriod::FirstHalf
+                                | GamePeriod::SecondHalf
+                                | GamePeriod::OvertimeFirstHalf
+                                | GamePeriod::OvertimeSecondHalf
+                                | GamePeriod::SuddenDeath,
+                            None,
+                        ) | (GamePeriod::BetweenGames, _)
+                    );
+                if !self.spacebar_held && alarm_condition {
+                    let was_active = self.mouse_alarm_held;
+                    self.spacebar_held = true;
+                    if !was_active {
+                        if self.snapshot.current_period == GamePeriod::BetweenGames {
+                            self.alarm_delay_token += 1;
+                            let token = self.alarm_delay_token;
+                            info!("Test alarm delay started (spacebar), token={token}");
+                            return Task::future(async move {
+                                sleep(Duration::from_secs(1)).await;
+                                Message::AlarmDelayElapsed(token)
+                            });
+                        } else {
+                            info!("Manual alarm started (spacebar)");
+                            self.sound.start_manual_buzzer();
+                        }
+                    }
+                }
+                Task::none()
+            }
+            Message::SpacebarReleased => {
+                // Keyboard release — stop alarm only when mouse is also not held.
+                if self.spacebar_held {
+                    self.spacebar_held = false;
+                    if !self.mouse_alarm_held {
+                        info!("Manual alarm released (spacebar)");
+                        self.sound.stop_manual_buzzer();
+                    }
+                }
+                Task::none()
+            }
+            Message::AlarmDelayElapsed(token) => {
+                // Fires 1 second after a BetweenGames press. Only start the sound if the
+                // token still matches (no newer press has superseded this one) and at least
+                // one input is still held.
+                if token == self.alarm_delay_token && (self.mouse_alarm_held || self.spacebar_held)
                 {
-                    info!("Manual alarm triggered after hold during BetweenGames");
-                    self.sound.trigger_buzzer();
+                    info!("Test alarm started after delay, token={token}");
+                    self.sound.start_manual_buzzer();
                 }
                 Task::none()
             }
@@ -2219,6 +2280,7 @@ impl RefBoxApp {
                     self.schedule.as_ref().map(|s| &s.games),
                     self.config.track_fouls_and_warnings,
                     self.config.sound.sound_enabled && self.config.sound.manual_alarm_enabled,
+                    self.mouse_alarm_held || self.spacebar_held,
                 )
             }
             AppState::TimeEdit(_, time, timeout_time) =>
@@ -2299,19 +2361,28 @@ impl RefBoxApp {
         if self.config.sound.sound_enabled && self.config.sound.manual_alarm_enabled {
             let key_press = keyboard::on_key_press(|key, _modifiers| {
                 if matches!(key, Key::Named(Named::Space)) {
-                    Some(Message::AlarmPressed)
+                    Some(Message::SpacebarPressed)
                 } else {
                     None
                 }
             });
             let key_release = keyboard::on_key_release(|key, _modifiers| {
                 if matches!(key, Key::Named(Named::Space)) {
-                    Some(Message::AlarmReleased)
+                    Some(Message::SpacebarReleased)
                 } else {
                     None
                 }
             });
-            Subscription::batch([time_sub, key_press, key_release])
+            // mouse_area.on_release only fires when the cursor is still over the widget.
+            // This global subscription catches the release anywhere in the window, so
+            // alarm_held never gets stuck true if the user moves the mouse away first.
+            let mouse_release = event::listen_with(|ev, _status, _window| match ev {
+                iced::Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)) => {
+                    Some(Message::AlarmReleased)
+                }
+                _ => None,
+            });
+            Subscription::batch([time_sub, key_press, key_release, mouse_release])
         } else {
             time_sub
         }

--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -7,7 +7,13 @@ use crate::{
     tournament_manager::{penalty::*, *},
 };
 use futures_lite::Stream;
-use iced::{Element, Subscription, Task, Theme, application::Appearance, widget::column, window};
+use iced::{
+    Element, Subscription, Task, Theme,
+    application::Appearance,
+    keyboard::{self, Key, key::Named},
+    widget::column,
+    window,
+};
 use log::*;
 use std::{
     cmp::min,
@@ -2287,7 +2293,27 @@ impl RefBoxApp {
     }
 
     pub(super) fn subscription(&self) -> Subscription<Message> {
-        Subscription::run(time_updater)
+        let time_sub = Subscription::run(time_updater);
+
+        if self.config.sound.sound_enabled && self.config.sound.manual_alarm_enabled {
+            let key_press = keyboard::on_key_press(|key, _modifiers| {
+                if matches!(key, Key::Named(Named::Space)) {
+                    Some(Message::AlarmPressed)
+                } else {
+                    None
+                }
+            });
+            let key_release = keyboard::on_key_release(|key, _modifiers| {
+                if matches!(key, Key::Named(Named::Space)) {
+                    Some(Message::AlarmReleased)
+                } else {
+                    None
+                }
+            });
+            Subscription::batch([time_sub, key_press, key_release])
+        } else {
+            time_sub
+        }
     }
 
     pub fn application_style(&self, _theme: &Theme) -> Appearance {

--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -2135,9 +2135,11 @@ impl RefBoxApp {
                             | GamePeriod::SuddenDeath,
                             None,
                         ) => {
+                            info!("Manual alarm triggered during active play");
                             self.sound.trigger_buzzer();
                         }
                         (GamePeriod::BetweenGames, _) => {
+                            // wrapping_add: overflow would require ~4 billion presses per second, impossible.
                             self.alarm_hold_generation = self.alarm_hold_generation.wrapping_add(1);
                             let generation = self.alarm_hold_generation;
                             return Task::future(async move {
@@ -2145,13 +2147,17 @@ impl RefBoxApp {
                                 Message::AlarmFired(generation)
                             });
                         }
-                        _ => {}
+                        _ => {} // no alarm during non-play breaks (HalfTime, PreOvertime, etc.)
                     }
                 }
                 Task::none()
             }
             Message::AlarmReleased => {
-                self.alarm_hold_generation = self.alarm_hold_generation.wrapping_add(1);
+                // Only cancel a pending delayed-fire if we are in BetweenGames,
+                // since that is the only period where an async task was started.
+                if self.snapshot.current_period == GamePeriod::BetweenGames {
+                    self.alarm_hold_generation = self.alarm_hold_generation.wrapping_add(1);
+                }
                 Task::none()
             }
             Message::AlarmFired(generation) => {
@@ -2161,6 +2167,7 @@ impl RefBoxApp {
                     && self.config.sound.sound_enabled
                     && self.config.sound.manual_alarm_enabled
                 {
+                    info!("Manual alarm triggered after hold during BetweenGames");
                     self.sound.trigger_buzzer();
                 }
                 Task::none()

--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -73,6 +73,7 @@ pub struct RefBoxApp {
     sound: SoundController,
     sim_child: Option<Child>,
     list_all_events: bool,
+    alarm_hold_generation: u32,
 }
 
 #[derive(Debug)]
@@ -529,6 +530,7 @@ impl RefBoxApp {
             sound,
             sim_child,
             list_all_events,
+            alarm_hold_generation: 0,
         };
 
         let task = Task::batch(vec![
@@ -1665,6 +1667,9 @@ impl RefBoxApp {
                             BoolGameParameter::ConfirmScore => {
                                 edited_settings.confirm_score ^= true
                             }
+                            BoolGameParameter::ManualAlarmEnabled => {
+                                edited_settings.sound.manual_alarm_enabled ^= true
+                            }
                         }
                     }
                 };
@@ -2117,6 +2122,47 @@ impl RefBoxApp {
             Message::TimeUpdaterStarted(tx) => {
                 let tm = self.tm.clone();
                 tx.blocking_send(tm).unwrap();
+                Task::none()
+            }
+            Message::AlarmPressed => {
+                if self.config.sound.sound_enabled && self.config.sound.manual_alarm_enabled {
+                    match (self.snapshot.current_period, self.snapshot.timeout) {
+                        (
+                            GamePeriod::FirstHalf
+                            | GamePeriod::SecondHalf
+                            | GamePeriod::OvertimeFirstHalf
+                            | GamePeriod::OvertimeSecondHalf
+                            | GamePeriod::SuddenDeath,
+                            None,
+                        ) => {
+                            self.sound.trigger_buzzer();
+                        }
+                        (GamePeriod::BetweenGames, _) => {
+                            self.alarm_hold_generation = self.alarm_hold_generation.wrapping_add(1);
+                            let generation = self.alarm_hold_generation;
+                            return Task::future(async move {
+                                tokio::time::sleep(Duration::from_secs(1)).await;
+                                Message::AlarmFired(generation)
+                            });
+                        }
+                        _ => {}
+                    }
+                }
+                Task::none()
+            }
+            Message::AlarmReleased => {
+                self.alarm_hold_generation = self.alarm_hold_generation.wrapping_add(1);
+                Task::none()
+            }
+            Message::AlarmFired(generation) => {
+                if generation == self.alarm_hold_generation
+                    && self.snapshot.current_period == GamePeriod::BetweenGames
+                    && self.snapshot.timeout.is_none()
+                    && self.config.sound.sound_enabled
+                    && self.config.sound.manual_alarm_enabled
+                {
+                    self.sound.trigger_buzzer();
+                }
                 Task::none()
             }
             Message::NoAction => Task::none(),

--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -557,6 +557,20 @@ impl RefBoxApp {
         (new, task)
     }
 
+    fn manual_alarm_hold_duration(&self) -> Duration {
+        match (self.snapshot.current_period, self.snapshot.timeout) {
+            (
+                GamePeriod::FirstHalf
+                | GamePeriod::SecondHalf
+                | GamePeriod::OvertimeFirstHalf
+                | GamePeriod::OvertimeSecondHalf
+                | GamePeriod::SuddenDeath,
+                None,
+            ) => Duration::from_millis(250),
+            _ => Duration::from_secs(1),
+        }
+    }
+
     pub(super) fn update(&mut self, message: Message) -> Task<Message> {
         trace!("Handling message: {message:?}");
 
@@ -2138,38 +2152,28 @@ impl RefBoxApp {
             }
             Message::AlarmPressed => {
                 // Mouse press on the alarm button.
-                let alarm_condition = self.config.sound.sound_enabled
-                    && self.config.sound.manual_alarm_enabled
-                    && matches!(
-                        (self.snapshot.current_period, self.snapshot.timeout),
-                        (
-                            GamePeriod::FirstHalf
-                                | GamePeriod::SecondHalf
-                                | GamePeriod::OvertimeFirstHalf
-                                | GamePeriod::OvertimeSecondHalf
-                                | GamePeriod::SuddenDeath,
-                            None,
-                        ) | (GamePeriod::BetweenGames, _)
-                    );
-                if !self.mouse_alarm_held && alarm_condition {
-                    let was_active = self.spacebar_held;
-                    self.mouse_alarm_held = true;
-                    if !was_active {
-                        if self.snapshot.current_period == GamePeriod::BetweenGames {
-                            self.alarm_delay_token += 1;
-                            let token = self.alarm_delay_token;
-                            info!("Test alarm delay started (mouse), token={token}");
-                            return Task::future(async move {
-                                sleep(Duration::from_secs(1)).await;
-                                Message::AlarmDelayElapsed(token)
-                            });
-                        } else {
-                            info!("Manual alarm started (mouse)");
-                            self.sound.start_manual_buzzer();
-                        }
-                    }
+                // Uniform hold model: always schedule a delay; duration depends on game state.
+                if !(self.config.sound.sound_enabled && self.config.sound.manual_alarm_enabled) {
+                    return Task::none();
                 }
-                Task::none()
+                if self.mouse_alarm_held {
+                    return Task::none();
+                }
+                let was_active = self.spacebar_held;
+                self.mouse_alarm_held = true;
+                if was_active {
+                    return Task::none();
+                }
+                let hold_duration = self.manual_alarm_hold_duration();
+                self.alarm_delay_token += 1;
+                let token = self.alarm_delay_token;
+                info!(
+                    "Manual alarm delay started (mouse), duration={hold_duration:?}, token={token}"
+                );
+                Task::future(async move {
+                    sleep(hold_duration).await;
+                    Message::AlarmDelayElapsed(token)
+                })
             }
             Message::AlarmReleased => {
                 // Mouse release — stop alarm only when spacebar is also not held.
@@ -2184,38 +2188,27 @@ impl RefBoxApp {
             }
             Message::SpacebarPressed => {
                 // Keyboard press — spacebar_held guards against OS key-repeat.
-                let alarm_condition = self.config.sound.sound_enabled
-                    && self.config.sound.manual_alarm_enabled
-                    && matches!(
-                        (self.snapshot.current_period, self.snapshot.timeout),
-                        (
-                            GamePeriod::FirstHalf
-                                | GamePeriod::SecondHalf
-                                | GamePeriod::OvertimeFirstHalf
-                                | GamePeriod::OvertimeSecondHalf
-                                | GamePeriod::SuddenDeath,
-                            None,
-                        ) | (GamePeriod::BetweenGames, _)
-                    );
-                if !self.spacebar_held && alarm_condition {
-                    let was_active = self.mouse_alarm_held;
-                    self.spacebar_held = true;
-                    if !was_active {
-                        if self.snapshot.current_period == GamePeriod::BetweenGames {
-                            self.alarm_delay_token += 1;
-                            let token = self.alarm_delay_token;
-                            info!("Test alarm delay started (spacebar), token={token}");
-                            return Task::future(async move {
-                                sleep(Duration::from_secs(1)).await;
-                                Message::AlarmDelayElapsed(token)
-                            });
-                        } else {
-                            info!("Manual alarm started (spacebar)");
-                            self.sound.start_manual_buzzer();
-                        }
-                    }
+                if !(self.config.sound.sound_enabled && self.config.sound.manual_alarm_enabled) {
+                    return Task::none();
                 }
-                Task::none()
+                if self.spacebar_held {
+                    return Task::none();
+                }
+                let was_active = self.mouse_alarm_held;
+                self.spacebar_held = true;
+                if was_active {
+                    return Task::none();
+                }
+                let hold_duration = self.manual_alarm_hold_duration();
+                self.alarm_delay_token += 1;
+                let token = self.alarm_delay_token;
+                info!(
+                    "Manual alarm delay started (spacebar), duration={hold_duration:?}, token={token}"
+                );
+                Task::future(async move {
+                    sleep(hold_duration).await;
+                    Message::AlarmDelayElapsed(token)
+                })
             }
             Message::SpacebarReleased => {
                 // Keyboard release — stop alarm only when mouse is also not held.
@@ -2229,12 +2222,12 @@ impl RefBoxApp {
                 Task::none()
             }
             Message::AlarmDelayElapsed(token) => {
-                // Fires 1 second after a BetweenGames press. Only start the sound if the
-                // token still matches (no newer press has superseded this one) and at least
-                // one input is still held.
+                // Fires after the per-state hold delay (250ms in active play, 1s otherwise).
+                // Only start the sound if the token still matches (no newer press has
+                // superseded this one) and at least one input is still held.
                 if token == self.alarm_delay_token && (self.mouse_alarm_held || self.spacebar_held)
                 {
-                    info!("Test alarm started after delay, token={token}");
+                    info!("Manual alarm started after delay, token={token}");
                     self.sound.start_manual_buzzer();
                 }
                 Task::none()

--- a/refbox/src/app/theme/container.rs
+++ b/refbox/src/app/theme/container.rs
@@ -1,6 +1,6 @@
 use super::{
-    BLACK, BLUE, BORDER_COLOR, BORDER_RADIUS, BORDER_WIDTH, DISABLED_COLOR, GRAY, GREEN,
-    LIGHT_GRAY, RED, WHITE, WINDOW_BACKGROUND,
+    BLACK, BLUE, BLUE_PRESSED, BORDER_COLOR, BORDER_RADIUS, BORDER_WIDTH, DISABLED_COLOR, GRAY,
+    GREEN, LIGHT_GRAY, RED, RED_PRESSED, WHITE, WINDOW_BACKGROUND,
 };
 use iced::{Background, Border, Theme, widget::container::Style};
 
@@ -57,6 +57,21 @@ pub fn green_container(theme: &Theme) -> Style {
 pub fn red_container(theme: &Theme) -> Style {
     Style {
         background: Some(Background::Color(RED)),
+        ..gray_container(theme)
+    }
+}
+
+pub fn red_pressed_container(theme: &Theme) -> Style {
+    Style {
+        background: Some(Background::Color(RED_PRESSED)),
+        ..gray_container(theme)
+    }
+}
+
+pub fn blue_pressed_container(theme: &Theme) -> Style {
+    Style {
+        background: Some(Background::Color(BLUE_PRESSED)),
+        text_color: Some(WHITE),
         ..gray_container(theme)
     }
 }

--- a/refbox/src/app/theme/mod.rs
+++ b/refbox/src/app/theme/mod.rs
@@ -77,9 +77,9 @@ pub use button::{
 
 pub mod container;
 pub use container::{
-    black_container, blue_container, disabled_container, gray_container, green_container,
-    light_gray_container, red_container, scroll_bar_container, transparent_container,
-    white_container,
+    black_container, blue_container, blue_pressed_container, disabled_container, gray_container,
+    green_container, light_gray_container, red_container, red_pressed_container,
+    scroll_bar_container, transparent_container, white_container,
 };
 
 pub mod text;

--- a/refbox/src/app/view_builders/configuration.rs
+++ b/refbox/src/app/view_builders/configuration.rs
@@ -798,6 +798,19 @@ fn make_sound_config_page<'a>(
             )
         ]
         .spacing(SPACING),
+        row![make_value_button(
+            fl!("alarm-button"),
+            bool_string(sound.manual_alarm_enabled),
+            (false, true),
+            if sound.sound_enabled {
+                Some(Message::ToggleBoolParameter(
+                    BoolGameParameter::ManualAlarmEnabled,
+                ))
+            } else {
+                None
+            },
+        ),]
+        .spacing(SPACING),
         vertical_space(),
         row![
             horizontal_space(),

--- a/refbox/src/app/view_builders/configuration.rs
+++ b/refbox/src/app/view_builders/configuration.rs
@@ -798,18 +798,22 @@ fn make_sound_config_page<'a>(
             )
         ]
         .spacing(SPACING),
-        row![make_value_button(
-            fl!("alarm-button"),
-            bool_string(sound.manual_alarm_enabled),
-            (false, true),
-            if sound.sound_enabled {
-                Some(Message::ToggleBoolParameter(
-                    BoolGameParameter::ManualAlarmEnabled,
-                ))
-            } else {
-                None
-            },
-        ),]
+        row![
+            make_value_button(
+                fl!("alarm-button"),
+                bool_string(sound.manual_alarm_enabled),
+                (false, true),
+                if sound.sound_enabled {
+                    Some(Message::ToggleBoolParameter(
+                        BoolGameParameter::ManualAlarmEnabled,
+                    ))
+                } else {
+                    None
+                },
+            ),
+            horizontal_space(),
+            horizontal_space(),
+        ]
         .spacing(SPACING),
         vertical_space(),
         row![

--- a/refbox/src/app/view_builders/main_view.rs
+++ b/refbox/src/app/view_builders/main_view.rs
@@ -18,6 +18,7 @@ pub(in super::super) fn build_main_view<'a>(
     games: Option<&GameList>,
     track_fouls_and_warnings: bool,
     manual_alarm_enabled: bool,
+    alarm_held: bool,
 ) -> Element<'a, Message> {
     let ViewData {
         snapshot,
@@ -28,7 +29,10 @@ pub(in super::super) fn build_main_view<'a>(
 
     let time_button = make_game_time_button(snapshot, true, false, mode, clock_running);
 
-    let mut center_col = column![time_button].spacing(SPACING).width(Length::Fill);
+    let mut center_col = column![time_button]
+        .spacing(SPACING)
+        .width(Length::Fill)
+        .height(Length::Fill);
 
     let make_warn_button = || {
         make_button(fl!("add-warning"))
@@ -108,18 +112,10 @@ pub(in super::super) fn build_main_view<'a>(
         .unwrap();
 
     if manual_alarm_enabled {
-        // Compact GAME INFO button
         center_col = center_col.push(
-            button(
-                text(fl!("game-info"))
-                    .size(SMALL_TEXT)
-                    .align_y(Vertical::Center)
-                    .align_x(Horizontal::Center),
-            )
-            .padding(PADDING)
-            .style(light_gray_button)
-            .width(Length::Fill)
-            .on_press(Message::ShowGameDetails),
+            make_button(fl!("game-info"))
+                .style(light_gray_button)
+                .on_press(Message::ShowGameDetails),
         );
 
         // Determine whether alarm is interactive in the current state
@@ -135,39 +131,59 @@ pub(in super::super) fn build_main_view<'a>(
             ) | (GamePeriod::BetweenGames, _)
         );
 
-        // Build the alarm button (visual only — mouse_area handles press/release)
-        let mut alarm_btn = button(
+        // Build the alarm face. During BetweenGames: blue "Hold to Test" with a 1-second delay.
+        // During active play: red "Alarm" that fires immediately.
+        // mouse_area wraps only this inner face so only the button is interactive,
+        // not the surrounding light-gray padding zone.
+        let is_between_games = snapshot.current_period == GamePeriod::BetweenGames;
+        let alarm_label = if is_between_games {
+            fl!("hold-to-test")
+        } else {
+            fl!("alarm")
+        };
+        let spacebar_label = if is_between_games {
+            fl!("or-hold-spacebar")
+        } else {
+            fl!("or-press-spacebar")
+        };
+        let alarm_face_container = container(
             column![
-                text(fl!("alarm")).size(MEDIUM_TEXT),
-                text(fl!("or-press-spacebar")).size(SMALL_TEXT),
+                text(alarm_label)
+                    .size(SMALL_PLUS_TEXT)
+                    .align_x(Horizontal::Center)
+                    .width(Length::Fill),
+                text(spacebar_label)
+                    .size(SMALL_TEXT)
+                    .align_x(Horizontal::Center)
+                    .width(Length::Fill),
             ]
-            .align_x(Alignment::Center),
+            .align_x(Alignment::Center)
+            .width(Length::Fill),
         )
-        .style(red_button)
-        .width(Length::Fill);
+        .style(if !alarm_available {
+            disabled_container
+        } else if alarm_held && is_between_games {
+            blue_pressed_container
+        } else if alarm_held {
+            red_pressed_container
+        } else if is_between_games {
+            blue_container
+        } else {
+            red_container
+        })
+        .padding(PADDING)
+        .width(Length::Fill)
+        .height(Length::Fill)
+        .align_x(Horizontal::Center)
+        .align_y(Vertical::Center);
 
-        if alarm_available {
-            alarm_btn = alarm_btn.on_press(Message::NoAction);
-        }
-
-        // Alarm zone: padded container so the button doesn't fill edge-to-edge
-        let alarm_zone = {
-            let inner = container(alarm_btn)
-                .style(light_gray_container)
-                .padding([PADDING * 3.0, PADDING * 3.0])
-                .width(Length::Fill)
-                .height(Length::Fill)
-                .align_x(Horizontal::Center)
-                .align_y(Vertical::Center);
-
-            let area = mouse_area(inner);
-
-            if alarm_available {
-                area.on_press(Message::AlarmPressed)
-                    .on_release(Message::AlarmReleased)
-            } else {
-                area
-            }
+        let alarm_face: Element<'a, Message> = if alarm_available {
+            mouse_area(alarm_face_container)
+                .on_press(Message::AlarmPressed)
+                .on_release(Message::AlarmReleased)
+                .into()
+        } else {
+            alarm_face_container.into()
         };
 
         if track_fouls_and_warnings {
@@ -201,12 +217,12 @@ pub(in super::super) fn build_main_view<'a>(
             .on_press(Message::ShowWarnings);
 
             center_col = center_col.push(
-                row![alarm_zone, warnings_zone]
+                row![alarm_face, warnings_zone]
                     .spacing(SPACING)
                     .height(Length::Fill),
             );
         } else {
-            center_col = center_col.push(alarm_zone);
+            center_col = center_col.push(alarm_face);
         }
     } else {
         // Original behavior: game info area + optional warnings panel

--- a/refbox/src/app/view_builders/main_view.rs
+++ b/refbox/src/app/view_builders/main_view.rs
@@ -118,8 +118,9 @@ pub(in super::super) fn build_main_view<'a>(
                 .on_press(Message::ShowGameDetails),
         );
 
-        // Determine whether alarm is interactive in the current state
-        let alarm_available = matches!(
+        // Red + tap prompt during active play with no timeout; blue + hold prompt everywhere else.
+        // The button is always interactive while the feature is enabled.
+        let is_active_play = matches!(
             (snapshot.current_period, snapshot.timeout),
             (
                 GamePeriod::FirstHalf
@@ -128,23 +129,17 @@ pub(in super::super) fn build_main_view<'a>(
                     | GamePeriod::OvertimeSecondHalf
                     | GamePeriod::SuddenDeath,
                 None,
-            ) | (GamePeriod::BetweenGames, _)
+            )
         );
-
-        // Build the alarm face. During BetweenGames: blue "Hold to Test" with a 1-second delay.
-        // During active play: red "Alarm" that fires immediately.
-        // mouse_area wraps only this inner face so only the button is interactive,
-        // not the surrounding light-gray padding zone.
-        let is_between_games = snapshot.current_period == GamePeriod::BetweenGames;
-        let alarm_label = if is_between_games {
-            fl!("hold-to-test")
-        } else {
+        let alarm_label = if is_active_play {
             fl!("alarm")
-        };
-        let spacebar_label = if is_between_games {
-            fl!("or-hold-spacebar")
         } else {
+            fl!("hold-to-test")
+        };
+        let spacebar_label = if is_active_play {
             fl!("or-press-spacebar")
+        } else {
+            fl!("or-hold-spacebar")
         };
         let alarm_face_container = container(
             column![
@@ -160,16 +155,11 @@ pub(in super::super) fn build_main_view<'a>(
             .align_x(Alignment::Center)
             .width(Length::Fill),
         )
-        .style(if !alarm_available {
-            disabled_container
-        } else if alarm_held && is_between_games {
-            blue_pressed_container
-        } else if alarm_held {
-            red_pressed_container
-        } else if is_between_games {
-            blue_container
-        } else {
-            red_container
+        .style(match (is_active_play, alarm_held) {
+            (true, true) => red_pressed_container,
+            (true, false) => red_container,
+            (false, true) => blue_pressed_container,
+            (false, false) => blue_container,
         })
         .padding(PADDING)
         .width(Length::Fill)
@@ -177,14 +167,10 @@ pub(in super::super) fn build_main_view<'a>(
         .align_x(Horizontal::Center)
         .align_y(Vertical::Center);
 
-        let alarm_face: Element<'a, Message> = if alarm_available {
-            mouse_area(alarm_face_container)
-                .on_press(Message::AlarmPressed)
-                .on_release(Message::AlarmReleased)
-                .into()
-        } else {
-            alarm_face_container.into()
-        };
+        let alarm_face: Element<'a, Message> = mouse_area(alarm_face_container)
+            .on_press(Message::AlarmPressed)
+            .on_release(Message::AlarmReleased)
+            .into();
 
         if track_fouls_and_warnings {
             // Split the lower area: alarm left, warnings right

--- a/refbox/src/app/view_builders/main_view.rs
+++ b/refbox/src/app/view_builders/main_view.rs
@@ -2,7 +2,7 @@ use super::*;
 use iced::{
     Alignment, Element, Length,
     alignment::{Horizontal, Vertical},
-    widget::{Space, button, column, row, text},
+    widget::{Space, button, column, container, mouse_area, row, text},
 };
 use uwh_common::{
     color::Color as GameColor,
@@ -17,6 +17,7 @@ pub(in super::super) fn build_main_view<'a>(
     using_uwhportal: bool,
     games: Option<&GameList>,
     track_fouls_and_warnings: bool,
+    manual_alarm_enabled: bool,
 ) -> Element<'a, Message> {
     let ViewData {
         snapshot,
@@ -106,41 +107,73 @@ pub(in super::super) fn build_main_view<'a>(
         .max()
         .unwrap();
 
-    center_col = center_col.push(if max_num_warns < 4 {
-        button(
-            text(config_string(
-                snapshot,
-                game_config,
-                using_uwhportal,
-                games,
-                teams,
-                track_fouls_and_warnings,
-            ))
-            .size(SMALL_TEXT)
-            .align_y(Vertical::Center)
-            .align_x(Horizontal::Left),
-        )
-        .padding(PADDING)
-        .style(light_gray_button)
-        .height(Length::FillPortion(2))
-        .width(Length::Fill)
-        .on_press(Message::ShowGameDetails)
-    } else {
-        button(
-            text(config_string_game_num(snapshot, using_uwhportal, games).0)
-                .size(SMALL_TEXT)
-                .align_y(Vertical::Center)
-                .align_x(Horizontal::Left),
-        )
-        .padding(PADDING)
-        .style(light_gray_button)
-        .width(Length::Fill)
-        .on_press(Message::ShowGameDetails)
-    });
-
-    if track_fouls_and_warnings {
+    if manual_alarm_enabled {
+        // Compact GAME INFO button
         center_col = center_col.push(
             button(
+                text(fl!("game-info"))
+                    .size(SMALL_TEXT)
+                    .align_y(Vertical::Center)
+                    .align_x(Horizontal::Center),
+            )
+            .padding(PADDING)
+            .style(light_gray_button)
+            .width(Length::Fill)
+            .on_press(Message::ShowGameDetails),
+        );
+
+        // Determine whether alarm is interactive in the current state
+        let alarm_available = match (snapshot.current_period, snapshot.timeout) {
+            (
+                GamePeriod::FirstHalf
+                | GamePeriod::SecondHalf
+                | GamePeriod::OvertimeFirstHalf
+                | GamePeriod::OvertimeSecondHalf
+                | GamePeriod::SuddenDeath,
+                None,
+            ) => true,
+            (GamePeriod::BetweenGames, _) => true,
+            _ => false,
+        };
+
+        // Build the alarm button (visual only — mouse_area handles press/release)
+        let mut alarm_btn = button(
+            column![
+                text(fl!("alarm")).size(MEDIUM_TEXT),
+                text(fl!("or-press-spacebar")).size(SMALL_TEXT),
+            ]
+            .align_x(Alignment::Center),
+        )
+        .style(red_button)
+        .width(Length::Fill);
+
+        if alarm_available {
+            alarm_btn = alarm_btn.on_press(Message::NoAction);
+        }
+
+        // Alarm zone: padded container so the button doesn't fill edge-to-edge
+        let alarm_zone = {
+            let inner = container(alarm_btn)
+                .style(light_gray_container)
+                .padding([PADDING * 3.0, PADDING * 3.0])
+                .width(Length::Fill)
+                .height(Length::Fill)
+                .align_x(Horizontal::Center)
+                .align_y(Vertical::Center);
+
+            let area = mouse_area(inner);
+
+            if alarm_available {
+                area.on_press(Message::AlarmPressed)
+                    .on_release(Message::AlarmReleased)
+            } else {
+                area
+            }
+        };
+
+        if track_fouls_and_warnings {
+            // Split the lower area: alarm left, warnings right
+            let warnings_zone = button(
                 column![
                     text(fl!("warnings"))
                         .align_y(Vertical::Top)
@@ -165,10 +198,82 @@ pub(in super::super) fn build_main_view<'a>(
             )
             .width(Length::Fill)
             .height(Length::Fill)
-            .on_press(Message::NoAction)
             .style(light_gray_button)
-            .on_press(Message::ShowWarnings),
-        )
+            .on_press(Message::ShowWarnings);
+
+            center_col = center_col.push(
+                row![alarm_zone, warnings_zone]
+                    .spacing(SPACING)
+                    .height(Length::Fill),
+            );
+        } else {
+            center_col = center_col.push(alarm_zone);
+        }
+    } else {
+        // Original behavior: game info area + optional warnings panel
+        center_col = center_col.push(if max_num_warns < 4 {
+            button(
+                text(config_string(
+                    snapshot,
+                    game_config,
+                    using_uwhportal,
+                    games,
+                    teams,
+                    track_fouls_and_warnings,
+                ))
+                .size(SMALL_TEXT)
+                .align_y(Vertical::Center)
+                .align_x(Horizontal::Left),
+            )
+            .padding(PADDING)
+            .style(light_gray_button)
+            .height(Length::FillPortion(2))
+            .width(Length::Fill)
+            .on_press(Message::ShowGameDetails)
+        } else {
+            button(
+                text(config_string_game_num(snapshot, using_uwhportal, games).0)
+                    .size(SMALL_TEXT)
+                    .align_y(Vertical::Center)
+                    .align_x(Horizontal::Left),
+            )
+            .padding(PADDING)
+            .style(light_gray_button)
+            .width(Length::Fill)
+            .on_press(Message::ShowGameDetails)
+        });
+
+        if track_fouls_and_warnings {
+            center_col = center_col.push(
+                button(
+                    column![
+                        text(fl!("warnings"))
+                            .align_y(Vertical::Top)
+                            .align_x(Horizontal::Center)
+                            .width(Length::Fill),
+                        row(snapshot.warnings.iter().map(|(color, warns)| column(
+                            warns
+                                .iter()
+                                .rev()
+                                .take(10)
+                                .map(|warning| make_warning_container(warning, Some(color)).into())
+                        )
+                        .spacing(1)
+                        .width(Length::Fill)
+                        .height(Length::Fill)
+                        .into()))
+                        .spacing(SPACING),
+                    ]
+                    .spacing(0)
+                    .width(Length::Fill)
+                    .height(Length::Fill),
+                )
+                .width(Length::Fill)
+                .height(Length::Fill)
+                .style(light_gray_button)
+                .on_press(Message::ShowWarnings),
+            )
+        }
     }
 
     let make_penalty_button = |snapshot: &GameSnapshot, color: GameColor| {

--- a/refbox/src/app/view_builders/main_view.rs
+++ b/refbox/src/app/view_builders/main_view.rs
@@ -123,18 +123,17 @@ pub(in super::super) fn build_main_view<'a>(
         );
 
         // Determine whether alarm is interactive in the current state
-        let alarm_available = match (snapshot.current_period, snapshot.timeout) {
+        let alarm_available = matches!(
+            (snapshot.current_period, snapshot.timeout),
             (
                 GamePeriod::FirstHalf
-                | GamePeriod::SecondHalf
-                | GamePeriod::OvertimeFirstHalf
-                | GamePeriod::OvertimeSecondHalf
-                | GamePeriod::SuddenDeath,
+                    | GamePeriod::SecondHalf
+                    | GamePeriod::OvertimeFirstHalf
+                    | GamePeriod::OvertimeSecondHalf
+                    | GamePeriod::SuddenDeath,
                 None,
-            ) => true,
-            (GamePeriod::BetweenGames, _) => true,
-            _ => false,
-        };
+            ) | (GamePeriod::BetweenGames, _)
+        );
 
         // Build the alarm button (visual only — mouse_area handles press/release)
         let mut alarm_btn = button(

--- a/refbox/src/sound_controller/button_handler/mod.rs
+++ b/refbox/src/sound_controller/button_handler/mod.rs
@@ -20,6 +20,8 @@ impl From<u32> for RemoteId {
 pub(super) enum SoundMessage {
     TriggerBuzzer,
     TriggerWhistle,
+    StartManualBuzzer,
+    StopManualBuzzer,
     #[cfg(target_os = "linux")]
     StartWiredBuzzer,
     #[cfg(target_os = "linux")]

--- a/refbox/src/sound_controller/mod.rs
+++ b/refbox/src/sound_controller/mod.rs
@@ -227,6 +227,7 @@ pub struct RemoteInfo {
 enum SoundId {
     AutoBuzzer,
     Whistle,
+    ManualAlarm,
     #[cfg(target_os = "linux")]
     WiredButton,
     #[cfg(target_os = "linux")]
@@ -349,6 +350,18 @@ impl SoundController {
                                             sound_queue.push_back(SoundId::Whistle);
                                         }
                                     }
+                                    SoundMessage::StartManualBuzzer => {
+                                        if !sound_queue.contains(&SoundId::ManualAlarm) {
+                                            // Push to front so the manual alarm immediately
+                                            // takes priority over any queued auto-buzzer.
+                                            sound_queue.push_front(SoundId::ManualAlarm);
+                                        }
+                                    }
+                                    SoundMessage::StopManualBuzzer => {
+                                        if sound_queue.contains(&SoundId::ManualAlarm) {
+                                            sound_queue.retain(|s| *s != SoundId::ManualAlarm);
+                                        }
+                                    }
                                     #[cfg(target_os = "linux")]
                                     SoundMessage::StartWiredBuzzer => {
                                         if !sound_queue.contains(&SoundId::WiredButton) {
@@ -431,6 +444,20 @@ impl SoundController {
                                 volumes,
                                 library.whistle().clone(),
                                 false,
+                                false,
+                            )
+                        }
+                        SoundId::ManualAlarm => {
+                            info!("Manual alarm buzzer started");
+                            let volumes = ChannelVolumes::new(&settings, false);
+                            if flash {
+                                trigger_flash().unwrap();
+                            }
+                            Sound::new(
+                                _context.clone(),
+                                volumes,
+                                library[settings.buzzer_sound].clone(),
+                                true,
                                 false,
                             )
                         }
@@ -548,6 +575,14 @@ impl SoundController {
 
     pub fn trigger_whistle(&self) {
         self.msg_tx.send(SoundMessage::TriggerWhistle).unwrap()
+    }
+
+    pub fn start_manual_buzzer(&self) {
+        self.msg_tx.send(SoundMessage::StartManualBuzzer).unwrap()
+    }
+
+    pub fn stop_manual_buzzer(&self) {
+        self.msg_tx.send(SoundMessage::StopManualBuzzer).unwrap()
     }
 
     pub fn trigger_buzzer(&self) {

--- a/refbox/src/sound_controller/mod.rs
+++ b/refbox/src/sound_controller/mod.rs
@@ -76,6 +76,7 @@ pub struct SoundSettings {
     pub auto_sound_start_play: bool,
     #[derivative(Default(value = "true"))]
     pub auto_sound_stop_play: bool,
+    pub manual_alarm_enabled: bool,
     pub remotes: Vec<RemoteInfo>,
 }
 
@@ -90,6 +91,7 @@ impl SoundSettings {
             mut under_water_vol,
             mut auto_sound_start_play,
             mut auto_sound_stop_play,
+            mut manual_alarm_enabled,
             mut remotes,
         } = Default::default();
 
@@ -141,6 +143,11 @@ impl SoundSettings {
                 auto_sound_stop_play = old_auto_sound_stop_play;
             }
         }
+        if let Some(old_manual_alarm_enabled) = old.get("manual_alarm_enabled") {
+            if let Some(old_manual_alarm_enabled) = old_manual_alarm_enabled.as_bool() {
+                manual_alarm_enabled = old_manual_alarm_enabled;
+            }
+        }
         if let Some(old_remotes) = old.get("remotes") {
             if let Some(old_remotes) = old_remotes.as_array() {
                 remotes = old_remotes
@@ -167,6 +174,7 @@ impl SoundSettings {
             under_water_vol,
             auto_sound_start_play,
             auto_sound_stop_play,
+            manual_alarm_enabled,
             remotes,
         }
     }

--- a/refbox/src/sound_controller/mod.rs
+++ b/refbox/src/sound_controller/mod.rs
@@ -850,6 +850,7 @@ mod tests {
         assert_eq!(settings.under_water_vol, Volume::Medium);
         assert_eq!(settings.auto_sound_start_play, false);
         assert_eq!(settings.auto_sound_stop_play, false);
+        assert!(!settings.manual_alarm_enabled);
         assert_eq!(
             settings.remotes,
             vec![

--- a/refbox/tests/features/manual_alarm.feature
+++ b/refbox/tests/features/manual_alarm.feature
@@ -1,0 +1,156 @@
+Feature: Manual Alarm Button
+  # The manual alarm button lets the referee operator trigger the buzzer
+  # sound manually during a game. It is an opt-in feature — disabled by
+  # default so operators who don't need it see no change.
+  #
+  # When enabled, the button appears on the main game screen. The spacebar
+  # provides the same function as the button. A label on the button itself
+  # tells operators about the spacebar shortcut.
+  #
+  # The button requires a minimum hold to fire, to prevent accidental taps:
+  # - during active play (clock running, no timeout): 250ms minimum
+  # - during any other state (break periods or timeouts): 1 second minimum
+  # While held past the minimum, the alarm continues sounding. On release,
+  # the current tone finishes its natural cycle and then stops.
+
+  Background:
+    Given the refbox sound settings
+
+  # --- Settings page ---------------------------------------------------------
+
+  Scenario: Alarm button is hidden when the feature is disabled
+    Given the manual alarm is turned off in sound settings
+    When the main game screen is displayed
+    Then the alarm button is not shown
+
+  Scenario: Alarm button is visible when the feature is enabled
+    Given the manual alarm is turned on in sound settings
+    When the main game screen is displayed
+    Then the alarm button is shown
+
+  Scenario: Alarm toggle is greyed out when sound is disabled
+    Given sound is turned off in sound settings
+    When the sound settings page is displayed
+    Then the "Alarm Button" toggle is non-interactive
+
+  Scenario: Alarm toggle defaults to off
+    Given a fresh install with no saved sound settings
+    When the sound settings page is displayed
+    Then the "Alarm Button" toggle is off
+
+  Scenario: Existing settings files default to manual alarm disabled
+    Given a sound settings file that was saved before the manual alarm feature existed
+    When the settings file is loaded
+    Then the manual alarm is treated as turned off
+    And no error occurs during loading
+
+  # --- Main screen layout ----------------------------------------------------
+
+  Scenario: Enabling the alarm button replaces the game info area
+    Given the manual alarm is turned on in sound settings
+    When the main game screen is displayed
+    Then a compact "GAME INFO" button is shown where the game info area used to be
+
+  Scenario: Tapping the GAME INFO button opens the game details screen
+    Given the manual alarm is turned on in sound settings
+    When the GAME INFO button is pressed
+    Then the game details screen is shown
+
+  Scenario: With fouls and warnings tracking on, alarm and warnings share the lower area
+    Given the manual alarm is turned on in sound settings
+    And fouls and warnings tracking is on
+    When the main game screen is displayed
+    Then the alarm button is shown on the left side of the lower area
+    And the warnings panel is shown on the right side of the lower area
+
+  Scenario: With fouls and warnings tracking off, alarm button fills the lower area
+    Given the manual alarm is turned on in sound settings
+    And fouls and warnings tracking is off
+    When the main game screen is displayed
+    Then the alarm button fills the full width of the lower area
+
+  Scenario: Disabling the alarm button restores the original main screen
+    Given the manual alarm was turned on in sound settings
+    When the manual alarm is turned off in sound settings
+    And the main game screen is displayed
+    Then the original game info area is shown
+    And the alarm button is not shown
+
+  # --- Alarm button appearance ----------------------------------------------
+
+  Scenario: Alarm button during active play is red with the tap prompt
+    Given the manual alarm is turned on in sound settings
+    And the game is in an active play period (FirstHalf, SecondHalf, OvertimeFirstHalf, OvertimeSecondHalf, or SuddenDeath) with no timeout
+    When the main game screen is displayed
+    Then the alarm button is shown in the red colour scheme
+    And the alarm button displays "Alarm"
+    And the alarm button displays "Or press Spacebar"
+
+  Scenario: Alarm button outside active play is blue with the hold prompt
+    Given the manual alarm is turned on in sound settings
+    And either the game is in a break period (BetweenGames, HalfTime, PreOvertime, OvertimeHalfTime, or PreSuddenDeath) or a timeout is active
+    When the main game screen is displayed
+    Then the alarm button is shown in the blue colour scheme
+    And the alarm button displays "Hold to Test"
+    And the alarm button displays "Or hold Spacebar"
+
+  # --- Firing the alarm (button) ---------------------------------------------
+
+  Scenario: Holding the alarm button during active play fires the alarm after 250ms
+    Given the manual alarm is turned on in sound settings
+    And the game is in an active play period (FirstHalf, SecondHalf, OvertimeFirstHalf, OvertimeSecondHalf, or SuddenDeath) with no timeout
+    When the alarm button is pressed and held for 250ms
+    Then the alarm sound plays
+    And the alarm sound continues playing while the button is held
+
+  Scenario: Holding the alarm button during a break period or timeout fires the alarm after 1 second
+    Given the manual alarm is turned on in sound settings
+    And either the game is in a break period (BetweenGames, HalfTime, PreOvertime, OvertimeHalfTime, or PreSuddenDeath) or a timeout is active
+    When the alarm button is pressed and held for 1 second
+    Then the alarm sound plays
+    And the alarm sound continues playing while the button is held
+
+  # --- Firing the alarm (spacebar) -------------------------------------------
+
+  Scenario: Holding the spacebar during active play fires the alarm after 250ms
+    Given the manual alarm is turned on in sound settings
+    And the game is in an active play period (FirstHalf, SecondHalf, OvertimeFirstHalf, OvertimeSecondHalf, or SuddenDeath) with no timeout
+    When the spacebar is pressed and held for 250ms
+    Then the alarm sound plays
+    And the alarm sound continues playing while the spacebar is held
+
+  Scenario: Holding the spacebar during a break period or timeout fires the alarm after 1 second
+    Given the manual alarm is turned on in sound settings
+    And either the game is in a break period (BetweenGames, HalfTime, PreOvertime, OvertimeHalfTime, or PreSuddenDeath) or a timeout is active
+    When the spacebar is held for 1 second
+    Then the alarm sound plays
+
+  Scenario: Spacebar has no effect on non-main screens
+    Given the manual alarm is turned on in sound settings
+    And the operator is on the configuration, penalties, or score edit screen
+    When the spacebar is pressed
+    Then the alarm sound does not play
+
+  # --- Cancelling a press before the minimum hold ----------------------------
+
+  Scenario: Releasing the alarm button before 250ms during active play cancels the press
+    Given the manual alarm is turned on in sound settings
+    And the game is in an active play period (FirstHalf, SecondHalf, OvertimeFirstHalf, OvertimeSecondHalf, or SuddenDeath) with no timeout
+    When the alarm button is pressed and released after less than 250ms
+    Then the alarm sound does not play
+
+  Scenario: Releasing the alarm button before 1 second during a break period or timeout cancels the press
+    Given the manual alarm is turned on in sound settings
+    And either the game is in a break period (BetweenGames, HalfTime, PreOvertime, OvertimeHalfTime, or PreSuddenDeath) or a timeout is active
+    When the alarm button is pressed and released after less than 1 second
+    Then the alarm sound does not play
+
+  # --- Release behaviour while the alarm is playing --------------------------
+
+  Scenario: Releasing the alarm button while the alarm is playing lets the current tone finish
+    Given the manual alarm is turned on in sound settings
+    And the alarm sound is currently playing because the alarm button is held
+    When the alarm button is released
+    Then no further alarm tones are queued
+    And the currently playing tone finishes its natural cycle
+    And the alarm sound stops

--- a/refbox/tests/features/manual_alarm.feature
+++ b/refbox/tests/features/manual_alarm.feature
@@ -8,7 +8,7 @@ Feature: Manual Alarm Button
   # tells operators about the spacebar shortcut.
   #
   # The button requires a minimum hold to fire, to prevent accidental taps:
-  # - during active play (clock running, no timeout): 250ms minimum
+  # - during active play (clock running, no timeout): 150ms minimum
   # - during any other state (break periods or timeouts): 1 second minimum
   # While held past the minimum, the alarm continues sounding. On release,
   # the current tone finishes its natural cycle and then stops.
@@ -96,10 +96,10 @@ Feature: Manual Alarm Button
 
   # --- Firing the alarm (button) ---------------------------------------------
 
-  Scenario: Holding the alarm button during active play fires the alarm after 250ms
+  Scenario: Holding the alarm button during active play fires the alarm after 150ms
     Given the manual alarm is turned on in sound settings
     And the game is in an active play period (FirstHalf, SecondHalf, OvertimeFirstHalf, OvertimeSecondHalf, or SuddenDeath) with no timeout
-    When the alarm button is pressed and held for 250ms
+    When the alarm button is pressed and held for 150ms
     Then the alarm sound plays
     And the alarm sound continues playing while the button is held
 
@@ -112,10 +112,10 @@ Feature: Manual Alarm Button
 
   # --- Firing the alarm (spacebar) -------------------------------------------
 
-  Scenario: Holding the spacebar during active play fires the alarm after 250ms
+  Scenario: Holding the spacebar during active play fires the alarm after 150ms
     Given the manual alarm is turned on in sound settings
     And the game is in an active play period (FirstHalf, SecondHalf, OvertimeFirstHalf, OvertimeSecondHalf, or SuddenDeath) with no timeout
-    When the spacebar is pressed and held for 250ms
+    When the spacebar is pressed and held for 150ms
     Then the alarm sound plays
     And the alarm sound continues playing while the spacebar is held
 
@@ -133,10 +133,10 @@ Feature: Manual Alarm Button
 
   # --- Cancelling a press before the minimum hold ----------------------------
 
-  Scenario: Releasing the alarm button before 250ms during active play cancels the press
+  Scenario: Releasing the alarm button before 150ms during active play cancels the press
     Given the manual alarm is turned on in sound settings
     And the game is in an active play period (FirstHalf, SecondHalf, OvertimeFirstHalf, OvertimeSecondHalf, or SuddenDeath) with no timeout
-    When the alarm button is pressed and released after less than 250ms
+    When the alarm button is pressed and released after less than 150ms
     Then the alarm sound does not play
 
   Scenario: Releasing the alarm button before 1 second during a break period or timeout cancels the press

--- a/refbox/translations/en-US/refbox.ftl
+++ b/refbox/translations/en-US/refbox.ftl
@@ -103,7 +103,9 @@ auto-sound-stop-play = AUTO SOUND
 alarm-button = ALARM
     BUTTON:
 alarm = ALARM
+hold-to-test = HOLD TO TEST
 or-press-spacebar = Or Press Spacebar
+or-hold-spacebar = Or Hold Spacebar
 game-info = GAME INFO
 remotes = REMOTES
 default = DEFAULT

--- a/refbox/translations/en-US/refbox.ftl
+++ b/refbox/translations/en-US/refbox.ftl
@@ -100,6 +100,11 @@ underwater-volume = UNDERWATER
     VOLUME:
 auto-sound-stop-play = AUTO SOUND
     STOP PLAY:
+alarm-button = ALARM
+    BUTTON:
+alarm = ALARM
+or-press-spacebar = Or Press Spacebar
+game-info = GAME INFO
 remotes = REMOTES
 default = DEFAULT
 sound = SOUND: { $sound_text }

--- a/refbox/translations/es/refbox.ftl
+++ b/refbox/translations/es/refbox.ftl
@@ -104,7 +104,9 @@ auto-sound-stop-play = SONIDO AUTOMÁTICO
 alarm-button = BOTÓN DE
     ALARMA:
 alarm = ALARMA
+hold-to-test = MANTÉN PARA PROBAR
 or-press-spacebar = O Presiona la Barra
+or-hold-spacebar = O Mantén la Barra
 game-info = INFO JUEGO
 remotes = REMOTOS
 default = POR DEFECTO

--- a/refbox/translations/es/refbox.ftl
+++ b/refbox/translations/es/refbox.ftl
@@ -101,6 +101,11 @@ underwater-volume = VOLUMEN
     BAJO EL AGUA:
 auto-sound-stop-play = SONIDO AUTOMÁTICO
     AL PARAR:
+alarm-button = BOTÓN DE
+    ALARMA:
+alarm = ALARMA
+or-press-spacebar = O Presiona la Barra
+game-info = INFO JUEGO
 remotes = REMOTOS
 default = POR DEFECTO
 sound = SONIDO: { $sound_text }

--- a/refbox/translations/fr/refbox.ftl
+++ b/refbox/translations/fr/refbox.ftl
@@ -102,7 +102,9 @@ auto-sound-stop-play = SON AUTOMATIQUE
 alarm-button = BOUTON
     D'ALARME:
 alarm = ALARME
+hold-to-test = MAINTENIR POUR TESTER
 or-press-spacebar = Ou Appuyez sur Espace
+or-hold-spacebar = Ou Maintenez Espace
 game-info = INFO PARTIE
 remotes = TÉLÉCOMMANDES
 default = DÉFAUT

--- a/refbox/translations/fr/refbox.ftl
+++ b/refbox/translations/fr/refbox.ftl
@@ -99,6 +99,11 @@ underwater-volume = VOLUME
     SOUS L'EAU:
 auto-sound-stop-play = SON AUTOMATIQUE
     ARRÊT MATCH:
+alarm-button = BOUTON
+    D'ALARME:
+alarm = ALARME
+or-press-spacebar = Ou Appuyez sur Espace
+game-info = INFO PARTIE
 remotes = TÉLÉCOMMANDES
 default = DÉFAUT
 sound = SON: { $sound_text }


### PR DESCRIPTION
## What changed
Adds a manual alarm button the referee operator can press (on screen, or via spacebar) to sound the buzzer on demand. The button is enabled via a new toggle on the sound settings page.

**Behaviour:**
- When enabled, a red/blue alarm button appears on the main view
- Pressing fires the buzzer after a short hold (250ms during active play, 1 second in every other state)
- While held past the minimum, the alarm keeps sounding
- On release, the current tone finishes naturally and stops
- Spacebar also triggers the alarm when the feature is enabled

## Why
Referees need to sound the buzzer manually in situations not covered by automatic game events (e.g. signalling to players, emergencies). This is a feature request from tournament operators.

## Scope
Changes are limited to `refbox/`:
- Config: new `manual_alarm_enabled` field in `SoundSettings` (migration-safe)
- Messages: `AlarmPressed`/`AlarmReleased`/`AlarmFired` added to the message enum
- Settings page: new "Alarm Button" toggle
- Main view: new alarm button with state-dependent colour
- Input: spacebar subscription when enabled
- Translations: strings added (existing languages; coverage for new languages comes with PR 10)
- Docs: design spec, plan, and BDD feature file under `refbox/plans/`, `refbox/specs/`, `refbox/tests/features/`

## How to verify
1. Start the refbox; go to Settings → Sound
2. Toggle "Alarm Button" on
3. Return to main view — alarm button should appear
4. Press and hold (mouse or spacebar) — buzzer sounds after ~250ms (during active play) or ~1s (in other states)
5. Release — tone finishes and stops
6. Toggle off; button disappears and spacebar no longer triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)