### PR TITLE
chore(refbox): default track fouls/warnings to no

### DIFF
--- a/refbox/src/config.rs
+++ b/refbox/src/config.rs
@@ -79,7 +79,6 @@ pub struct Config {
     pub hide_time: bool,
     #[derivative(Default(value = "true"))]
     pub collect_scorer_cap_num: bool,
-    #[derivative(Default(value = "true"))]
     pub track_fouls_and_warnings: bool,
     #[derivative(Default(value = "true"))]
     pub confirm_score: bool,


### PR DESCRIPTION
## What changed
The default value for `track_fouls_and_warnings` flipped from `true` to `false`. Fresh installs of refbox now have **Track Fouls/Warnings** disabled by default; operators who want to track fouls and warnings at their tournament must opt in via Game Options → Track Fouls.

## Why
Operator decision on 2026-05-16: most tournaments don't formally track fouls and warnings, so the default should match the common case. The previous default of YES required operators to actively disable a feature they typically aren't using; flipping to NO matches the more common operational pattern.

## Scope
One-line deletion in `refbox/src/config.rs` — removes the `#[derivative(Default(value = "true"))]` attribute on `track_fouls_and_warnings`. Rust's natural `bool::default()` (false) now applies. No other code, tests, or translations touched.

**Impact on existing operator configs:** None. The `Config::migrate` path at `refbox/src/config.rs:117-121` preserves any explicit `track_fouls_and_warnings = true` value in saved `default-config.toml` files. The new default only takes effect for truly fresh installs (no saved config) or saved configs that happen to be missing this field.

## How to verify
- Smoke-tested locally on 2026-05-16: moved `~/.config/refbox/default-config.toml` aside, launched refbox, opened Game Options, observed the TRACK FOULS toggle reads NO.
- For reviewers: pull the branch, move your `default-config.toml` to a backup path, run `cargo run -p refbox`, open Game Options, confirm TRACK FOULS shows NO. Restore your config when done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)