### PR TITLE
chore(ci): add Providing App Credentials PDF to release bundle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,7 @@ jobs:
       run: |
         curl -L "https://drive.usercontent.google.com/download?id=1Momxds_2oyPTEZHgcuSxnTxI_HbGeaN8&export=download" -o "release/Getting Started Guide - English.pdf"
         curl -L "https://drive.usercontent.google.com/download?id=13eHCCmBH-IEUwIODaqpbbz_LiZQBBh0p&export=download" -o "release/Getting Started Guide - Spanish (Guía de Inicio).pdf"
+        curl -L "https://drive.usercontent.google.com/download?id=1sJTdKHKjul6Pa7eV44APEQBFaxwQSvYy&export=download" -o "release/Providing App Credentials - English.pdf"
         curl -L "https://drive.usercontent.google.com/download?id=1skrUYTEYBgHs4T-dl3AobwklfJR3ZGE1&export=download" -o "release/Refbox User Manual.pdf"
         curl -L "https://drive.usercontent.google.com/download?id=1FLtJwc8gb5vuSRVPUNLxKhT1ufcOSa-w&export=download" -o "release/Refbox User Manual with Fouls.pdf"
     - name: Zip release


### PR DESCRIPTION
## What changed
The release workflow now downloads a fifth PDF — "Providing App Credentials - English.pdf" — from Google Drive and includes it in the release zip alongside the existing four PDFs.

## Why
A new "Providing App Credentials" guide is being added to the release bundle so end users have documentation on configuring API credentials. The PDF will ship with v0.4.0 (and subsequent releases) once the workflow runs against a fresh tag.

## Scope
Changes are limited to `.github/workflows/release.yml`. One new `curl` line is inserted alphabetically in the "Download PDFs from Google Drive" step (between the Spanish Getting Started Guide and the Refbox User Manual). No code, dependency, or test changes.

## How to verify
- Confirm the diff shows exactly one new line in `.github/workflows/release.yml`: a `curl` call for `Providing App Credentials - English.pdf`, positioned alphabetically between the Spanish guide and the Refbox User Manual.
- After merge, the next time the `v0.4.0` tag is pushed (planned after the upcoming UI updates land), the resulting draft release's `refbox.zip` will contain 5 PDFs instead of 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)