### PR TITLE
chore(ci): add Raspberry Pi binary to release bundle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,11 +60,30 @@ jobs:
         name: refbox-macos-x86
         path: target/x86_64-apple-darwin/release/bundle/osx/refbox.app
 
+  build-rpi:
+    name: Build release on linux for aarch64 (Raspberry Pi)
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v5
+    - uses: Swatinem/rust-cache@v2
+    - name: Install cross from crates.io
+      uses: baptiste0928/cargo-install@v3
+      with:
+        crate: cross
+    - name: Versions
+      run: cargo --version && rustc --version && cargo fmt -- --version && cargo clippy -- --version && cross --version
+    - run: cross build --release --target aarch64-unknown-linux-gnu -p refbox
+    - uses: actions/upload-artifact@v4
+      with:
+        name: refbox-rpi
+        path: target/aarch64-unknown-linux-gnu/release/refbox
+
   upload-release:
     name: Upload release artifacts
     runs-on: ubuntu-latest
 
-    needs: [build-windows, build-macos-arm, build-macos-x86]
+    needs: [build-windows, build-macos-arm, build-macos-x86, build-rpi]
 
     steps:
     - uses: actions/download-artifact@v5
@@ -79,6 +98,10 @@ jobs:
       with:
         name: refbox-macos-x86
         path: release/Mac\ (Intel processor)/refbox.app
+    - uses: actions/download-artifact@v5
+      with:
+        name: refbox-rpi
+        path: release/Raspberry\ Pi
     - name: Download PDFs from Google Drive
       run: |
         curl -L "https://drive.usercontent.google.com/download?id=1Momxds_2oyPTEZHgcuSxnTxI_HbGeaN8&export=download" -o "release/Getting Started Guide - English.pdf"


### PR DESCRIPTION
## What changed
The release workflow now builds a Raspberry Pi binary alongside the Windows and macOS binaries on every version tag. The Pi binary is added to `refbox.zip` under a new `Raspberry Pi/refbox` folder.

## Why
The Pi binary has historically had to be cross-compiled manually after each release and copied to the Pi(s) by hand. Folding it into the automated release removes a manual step and ensures every shipped release has an up-to-date Pi binary available without extra work.

## Scope
A single file changed: `.github/workflows/release.yml`. Adds one new build job (`build-rpi`) and wires it into the existing upload job. No code in any Rust crate is touched.

## How to verify
The release workflow fires only on a version tag push (e.g., `v0.4.1`), so this change cannot be smoke-tested ahead of the next real release. Verification options:

1. **At next release tag:** push the next version tag and watch the workflow run at https://github.com/AtlantisSports/uwh-refbox-rs/actions. All four build jobs (Windows, macOS ARM, macOS x86, Raspberry Pi) and the upload-release job should go green. The published `refbox.zip` should contain `Raspberry Pi/refbox` (an aarch64 Linux binary, roughly 26 MB).

2. **Earlier validation:** the local recipe `just build-rpi` uses the same `cross build --release --target aarch64-unknown-linux-gnu -p refbox` command and was verified to produce a working binary on 2026-05-17.

The YAML has been syntax-checked locally with Python's `yaml.safe_load`.

## Notes
- Cross-compilation uses [cross-rs/cross](https://github.com/cross-rs/cross), which runs the build inside a Linux/aarch64 Docker container. GitHub's `ubuntu-latest` runners have Docker installed by default.
- The binary targets `aarch64-unknown-linux-gnu` — i.e., 64-bit ARM. This works on Raspberry Pi 4 / 5 with a 64-bit OS (which has been the default Raspberry Pi OS since 2022). If a 32-bit Pi target is ever needed, that would be a separate follow-up adding `armv7-unknown-linux-gnueabihf`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)