### PR TITLE
chore(workspace): bump version to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,7 +577,7 @@ dependencies = [
 
 [[package]]
 name = "beep-test"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "arrayref",
  "clap",
@@ -2235,7 +2235,7 @@ dependencies = [
 
 [[package]]
 name = "fonts"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "embedded-graphics",
 ]
@@ -3608,7 +3608,7 @@ checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
 
 [[package]]
 name = "led-panel-sim"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "matrix-drawing",
  "uwh-common",
@@ -3932,7 +3932,7 @@ dependencies = [
 
 [[package]]
 name = "matrix-drawing"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -4785,7 +4785,7 @@ dependencies = [
 
 [[package]]
 name = "overlay"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "alphagen",
  "clap",
@@ -5483,7 +5483,7 @@ dependencies = [
 
 [[package]]
 name = "refbox"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "arrayref",
  "bs58",
@@ -5908,7 +5908,7 @@ dependencies = [
 
 [[package]]
 name = "schedule-processor"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "clap",
  "csv",
@@ -7342,7 +7342,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uwh-common"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -8333,7 +8333,7 @@ dependencies = [
 
 [[package]]
 name = "wireless-modes"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "lora-modulation",
 ]

--- a/beep-test/Cargo.toml
+++ b/beep-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beep-test"
-version = "0.3.1"
+version = "0.4.0"
 description = "UI for Atlantis Sports's Underwater Hockey Refbox"
 authors = ["Atlantis Sports <maintainers@atlantissports.org>"]
 edition = "2024"
@@ -27,7 +27,7 @@ iced_futures = { version = "0.13", features = ["async-std"] }
 iced_graphics = "0.13"
 iced_renderer = "0.13"
 iced_runtime = "0.13"
-led-panel-sim = { version = "0.3.1", path = "../led-panel-sim" }
+led-panel-sim = { version = "0.4.0", path = "../led-panel-sim" }
 log = "0.4"
 log4rs = { version = "1", default-features = false, features = ["background_rotation", "compound_policy", "console_appender", "fixed_window_roller", "gzip", "pattern_encoder", "rolling_file_appender", "size_trigger"]}
 log-panics = { version = "2", features = ["with-backtrace"]}
@@ -44,8 +44,8 @@ time = { version = "0.3", features = ["local-offset", "macros", "serde", "serde-
 tokio = { version = "1", features = ["io-util", "macros", "net", "sync", "time"] }
 tokio-serial = "5"
 toml = "0.9"
-uwh-common = { version = "0.3.1", path = "../uwh-common"}
-matrix-drawing = { version = "0.3.1", path = "../matrix-drawing"}
+uwh-common = { version = "0.4.0", path = "../uwh-common"}
+matrix-drawing = { version = "0.4.0", path = "../matrix-drawing"}
 web-audio-api = { version = "1.2", default-features = false, features = ["cpal"] }
 enum-iterator = "2.1.0"
 

--- a/fonts/Cargo.toml
+++ b/fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fonts"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Atlantis Sports <maintainers@atlantissports.org>"]
 edition = "2024"
 rust-version = "1.85"

--- a/led-panel-sim/Cargo.toml
+++ b/led-panel-sim/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "led-panel-sim"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Atlantis Sports <maintainers@atlantissports.org>"]
 edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-matrix-drawing = { version = "0.3.1", path = "../matrix-drawing" }
-uwh-common = { version = "0.3.1", path = "../uwh-common" }
+matrix-drawing = { version = "0.4.0", path = "../matrix-drawing" }
+uwh-common = { version = "0.4.0", path = "../uwh-common" }
 
 [lib]
 name = "led_panel_sim"

--- a/matrix-drawing/Cargo.toml
+++ b/matrix-drawing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matrix-drawing"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Atlantis Sports <maintainers@atlantissports.org>"]
 edition = "2024"
 rust-version = "1.85"
@@ -15,9 +15,9 @@ arrayvec = { version = "0.7", default-features = false }
 derivative = "2"
 embedded-graphics = "0.8"
 enum-derive-2018 = { version = "3", optional = true }
-fonts = { version = "0.3.1", path = "../fonts" }
+fonts = { version = "0.4.0", path = "../fonts" }
 macro-attr-2018 = { version = "3", optional = true }
 more-asserts = "0.3"
 serde = { version = "1", default-features = false }
 serde_derive = "1"
-uwh-common = { version = "0.3.1", path = "../uwh-common", default-features = false }
+uwh-common = { version = "0.4.0", path = "../uwh-common", default-features = false }

--- a/overlay/Cargo.toml
+++ b/overlay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "overlay"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.85"
 

--- a/refbox/Cargo.toml
+++ b/refbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "refbox"
-version = "0.3.1"
+version = "0.4.0"
 description = "UI for Atlantis Sports's Underwater Hockey Refbox"
 authors = ["Atlantis Sports <maintainers@atlantissports.org>"]
 edition = "2024"
@@ -33,12 +33,12 @@ iced_graphics = "0.13"
 iced_renderer = "0.13"
 iced_runtime = "0.13"
 iced_winit = "0.13"
-led-panel-sim = { version = "0.3.1", path = "../led-panel-sim" }
+led-panel-sim = { version = "0.4.0", path = "../led-panel-sim" }
 log = "0.4"
 log-panics = { version = "2", features = ["with-backtrace"]}
 log4rs = { version = "1", default-features = false, features = ["background_rotation", "compound_policy", "console_appender", "fixed_window_roller", "gzip", "pattern_encoder", "rolling_file_appender", "size_trigger"]}
 macro-attr-2018 = "3"
-matrix-drawing = { version = "0.3.1", path = "../matrix-drawing"}
+matrix-drawing = { version = "0.4.0", path = "../matrix-drawing"}
 more-asserts = "0.3"
 once_cell = "1.21.3"
 paste = "1"
@@ -54,7 +54,7 @@ tokio = { version = "1", features = ["io-util", "macros", "net", "sync", "time"]
 tokio-serial = "5"
 toml = "0.9"
 unic-langid = "0.9.6"
-uwh-common = { version = "0.3.1", path = "../uwh-common"}
+uwh-common = { version = "0.4.0", path = "../uwh-common"}
 web-audio-api = { version = "1.2", default-features = false, features = ["cpal"] }
 
 [build-dependencies]
@@ -68,7 +68,7 @@ embedded-hal-async = "1.0.0"
 iced = { version = "0.13", default-features = false, features = ["canvas", "image", "svg", "tiny-skia", "tokio"] }
 lora-phy = "3.0.1"
 rppal = { version = "0.22", features = ["embedded-hal", "hal-unproven"] }
-wireless-modes = { version = "0.3.1", path = "../wireless-modes" }
+wireless-modes = { version = "0.4.0", path = "../wireless-modes" }
 
 [target.'cfg(not(target_os = "linux"))'.dependencies]
 iced = { version = "0.13", default-features = false, features = ["canvas", "image", "svg", "tokio", "wgpu"] }

--- a/schedule-processor/Cargo.toml
+++ b/schedule-processor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "schedule-processor"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Atlantis Sports <maintainers@atlantissports.org>"]
 edition = "2024"
 rust-version = "1.85"
@@ -23,4 +23,4 @@ serde_json = "1.0"
 strsim = "0.11.1"
 time = { version = "0.3", features = ["local-offset", "macros", "serde", "serde-human-readable"] }
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread"], default-features = false }
-uwh-common = { version = "0.3", path = "../uwh-common" }
+uwh-common = { version = "0.4", path = "../uwh-common" }

--- a/uwh-common/Cargo.toml
+++ b/uwh-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uwh-common"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Atlantis Sports <maintainers@atlantissports.org>"]
 edition = "2024"
 rust-version = "1.85"
@@ -16,7 +16,7 @@ defmt = "1.0"
 derivative = { version = "2", features = ["use_core"] }
 displaydoc = { version = "0.2", default-features = false }
 enum-iterator = "2"
-fonts = { version = "0.3.1", path = "../fonts" }
+fonts = { version = "0.4.0", path = "../fonts" }
 image = "0.25"
 indexmap = { version = "2.9.0", optional = true, features = ["serde"] }
 log = "0.4"

--- a/wireless-modes/Cargo.toml
+++ b/wireless-modes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wireless-modes"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Atlantis Sports <maintainers@atlantissports.org>"]
 edition = "2024"
 rust-version = "1.85"

--- a/wireless-remote/Cargo.toml
+++ b/wireless-remote/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wireless-remote"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Atlantis Sports <maintainers@atlantissports.org>"]
 edition = "2024"
 rust-version = "1.85"
@@ -20,7 +20,7 @@ embedded-hal-bus = { version = "0.3.0", features = ["async", "defmt-03"] }
 lora-phy = "3.0.1"
 panic-probe = { version = "1.0", features = ["print-defmt"] }
 portable-atomic = { version = "1.9.0", features = ["critical-section", "require-cas"] }
-wireless-modes = { version = "0.3.1", path = "../wireless-modes" }
+wireless-modes = { version = "0.4.0", path = "../wireless-modes" }
 
 
 [profile.release]


### PR DESCRIPTION
## What changed
Bumps every crate in the workspace from 0.3.x to 0.4.0. No behaviour change — this is the version-stamp PR that precedes the v0.4.0 tag.

## Why
v0.4.0 collects a substantial set of changes since v0.3.1:

- **Bug fixes:** confirm-scores timing freeze, sound artifacts, UI clipping
- **Features:** manual alarm button, list-of-placements, 12 new UI languages with CJK/Thai font support, referee-name display
- **New public API** in `uwh-common` (referee types, list-of-placements types, `/referees` endpoint)
- **Infrastructure:** CI release pipeline, Raspberry Pi cross-compilation

Under semver for pre-1.0 crates, new public API surface is a minor-version bump, not a patch.

## Scope
Version fields in every workspace `Cargo.toml` and the corresponding `Cargo.lock` entries. No source code changes.

## How to verify
- `just check` passes green.
- `cargo run -p refbox --version` (or any workspace crate) reports `0.4.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)