### PR TITLE
fix(refbox): resolve picker teams against in-edit event id

### DIFF
--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -3025,11 +3025,21 @@ impl RefBoxApp {
     }
 
     pub(super) fn view(&self) -> Element<'_, Message> {
+        // During Game Config edit, the operator may have picked a new event whose
+        // teams have already loaded into `self.events[new_id].teams` but whose
+        // commit is still pending Apply. Resolve teams against the in-edit
+        // event id (when present) so the picker shows real team names during edit;
+        // fall back to the committed `current_event_id` outside of edit.
+        let active_event_id = self
+            .edited_settings
+            .as_ref()
+            .and_then(|edits| edits.current_event_id.as_ref())
+            .or(self.current_event_id.as_ref());
         let data = ViewData {
             snapshot: &self.snapshot,
             mode: self.config.mode,
             clock_running: self.tm.lock().unwrap().clock_is_running(),
-            teams: self.current_event_id.as_ref().and_then(|id| {
+            teams: active_event_id.and_then(|id| {
                 self.events
                     .as_ref()
                     .and_then(|events| events.get(id).and_then(|event| event.teams.as_ref()))


### PR DESCRIPTION
## What changed
In Game Config edit, the game picker now resolves each game's team names against the **in-edit** event id rather than the **committed** one. The "1 - Unknown vs Unknown / 2 - Unknown vs Unknown / …" rows you saw after selecting a new event are gone — real team names render immediately, with no need to Cancel out of Game Config and re-enter.

## Why
Operator review on 2026-05-16 noted that after picking an event in Game Config, the SELECT GAME picker rendered every row with "Unknown vs Unknown" for the team labels. The workaround was to Cancel Game Config and re-enter — at which point the picker showed real team names. We had originally classified this as "schedule not propagating to `edited_settings.schedule`" (item 2b in the original triage), but reading the code shows the schedule propagation already works correctly at [mod.rs:2805-2811](refbox/src/app/mod.rs#L2805-L2811).

The actual bug is one layer up: the picker resolves each game's team names by looking up `self.events[event_id].teams`. The `event_id` it used came from `self.current_event_id` — the committed event, which is only updated on Apply. During Game Config edit:
- `edited_settings.current_event_id = Some(new_event)` — the operator's pick
- `self.current_event_id = Some(old_event)` or `None` — still pre-Apply
- Games list = new event's games (correctly propagated to `edited_settings.schedule`)
- Team lookup = old event's teams (or no teams at all) → "Unknown vs Unknown"

When the operator cancelled and re-entered, `self.current_event_id` was either now Some(new_event) (after Apply elsewhere) or the in-edit lookup happened to match by coincidence — making it look like the schedule had finally "arrived" when actually it had been there all along.

## Scope
Changes are limited to `refbox/src/app/mod.rs` in `view()`. One block added (~11 lines) computing an `active_event_id` that prefers `edited_settings.current_event_id` when an edit is in flight, and using that to resolve `ViewData.teams`. Existing fallback to `self.current_event_id` is preserved for the non-edit case.

The schedule-propagation code at [mod.rs:2805-2811](refbox/src/app/mod.rs#L2805-L2811) was already correct — no change there. The `portal_indicator` field at the same site continues to use `self.current_event_id` (the committed event) because the indicator reflects the health of committed portal state, not in-edit selections.

## How to verify
- Smoke-tested locally on WSL 2026-05-16: launched refbox, waited for event-list + teams-list to load, opened Game Options → picked an event → opened the Game picker → confirmed real team names render in every row immediately (no Cancel/re-enter required).
- For reviewers: pull the branch, run `cargo run -p refbox` with a portal token that has events with teams, navigate Game Options → Event → Game picker, confirm no "Unknown vs Unknown" rows during the in-edit selection.

## Related
This is PR 2 of the portal-flow fixes triaged on 2026-05-16:
- **PR 1 (#828):** Portal subsystem dormancy — fetch + indicator gated on Using-UWH-Portal toggle.
- **PR 2 (this one):** Team-name lookup uses the in-edit event id during Game Config edit.
- **PR 3 (next):** Reset event/token/court/game to blank when toggling Using-UWH-Portal ON (separate state-semantics change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)