### PR TITLE
feat(refbox): collapse user options to two adjacent buttons

### DIFF
--- a/refbox/src/app/view_builders/configuration.rs
+++ b/refbox/src/app/view_builders/configuration.rs
@@ -410,14 +410,10 @@ fn make_user_config_page<'a>(
     clock_running: bool,
     portal_indicator: Option<PortalIndicatorState>,
 ) -> Element<'a, Message> {
-    // Hidden spacer reserved for a future view-mode tile so the row keeps three equal columns.
-    let view_mode_spacer = horizontal_space().width(Length::Fill);
-
     let tiles = row![
         make_button(fl!("display-options"))
             .style(light_gray_button)
             .on_press(Message::ChangeConfigPage(ConfigPage::Display)),
-        view_mode_spacer,
         make_button(fl!("sound-options"))
             .style(light_gray_button)
             .on_press(Message::ChangeConfigPage(ConfigPage::Sound)),


### PR DESCRIPTION
## What changed
The User Options page (Display Options / Sound Options) now shows the two option buttons side by side with the standard theme spacing between them. Previously the row was a 3-column layout with a large empty middle column reserved as a placeholder for a future "view-mode" tile.

## Why
Operator decision on 2026-05-16 ("for the time being") to simplify the User Options page while the planned third tile (view-mode) is not yet in scope. The empty middle column was an explicit placeholder added with a code comment; collapsing to two adjacent buttons makes the page feel intentional rather than half-built.

The implementation matches the canonical 2-button row pattern already used in this file at `make_main_config_page` (lines 320-340) — the parent page that hosts the User Options button itself. That page has two identical 2-button rows (Game Options / App Options and User Options / Language) using `.spacing(SPACING).height(Length::Fill)`. The User Options page now mirrors that shape exactly.

## Scope
Changes are limited to `refbox/src/app/view_builders/configuration.rs` — `make_user_config_page`. Diff is 4 deletions, 0 insertions:
- Removed the `view_mode_spacer` local variable (a `horizontal_space().width(Length::Fill)`).
- Removed the placeholder comment explaining the 3-column layout.
- Removed the spacer reference from the `tiles` row macro.

`.spacing(SPACING)` and `.height(Length::Fill)` on the row are unchanged from master.

## How to verify
- Smoke-tested locally on 2026-05-16: navigated to Game Options → User Options, confirmed the Display Options and Sound Options buttons each fill ~50% of the row width with the standard 8-px theme gap between them. Visually consistent with the parent Main Config Page's 2-button rows (Game Options / App Options and User Options / Language).
- For reviewers: pull the branch, run `cargo run -p refbox`, open Game Options → User Options, confirm the two buttons sit side by side without the previous large empty middle gap, and both buttons still navigate correctly to their respective config pages.

## Future considerations
When the planned third tile (view-mode) is implemented, restore the 3-column shape — either reintroduce a `horizontal_space().width(Length::Fill)` placeholder, or place the new tile between Display and Sound. The `.spacing(SPACING)` and `.height(Length::Fill)` row settings remain correct for either layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)