### PR TITLE
fix(refbox): allow time-bar click on App/Sound/Languages config pages

### DIFF
--- a/refbox/src/app/view_builders/configuration.rs
+++ b/refbox/src/app/view_builders/configuration.rs
@@ -820,7 +820,14 @@ fn make_app_config_page<'a>(
     } = settings;
 
     column![
-        make_game_time_button(snapshot, false, true, mode, clock_running, portal_indicator),
+        make_game_time_button(
+            snapshot,
+            false,
+            false,
+            mode,
+            clock_running,
+            portal_indicator
+        ),
         row![
             make_value_button(
                 fl!("app-mode"),
@@ -965,7 +972,14 @@ fn make_sound_config_page<'a>(
     let EditableSettings { sound, .. } = settings;
 
     column![
-        make_game_time_button(snapshot, false, true, mode, clock_running, portal_indicator),
+        make_game_time_button(
+            snapshot,
+            false,
+            false,
+            mode,
+            clock_running,
+            portal_indicator
+        ),
         row![
             make_value_button(
                 fl!("sound-enabled"),
@@ -1386,7 +1400,14 @@ fn make_language_select_page<'a>(
     // gets a small "(UNVERIFIED)" note in its own language, signalling to operators
     // that a native speaker has not yet reviewed the translation.
     column![
-        make_game_time_button(snapshot, false, true, mode, clock_running, portal_indicator),
+        make_game_time_button(
+            snapshot,
+            false,
+            false,
+            mode,
+            clock_running,
+            portal_indicator
+        ),
         row![
             lang_btn_note(
                 Language::Indonesian,


### PR DESCRIPTION
## What changed
Clicking the time bar at the top of the **App Options**, **Sound Options**, and **Languages** configuration sub-pages now opens the time-edit screen and pauses the game clock — matching the behaviour of every other screen in the application. Previously the time-bar click did nothing on those three pages.

## Why
Operator review on 2026-05-16 flagged that the time bar didn't respond on the Languages screen. Investigation showed three configuration sub-pages were calling `make_game_time_button` with `editing_time=true`, which is the gate at [`shared_elements.rs:571-575`](refbox/src/app/view_builders/shared_elements.rs#L571-L575) that swaps `Message::EditTime` for `Message::NoAction`.

The `editing_time=true` argument is intended for:
- The time-edit screen itself (already editing — clicking would be a no-op)
- Confirmation dialogs (transient modal states where clicking away would abandon an in-flight goal/penalty confirmation)

The three configuration sub-pages didn't fit either pattern — they're editable settings screens, not modal confirms — so passing `editing_time=true` was an unintentional inconsistency. Every other configuration sub-page (Game Settings, App Settings parent, Display Options, etc.) already passes `false`. Aligns with the post-v0.4.0 audit lesson "predictable UI > conditional UI" — flows the operator sees every time are better than ones that shape-shift based on internal state.

## Scope
Changes are limited to `refbox/src/app/view_builders/configuration.rs` — three identical edits flipping `editing_time` from `true` to `false`:
- `make_app_config_page` (line ~823)
- `make_sound_config_page` (line ~972)
- `make_language_select_page` (line ~1400)

`cargo fmt` expanded each call to multi-line form during commit (matches how other `make_game_time_button` calls in this file were already formatted). The accounting in the diff shows 24 insertions / 3 deletions, but the only semantic change is three `true → false` flips.

Confirmation dialogs (`confirmation.rs:136, 212`) and the time-edit screen itself intentionally remain locked. All other screens are unchanged.

## How to verify
- Smoke-tested locally on 2026-05-16: navigated to App Options, Sound Options, and Languages in turn; clicked the time bar on each; confirmed the time-edit screen opened and the game clock paused. Also confirmed the main screen still responds correctly (no regression).
- For reviewers: pull the branch, run `cargo run -p refbox`, navigate to each of the three configuration sub-pages from Game Options, click the time bar at the top of the screen, confirm the time-edit screen opens and the clock pauses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)