### PR TITLE
chore(workspace): fix clippy 1.95 lints (unblocks #763 CI)

### DIFF
--- a/refbox/src/app/view_builders/configuration.rs
+++ b/refbox/src/app/view_builders/configuration.rs
@@ -165,15 +165,8 @@ fn make_main_config_page<'a>(
         if let (Some(_), Some(cur_court)) = (current_event_id, current_court) {
             if let Some(schedule) = schedule {
                 match schedule.games.get(game_number) {
-                    Some(game) => {
-                        if game.court == *cur_court {
-                            game.number.to_string()
-                        } else {
-                            game_large_text = false;
-                            fl!("none-selected")
-                        }
-                    }
-                    None => {
+                    Some(game) if game.court == *cur_court => game.number.to_string(),
+                    _ => {
                         game_large_text = false;
                         fl!("none-selected")
                     }

--- a/refbox/src/penalty_editor.rs
+++ b/refbox/src/penalty_editor.rs
@@ -357,7 +357,7 @@ where
             }
         }
 
-        modified_pens.sort_by(|a, b| a.0.index.cmp(&b.0.index));
+        modified_pens.sort_by_key(|a| a.0.index);
 
         let mut tm = self.tm.lock()?;
 

--- a/schedule-processor/src/schedule_checks.rs
+++ b/schedule-processor/src/schedule_checks.rs
@@ -260,7 +260,7 @@ fn check_game_overlap(schedule: &Schedule) -> Result<(), Box<dyn std::error::Err
     }
 
     for games in court_games.values_mut() {
-        games.sort_by(|a, b| a.0.start_time.cmp(&b.0.start_time));
+        games.sort_by_key(|a| a.0.start_time);
     }
 
     let mut games_overlap = false;

--- a/uwh-common/src/game_snapshot.rs
+++ b/uwh-common/src/game_snapshot.rs
@@ -72,7 +72,7 @@ impl From<GameSnapshot> for GameSnapshotNoHeap {
                         true
                     }
                 });
-                orig.sort_by(|a, b| a.time.cmp(&b.time));
+                orig.sort_by_key(|a| a.time);
                 (c, orig.into_iter().take(3).collect())
             })
             .collect();


### PR DESCRIPTION
## What changed

Four small, behaviour-preserving edits to silence two new clippy lints that Rust 1.95 added under `-D warnings`:

| File | Old | New | Lint |
|------|-----|-----|------|
| `uwh-common/src/game_snapshot.rs:75` | `sort_by(\|a, b\| a.time.cmp(&b.time))` | `sort_by_key(\|a\| a.time)` | `unnecessary_sort_by` |
| `schedule-processor/src/schedule_checks.rs:263` | `sort_by(\|a, b\| a.0.start_time.cmp(&b.0.start_time))` | `sort_by_key(\|a\| a.0.start_time)` | `unnecessary_sort_by` |
| `refbox/src/penalty_editor.rs:360` | `sort_by(\|a, b\| a.0.index.cmp(&b.0.index))` | `sort_by_key(\|a\| a.0.index)` | `unnecessary_sort_by` |
| `refbox/src/app/view_builders/configuration.rs:169` | nested `if game.court == *cur_court { ... } else { ... }` inside `match schedule.games.get(game_number) { Some(game) => ... }` | match guard + wildcard fallback | `collapsible_match` |

All four lines were pre-existing on master (Tristan's commits dated 2022, 2025-02-25, 2025-03-03, and 2025-06-03). The lints became errors only because CI uses the latest stable Rust (currently 1.95), while the project's MSRV is 1.85.

## Why

PR #763 (the Units 1–8 audit chain) is otherwise green but is failing the Clippy job on these four pre-existing patterns. Landing this small chore PR first unblocks #763's CI without mixing infrastructure-drift cleanup into the audit chain's history. Subsequent PRs (#764 ADR 016, #765 ADR 018) will inherit the fix when they rebase onto fresh master post-merge of this and #763.

## Scope

- **`uwh-common/`** — one sort-by rewrite. Verified `cargo build -p uwh-common --no-default-features` per uwh-common's `no_std` requirement.
- **`schedule-processor/`** — one sort-by rewrite.
- **`refbox/`** — one sort-by rewrite in `penalty_editor.rs`; one match-guard rewrite in `view_builders/configuration.rs`.

No behaviour change in any of the four edits. No test changes needed.

## How to verify

- `just check` clean on local MSRV 1.85 (unchanged).
- `rustup run stable cargo clippy --all -- --deny=warnings` clean on Rust 1.95 (newly passing).
- `rustup run stable cargo clippy --all --no-default-features -- --deny=warnings` clean (verifies the `uwh-common` `no_std` build).
- After this lands, PR #763's CI will re-run on rebase and the Clippy job should turn green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
