### PR TITLE
feat(refbox): portal subsystem dormant when using-uwh-portal is off

### DIFF
--- a/docs/decisions/011-portal-health-indicator.md
+++ b/docs/decisions/011-portal-health-indicator.md
@@ -487,6 +487,37 @@ the orphaned `check_circle.svg` asset and two now-moot unit tests.
 The Deviations log entry for Task 22 captures the same change on
 the plan side.
 
+### 2026-05-16 — Indicator dormant when Using-UWH-Portal is off
+
+Operator review on 2026-05-16 surfaced that the portal health
+indicator stayed visible even when the operator had set
+"Using UWH Portal" to NO (provided an `current_event_id` was
+still linked from a prior session). This contradicts the spirit
+of "use of the UWH Portal feature is gated by the operator toggle".
+
+The 2026-04-23-dormant amendment established the rule "indicator
+hidden when no event is linked" (`current_event_id == None`). This
+2026-05-16 amendment adds a second necessary condition:
+
+**Indicator visibility now requires both:**
+- `self.using_uwhportal == true` (the operator has the feature on), AND
+- `self.current_event_id.is_some()` (an event is linked)
+
+When either condition fails, `portal_indicator: None` flows to the
+view builders and the time banner falls back to the pre-feature
+layout — same behaviour as the 2026-04-23-dormant amendment, just
+triggered by a broader gate.
+
+Code change lands on `feat/refbox/portal-subsystem-dormancy`:
+the conditional in `app/mod.rs::view()` (around line 3055) is
+extended from `self.current_event_id.as_ref().map(...)` to
+`if self.using_uwhportal { self.current_event_id.as_ref().map(...) } else { None }`.
+
+The pairing with ADR 017's dormancy contract (no fetches when
+toggle is off) makes the indicator's behaviour internally
+consistent: portal subsystem is invisible AND idle whenever the
+operator has not opted in.
+
 ## Verified by Unit 7 audit (2026-05-15)
 
 ### Audit scope

--- a/docs/decisions/017-portal-data-lifecycle.md
+++ b/docs/decisions/017-portal-data-lifecycle.md
@@ -1,10 +1,7 @@
 # 017 — Portal Data Lifecycle (Lazy Fetch and Refresh)
 
-**Date:** 2026-05-12
-**Status:** proposed
-**Behavior definition required:** before any planning or implementation, the
-operator must define the desired lifecycle semantics. The Open Design Questions
-section is a checklist of decisions needed.
+**Date:** 2026-05-12 (proposed); accepted 2026-05-16
+**Status:** accepted (verified by `feat/refbox/portal-subsystem-dormancy` 2026-05-16)
 
 ## Context
 
@@ -82,7 +79,89 @@ it crosses architectural boundaries and ADR-011 territory.
 
 ## Decision
 
