### PR TITLE
feat(refbox): always show zero button on time editors

### DIFF
--- a/refbox/src/app/view_builders/shared_elements.rs
+++ b/refbox/src/app/view_builders/shared_elements.rs
@@ -660,15 +660,11 @@ pub(super) fn make_time_editor<'a, T: IntoFragment<'a>>(
     ]
     .spacing(SPACING);
 
-    let mut time_col = column![text(time_string(time)).size(LARGE_TEXT),]
-        .align_x(Horizontal::Center)
-        .width(Length::Fixed(if wide { 300.0 } else { 200.0 }))
-        .spacing(SPACING);
-
-    if wide {
-        time_col = time_col.push(row![
+    let time_col = column![
+        text(time_string(time)).size(LARGE_TEXT),
+        row![
             horizontal_space(),
-            make_smaller_button(fl!("zero"))
+            make_small_button(fl!("zero"), MEDIUM_TEXT)
                 .style(blue_button)
                 .on_press(Message::ChangeTime {
                     increase: false,
@@ -676,8 +672,11 @@ pub(super) fn make_time_editor<'a, T: IntoFragment<'a>>(
                     timeout,
                 }),
             horizontal_space(),
-        ]);
-    }
+        ],
+    ]
+    .align_x(Horizontal::Center)
+    .width(Length::Fixed(if wide { 300.0 } else { 200.0 }))
+    .spacing(SPACING);
 
     let time_edit = row![min_edits, time_col, sec_edits]
         .spacing(SPACING)

--- a/refbox/translations/de-DE/refbox.ftl
+++ b/refbox/translations/de-DE/refbox.ftl
@@ -307,7 +307,7 @@ penalty-shot-short = STRAFSTOSS
 ## Verwarnungscontainer erstellen
 team-warning-abreviation = T
 ## Zeiteditor erstellen
-zero = NULL
+zero = = 0
 
 # Zeitbearbeitung
 game-time = SPIELZEIT

--- a/refbox/translations/en-US/refbox.ftl
+++ b/refbox/translations/en-US/refbox.ftl
@@ -316,7 +316,7 @@ penalty-shot-short = PNLTY SHT
 ## Make warning container
 team-warning-abreviation = T
 ## Make time editor
-zero = ZERO
+zero = = 0
 
 # Time edit
 game-time = GAME TIME

--- a/refbox/translations/es/refbox.ftl
+++ b/refbox/translations/es/refbox.ftl
@@ -318,7 +318,7 @@ penalty-shot-short = TIRO PENAL
 ## Make warning container
 team-warning-abreviation = A
 ## Make time editor
-zero = CERO
+zero = = 0
 
 # Time edit
 game-time = TIEMPO DE JUEGO

--- a/refbox/translations/fr/refbox.ftl
+++ b/refbox/translations/fr/refbox.ftl
@@ -309,7 +309,7 @@ penalty-shot-short = TIR DE PÉN.
 ## Make warning container
 team-warning-abreviation = É
 ## Make time editor
-zero = ZÉRO
+zero = = 0
 
 # Time edit
 game-time = TEMPS DE MATCH

--- a/refbox/translations/id-ID/refbox.ftl
+++ b/refbox/translations/id-ID/refbox.ftl
@@ -307,7 +307,7 @@ penalty-shot-short = TBK PEN
 ## Kontainer peringatan tim
 team-warning-abreviation = T
 ## Editor waktu
-zero = NOL
+zero = = 0
 
 # Edit Waktu
 game-time = WAKTU PERTANDINGAN

--- a/refbox/translations/it-IT/refbox.ftl
+++ b/refbox/translations/it-IT/refbox.ftl
@@ -307,7 +307,7 @@ penalty-shot-short = TIRO RIG.
 ## Contenitore ammonizione di squadra
 team-warning-abreviation = S
 ## Editor tempo
-zero = ZERO
+zero = = 0
 
 # Modifica Tempo
 game-time = TEMPO DI GIOCO

--- a/refbox/translations/ja-JP/refbox.ftl
+++ b/refbox/translations/ja-JP/refbox.ftl
@@ -307,7 +307,7 @@ penalty-shot-short = PEN SHT
 ## 警告コンテナ
 team-warning-abreviation = 警
 ## 時間編集
-zero = ゼロ
+zero = = 0
 
 # 時間編集
 game-time = 試合時間

--- a/refbox/translations/ko-KR/refbox.ftl
+++ b/refbox/translations/ko-KR/refbox.ftl
@@ -309,7 +309,7 @@ penalty-shot-short = 페널티 샷
 ## 경고 컨테이너 생성
 team-warning-abreviation = 팀
 ## 시간 편집기 생성
-zero = 영
+zero = = 0
 
 # 시간 편집
 game-time = 경기 시간

--- a/refbox/translations/ms-MY/refbox.ftl
+++ b/refbox/translations/ms-MY/refbox.ftl
@@ -307,7 +307,7 @@ penalty-shot-short = TMBN PENALTI
 ## Buat bekas amaran
 team-warning-abreviation = P
 ## Buat penyunting masa
-zero = SIFAR
+zero = = 0
 
 # Edit Masa
 game-time = MASA PERLAWANAN

--- a/refbox/translations/nl-NL/refbox.ftl
+++ b/refbox/translations/nl-NL/refbox.ftl
@@ -307,7 +307,7 @@ penalty-shot-short = STRAFSCHOT
 ## Waarschuwingscontainer maken
 team-warning-abreviation = T
 ## Tijdeditor maken
-zero = NUL
+zero = = 0
 
 # Tijd bewerken
 game-time = WEDSTRIJDTIJD

--- a/refbox/translations/pt-PT/refbox.ftl
+++ b/refbox/translations/pt-PT/refbox.ftl
@@ -307,7 +307,7 @@ penalty-shot-short = TIRO PENAL
 ## Contentor de aviso de equipa
 team-warning-abreviation = A
 ## Editor de tempo
-zero = ZERO
+zero = = 0
 
 # Edição de Tempo
 game-time = TEMPO DE JOGO

--- a/refbox/translations/th-TH/refbox.ftl
+++ b/refbox/translations/th-TH/refbox.ftl
@@ -307,7 +307,7 @@ penalty-shot-short = ยิงโทษ
 ## สร้างกล่องการเตือน
 team-warning-abreviation = ท
 ## สร้างตัวแก้ไขเวลา
-zero = ศูนย์
+zero = = 0
 
 # แก้ไขเวลา
 game-time = เวลาเกม

--- a/refbox/translations/tl-PH/refbox.ftl
+++ b/refbox/translations/tl-PH/refbox.ftl
@@ -307,7 +307,7 @@ penalty-shot-short = PENALTY SHT
 ## Gawing warning container
 team-warning-abreviation = K
 ## Gawing time editor
-zero = SERO
+zero = = 0
 
 # Pag-edit ng Oras
 game-time = ORAS NG LARO

--- a/refbox/translations/tr-TR/refbox.ftl
+++ b/refbox/translations/tr-TR/refbox.ftl
@@ -307,7 +307,7 @@ penalty-shot-short = CZA ATŞ
 ## Uyarı konteyneri oluştur
 team-warning-abreviation = T
 ## Zaman düzenleyici oluştur
-zero = SIFIR
+zero = = 0
 
 # Zaman Düzenleme
 game-time = OYUN SAATİ

--- a/refbox/translations/zh-CN/refbox.ftl
+++ b/refbox/translations/zh-CN/refbox.ftl
@@ -307,7 +307,7 @@ penalty-shot-short = 罚球
 ## 警告容器
 team-warning-abreviation = 队
 ## 时间编辑器
-zero = 零
+zero = = 0
 
 # 时间编辑
 game-time = 比赛时间


### PR DESCRIPTION
## What changed
Every time-edit screen (game time, half time, between-period, penalty length, timeout length, configuration durations, etc.) now renders a Zero button that:
- Always appears, regardless of the current value (previously hidden when the time was at or below 99:59).
- Reads `= 0` instead of a translated word like "ZERO" / "CERO" / "ZÉRO" — locale-neutral math notation that fits cleanly in narrow column layouts and works in every supported language.
- Matches the +/- buttons in size (89×89 px) so all three buttons in the editor share one visual footprint.

## Why
Operator review on 2026-05-16 surfaced two related issues with the existing Zero button:
1. It only rendered when the current time exceeded 99 minutes 59 seconds, so the operator saw it on some pages but not others and assumed the rule was per-page. The actual gate was per-value (`time > MAX_STRINGABLE_SECS`). This aligns the behaviour with the post-v0.4.0 audit lesson "predictable UI > conditional UI" — flows the operator sees every time are better than ones that shape-shift based on internal state.
2. Smoke-testing the gate removal showed the English "ZERO" label wrapping to "ZE / RO" in narrow-column layouts (where the editor column is 200 px). The previous helper (`make_smaller_button`) used `Length::Fill` width which split with the surrounding `horizontal_space()` siblings and squeezed the button to ~67 px. Switching to `make_small_button` with `MEDIUM_TEXT` gives a fixed 89×89 footprint matching the +/- buttons, and switching to the universal `= 0` glyph keeps the label short across all 15 supported locales.

## Scope
Changes are limited to:
- `refbox/src/app/view_builders/shared_elements.rs` — `make_time_editor` helper: unconditional Zero button + `make_small_button(..., MEDIUM_TEXT)`.
- `refbox/translations/<15 locales>/refbox.ftl` — `zero` key value changed from a translated word to `= 0`.

No other code, dependencies, or tests touched.

## How to verify
- Launch refbox locally (`WAYLAND_DISPLAY= cargo run -p refbox` under WSL).
- Open any time-edit screen — e.g. tap the game clock to enter time-edit, or open Game Options and tap any duration field (game time, half time, between-games, etc.).
- Confirm the blue `= 0` button appears below the time display on every time-edit screen, sized the same as the surrounding +/- buttons.
- Confirm pressing `= 0` on any screen sets that value to `00:00` (existing behaviour, unchanged).
- For the wide-column layout (time > 99:59), confirm the same button still renders correctly and is the same 89×89 square.

🤖 Generated with [Claude Code](https://claude.com/claude-code)