### PR TITLE
feat(refbox): clear portal pickers on using-uwh-portal toggle ON

### DIFF
--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -2427,7 +2427,23 @@ impl RefBoxApp {
                                 edited_settings.white_on_right ^= true
                             }
                             BoolGameParameter::UsingUwhPortal => {
-                                edited_settings.using_uwhportal ^= true
+                                let was_using = edited_settings.using_uwhportal;
+                                edited_settings.using_uwhportal ^= true;
+                                // When the operator toggles Using-UWH-Portal ON, the
+                                // event / court / game / schedule pickers start from
+                                // a blank slate (don't pre-fill with the last-known
+                                // values from a previous session or toggle). The
+                                // token credential itself is kept in
+                                // `config.uwhportal.token`; only its validity cache
+                                // is reset so the portal re-verifies on next
+                                // interaction.
+                                if !was_using && edited_settings.using_uwhportal {
+                                    edited_settings.current_event_id = None;
+                                    edited_settings.current_court = None;
+                                    edited_settings.schedule = None;
+                                    edited_settings.game_number = String::new();
+                                    edited_settings.uwhportal_token_valid = None;
+                                }
                             }
                             BoolGameParameter::SoundEnabled => {
                                 edited_settings.sound.sound_enabled ^= true


### PR DESCRIPTION
## What changed
When the operator toggles Using-UWH-Portal from OFF to ON, the Event / Court / Game / schedule pickers in Game Config now start from a blank slate instead of pre-filling with the last-known values. The token credential is preserved (no re-entry required); only its in-edit validity cache (`uwhportal_token_valid`) is reset so the portal re-verifies on next interaction.

| Field | Behaviour on toggle ON |
|---|---|
| `edited_settings.current_event_id` | Reset to `None` |
| `edited_settings.current_court` | Reset to `None` |
| `edited_settings.schedule` | Reset to `None` |
| `edited_settings.game_number` | Reset to empty string |
| `edited_settings.uwhportal_token_valid` | Reset to `None` (re-verify on next interaction) |
| `config.uwhportal.token` | **Preserved** — credential not cleared |
| All other `edited_settings` fields | Unchanged |

Behaviour on toggle OFF: no state cleared. Dormancy (per PR #828) hides the indicator and stops new fetches anyway; preserving in-memory selections lets the operator flip back without re-picking.

## Why
Operator decision on 2026-05-16: when re-engaging the portal feature, the pickers should start from a blank slate rather than pre-filling with stale event/court/game state from a previous session or earlier toggle. This matters across tournaments — leaving last week's event selected by default is confusing when the operator turns the portal back on for a different event.

Operator-confirmed token semantics: keep the credential, reset only the validity cache. Re-entering credentials every toggle would be hostile to operators using the portal regularly; re-verifying ensures any token expiry or revocation is detected on the next interaction without operator action.

## Scope
Changes are limited to `refbox/src/app/mod.rs` — the `BoolGameParameter::UsingUwhPortal` arm of `Message::ToggleBoolParameter` (around line 2429). The arm now detects the OFF→ON transition and clears five `edited_settings` fields when it fires. No changes to other arms, no changes to view rendering, no changes elsewhere.

This PR overlaps the same arm modified by PR #828 (portal dormancy — adds the `request_event_list()` dispatch on the same OFF→ON transition). The two changes are complementary and the integration merge will combine cleanly: PR #828 detects the transition and fetches, PR #829 detects the transition and clears, both wrapped in `if !was_using && edited_settings.using_uwhportal`.

## How to verify
- Smoke-tested locally on WSL 2026-05-16:
  1. Operator with an event/court/game linked from a prior session opened Game Options — confirmed status quo (fields pre-filled).
  2. Toggled Using-UWH-Portal OFF then ON — confirmed all three pickers (Event, Court, Game) show blank/default.
  3. Confirmed token not re-prompted.
  4. Confirmed normal Event-pick → Court-pick → Game-pick → Apply flow works after the reset.
- For reviewers: pull the branch, run `cargo run -p refbox`, commit an event/court/game via Game Options Apply, then toggle Using-UWH-Portal OFF → ON in Game Options. Confirm the three pickers are blank, then exercise a fresh pick flow.

## Related
This is PR 3 of the portal-flow fixes triaged on 2026-05-16:
- **PR 1 (#828):** Portal subsystem dormancy — fetch + indicator gated on Using-UWH-Portal toggle.
- **PR 2 (#829):** Team-name lookup uses the in-edit event id during Game Config edit.
- **PR 3 (this one):** Reset event/court/game/schedule + token validity on Using-UWH-Portal OFF→ON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)