-**TBD — pending operator-defined behavior for the questions above.**
+The portal subsystem is **dormant** whenever `self.using_uwhportal == false`.
+Dormant means no new fetches are dispatched, the health indicator is hidden,
+and no portal-side activity is observable to the operator. The toggle is the
+single authoritative gate.
+
+### Answers to the six open questions
+
+1. **When should event-list fetch fire?**
+   - **At startup,** only if the runtime `self.using_uwhportal` is true at the
+     moment `RefBoxApp::new()` returns. The unconditional fetch in
+     `RefBoxApp::new()` is replaced with a conditional push to the startup-task
+     batch.
+   - **On toggle ON,** the moment the operator taps the Using-UWH-Portal toggle
+     button (handled in `BoolGameParameter::UsingUwhPortal` arm of
+     `Message::ToggleBoolParameter`). The fetch fires immediately — operators
+     do not wait for Apply to commit the toggle before seeing the picker populate.
+   - **Never** while `using_uwhportal == false`. There is no other entry point
+     for the event-list fetch.
+
+2. **When should teams-list fetch fire for each event?**
+   - **No structural change.** Teams-list fetches continue to fire in batch
+     from the `RecvEventList` handler. Because the event-list fetch is now
+     gated upstream by the dormancy contract, the teams-list burst only happens
+     when the operator has opted in.
+   - The "loading…" affordance for the picker, and the "fetch only for events
+     the operator selects" optimisation, are out of scope for this ADR. They
+     can land as follow-up branches if operator review surfaces a concrete need.
+
+3. **How should mid-session changes on the portal be handled?**
+   - **Manual refresh via `Message::RequestPortalRefresh` only.** No periodic
+     auto-refresh, no server-sent events. The operator-facing refresh path
+     is unchanged from today.
+   - If the operator turns the toggle OFF and back ON in one session, the
+     toggle-on path re-fires the event-list fetch (fresh data on each
+     re-engagement). This is an intentional consequence of question 1's
+     toggle-time fetch.
+
+4. **What does the operator see while data is loading?**
+   - **No change in this ADR.** The "1 - Unknown vs Unknown" placeholder
+     issue is real but separable from the dormancy contract. Recommended
+     follow-up branch:
+     `feat/refbox/portal-loading-affordance` — replaces the placeholder
+     with an explicit "loading…" row in the picker and disables Apply
+     until teams data lands. Out of scope here.
+
+5. **How does this interact with ADR 011 (portal health indicator)?**
+   - **ADR 011 is amended.** A 2026-05-16 amendment to ADR 011 ties the
+     indicator's visibility to `self.using_uwhportal && self.current_event_id.is_some()`,
+     so the indicator is hidden whenever the subsystem is dormant. The
+     previous 2026-04-23 amendment's "dormant until event linked" rule
+     remains in force — both gates must pass for the tile to render.
+   - Lazy-fetch failures continue to surface in the health tile the same
+     way they do today (Yellow during retry, Red after escalation). No
+     new failure surface is introduced.
+
+6. **What is the credential / privacy story for unauthenticated requests?**
+   - **`UwhPortalClient` is still constructed at startup** regardless of the
+     toggle, because the client itself is cheap (no network I/O at
+     construction time) and is referenced by other code paths (token
+     verification, manual refresh). The dormancy contract gates *what
+     requests fire*, not *whether the client exists*.
+   - With this ADR's contract enforced, an operator running offline with
+     `using_uwhportal == false` makes **no portal HTTP requests at any point
+     in the session**, eliminating the leak/fingerprint concern raised in the
+     original Context.
+
+### Cached data on toggle transitions
+
+- **OFF → ON:** fetch immediately (per Q1).
+- **ON → OFF:** cached `self.events` / `self.schedule` / `current_event_id`
+  are preserved in memory. The indicator hides immediately on the next
+  snapshot. Toggling back to ON re-runs the event-list fetch (fresh data).
+  No proactive clearing — keeps the toggle as a UI-level switch rather than
+  a destructive state purge.
+
+### What is not in scope for this ADR
+
+- Persisting `using_uwhportal` across sessions in `config.toml` (currently
+  hardcoded to `false` at startup in `RefBoxApp::new()`). If operator review
+  later prefers session-persisted toggle state, that is a follow-up.
+- Loading affordance for the picker (deferred per Q4).
+- Per-event teams-list fetching (deferred per Q2).
+- Push notifications / server-sent events (rejected as out-of-scope future work).
 
 ## Sequencing
 

--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -1204,14 +1204,18 @@ impl RefBoxApp {
             scramble_token_pending,
         };
 
-        let task = Task::batch(vec![
-            new.request_event_list(),
-            if fullscreen {
-                window::get_latest().and_then(|w| window::change_mode(w, window::Mode::Fullscreen))
-            } else {
-                Task::none()
-            },
-        ]);
+        // Portal subsystem stays dormant until the operator turns Using-UWH-Portal
+        // ON: no event-list fetch fires at startup unless the runtime flag is true.
+        // See ADR 017 (Portal Data Lifecycle) for the dormancy contract.
+        let mut startup_tasks = vec![if fullscreen {
+            window::get_latest().and_then(|w| window::change_mode(w, window::Mode::Fullscreen))
+        } else {
+            Task::none()
+        }];
+        if new.using_uwhportal {
+            startup_tasks.push(new.request_event_list());
+        }
+        let task = Task::batch(startup_tasks);
 
         (new, task)
     }
@@ -2381,6 +2385,7 @@ impl RefBoxApp {
                 task
             }
             Message::ToggleBoolParameter(param) => {
+                let mut trigger_event_list_fetch = false;
                 match param {
                     BoolGameParameter::TeamWarning => {
                         if let AppState::KeypadPage(
@@ -2429,20 +2434,23 @@ impl RefBoxApp {
                             BoolGameParameter::UsingUwhPortal => {
                                 let was_using = edited_settings.using_uwhportal;
                                 edited_settings.using_uwhportal ^= true;
-                                // When the operator toggles Using-UWH-Portal ON, the
-                                // event / court / game / schedule pickers start from
-                                // a blank slate (don't pre-fill with the last-known
-                                // values from a previous session or toggle). The
-                                // token credential itself is kept in
-                                // `config.uwhportal.token`; only its validity cache
-                                // is reset so the portal re-verifies on next
-                                // interaction.
+                                // Per ADR 017 (Portal Data Lifecycle): on OFF -> ON,
+                                // start the event / court / game / schedule pickers
+                                // from a blank slate (don't pre-fill with the
+                                // last-known values from a previous session or
+                                // toggle) and kick off the event-list fetch
+                                // immediately so the picker has data ready when the
+                                // operator navigates to it. The token credential
+                                // itself is kept in `config.uwhportal.token`; only
+                                // its validity cache is reset so the portal
+                                // re-verifies on next interaction.
                                 if !was_using && edited_settings.using_uwhportal {
                                     edited_settings.current_event_id = None;
                                     edited_settings.current_court = None;
                                     edited_settings.schedule = None;
                                     edited_settings.game_number = String::new();
                                     edited_settings.uwhportal_token_valid = None;
+                                    trigger_event_list_fetch = true;
                                 }
                             }
                             BoolGameParameter::SoundEnabled => {
@@ -2477,7 +2485,11 @@ impl RefBoxApp {
                         }
                     }
                 };
-                Task::none()
+                if trigger_event_list_fetch {
+                    self.request_event_list()
+                } else {
+                    Task::none()
+                }
             }
             Message::CycleParameter(param) => {
                 let settings = &mut self.edited_settings.as_mut().unwrap();
@@ -3060,14 +3072,18 @@ impl RefBoxApp {
                     .as_ref()
                     .and_then(|events| events.get(id).and_then(|event| event.teams.as_ref()))
             }),
-            // The portal health indicator is dormant until an event is
-            // linked: `Some` when the tile and its state are live,
-            // `None` when the time banner falls back to the pre-feature
-            // layout. See ADR 011 amendment 2026-04-23.
-            portal_indicator: self
-                .current_event_id
-                .as_ref()
-                .map(|_| self.portal_manager.indicator_state()),
+            // The portal health indicator is dormant whenever Using-UWH-Portal
+            // is off OR no event is linked. `Some` only when the feature is on
+            // AND an event is linked; otherwise `None` and the time banner
+            // falls back to the pre-feature layout. See ADR 011 amendments
+            // 2026-04-23 (event-linked gate) and 2026-05-16 (using-uwh-portal gate).
+            portal_indicator: if self.using_uwhportal {
+                self.current_event_id
+                    .as_ref()
+                    .map(|_| self.portal_manager.indicator_state())
+            } else {
+                None
+            },
         };
 
         let mut main_view = column![match self.app_state {


### PR DESCRIPTION
## What changed
The portal subsystem (event-list fetch + health indicator) is now gated on the runtime "Using UWH Portal" toggle. When the toggle is OFF, refbox makes no portal HTTP requests and the health indicator does not render. When the operator flips the toggle from NO to YES, the event-list fetch fires **immediately** on the toggle tap — the picker has data ready by the time the operator navigates to it, with no wait for Apply.

## Why
Operator review on 2026-05-16 surfaced two related issues:
1. The event-list fetch fired unconditionally at every launch ([mod.rs:1208](refbox/src/app/mod.rs#L1208)), even for operators who never use the portal. Wasted HTTP requests and (if the URL was misconfigured) potential cross-tenant leaks.
2. The portal health indicator was visible whenever an event was linked, regardless of whether the operator had the portal feature on. Confusing for operators who selected an event and then turned the portal off.

Both are sub-issues of the long-standing `project_portal_subsystem_dormancy_followup` follow-up. ADR 017 (Portal Data Lifecycle) had been sitting in `proposed` status since 2026-05-12 with five open design questions; this PR resolves them and flips ADR 017 to `accepted`.

## Scope
Changes are limited to `refbox/src/app/mod.rs` and two ADR docs:

**Code changes** (`refbox/src/app/mod.rs`):
- **Startup gate** (around `RefBoxApp::new()` line ~1207): event-list fetch only pushed to the startup task batch when `new.using_uwhportal == true`. (Currently the field is hardcoded to `false` at startup; the gate is forward-compatible with future session persistence — out of scope for this PR per ADR 017.)
- **Toggle-time fetch** (around `Message::ToggleBoolParameter` UsingUwhPortal arm, line ~2441): when the operator toggles the flag from OFF to ON, `self.request_event_list()` is returned as the task from the handler. Fires on the toggle button tap, not on Apply.
- **Indicator visibility** (around `view()` line ~3050): the `portal_indicator` computation now requires `self.using_uwhportal == true` in addition to `self.current_event_id.is_some()`. When either fails, the time banner falls back to the pre-feature layout.

**ADR work:**
- `docs/decisions/017-portal-data-lifecycle.md` — status `proposed` → `accepted`. Decision section replaces the "TBD" with full answers to the six open questions.
- `docs/decisions/011-portal-health-indicator.md` — new 2026-05-16 amendment ties indicator visibility to `using_uwhportal && current_event_id.is_some()`. Pairs with the 2026-04-23 "dormant until event linked" amendment.

## How to verify
- Smoke-tested locally on WSL 2026-05-16, operator-driven, across four scenarios:
  1. Fresh launch with `using_uwhportal=false` — no `request_event_list` fires; indicator hidden even with an `current_event_id` cached.
  2. Open Game Options, tap Using-UWH-Portal toggle to ON — fetch fires immediately on tap (verified in logs).
  3. Select an event, hit Apply — indicator appears.
  4. Re-open Game Options, toggle OFF, Apply — indicator hides on next snapshot frame.
- For reviewers: pull the branch, run `cargo run -p refbox` (with `WAYLAND_DISPLAY=` under WSL), exercise the four scenarios above.

## Known follow-ups (out of scope for this PR)
- **PR 2 — Game list refresh during Game Config edit (item 2b).** When the operator picks an event in Game Config, the schedule fetch fires correctly, but the in-edit `edited_settings.schedule` is not refreshed — the picker shows "1 - Unknown vs Unknown" rows until Cancel/re-enter. Tracked as the next PR on `fix/refbox/recv-schedule-updates-edited-settings`.
- **Session persistence of `using_uwhportal`.** Currently hardcoded `false` at startup ([mod.rs:1189](refbox/src/app/mod.rs#L1189)). Operators must re-toggle ON every launch. Filed as a follow-up; ADR 017's Decision section notes this explicitly as not-in-scope.
- **Picker loading affordance** (the "Unknown vs Unknown" placeholder while teams data is in flight). ADR 017's Decision section Q4 defers this to a separate `feat/refbox/portal-loading-affordance` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)