### PR TITLE
fix(refbox): disable "open new display" when LED panel is connected

### DIFF
--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -104,6 +104,11 @@ pub struct RefBoxApp {
     sound: SoundController,
     sim_children: Vec<Child>,
     sim_spawn_config: crate::SimSpawnConfig,
+    /// `true` when the refbox was started with `--serial-port`, meaning a
+    /// real LED panel is connected. The "Open New Display" button is
+    /// disabled in this state so the operator can't fork the panel feed
+    /// into a window that competes with the physical display.
+    has_led_panel: bool,
     list_all_events: bool,
     mouse_alarm_held: bool,
     spacebar_held: bool,
@@ -1125,6 +1130,8 @@ impl RefBoxApp {
 
         let tm = Arc::new(Mutex::new(tm));
 
+        let has_led_panel = !serial_ports.is_empty();
+
         let update_sender =
             UpdateSender::new(serial_ports, binary_port, json_port, config.hide_time);
 
@@ -1211,6 +1218,7 @@ impl RefBoxApp {
             sound,
             sim_children,
             sim_spawn_config,
+            has_led_panel,
             list_all_events,
             mouse_alarm_held: false,
             spacebar_held: false,
@@ -1932,6 +1940,16 @@ impl RefBoxApp {
                 Task::none()
             }
             Message::OpenNewDisplay => {
+                if self.has_led_panel {
+                    // Defense in depth — the UI grays the button out when an
+                    // LED panel is connected, so this branch should be
+                    // unreachable via normal interaction. Log if it ever fires.
+                    warn!(
+                        "Ignoring OpenNewDisplay: a serial LED panel is connected; \
+                         simulator windows are disabled in this configuration"
+                    );
+                    return Task::none();
+                }
                 match crate::spawn_sim_child(&self.sim_spawn_config) {
                     Ok(child) => {
                         info!(
@@ -3119,6 +3137,7 @@ impl RefBoxApp {
             } else {
                 None
             },
+            has_led_panel: self.has_led_panel,
         };
 
         let mut main_view = column![match self.app_state {

--- a/refbox/src/app/view_builders/configuration.rs
+++ b/refbox/src/app/view_builders/configuration.rs
@@ -244,11 +244,12 @@ pub(in super::super) fn build_game_config_edit_page<'a>(
         mode,
         clock_running,
         portal_indicator,
+        has_led_panel,
         ..
     } = data;
 
     // Param order convention: per-branch additions appended in chronological order
-    // — page_entry_snapshot (Unit 3) then portal_indicator (Unit 7).
+    // — page_entry_snapshot (Unit 3) then portal_indicator (Unit 7) then has_led_panel (open-new-display gate).
     match page {
         ConfigPage::Main => {
             make_main_config_page(snapshot, settings, mode, clock_running, portal_indicator)
@@ -277,6 +278,7 @@ pub(in super::super) fn build_game_config_edit_page<'a>(
             clock_running,
             page_entry_snapshot,
             portal_indicator,
+            has_led_panel,
         ),
         ConfigPage::App => make_app_config_page(
             mode,
@@ -879,6 +881,7 @@ fn make_display_config_page<'a>(
     clock_running: bool,
     page_entry_snapshot: Option<&PageEntrySnapshot>,
     portal_indicator: Option<PortalIndicatorState>,
+    has_led_panel: bool,
 ) -> Element<'a, Message> {
     let EditableSettings {
         white_on_right,
@@ -947,11 +950,17 @@ fn make_display_config_page<'a>(
         ]
         .spacing(SPACING)
         .height(Length::Fill),
-        row![
-            make_button(fl!("open-new-display"))
-                .style(light_gray_button)
-                .on_press(Message::OpenNewDisplay),
-        ]
+        row![{
+            // The button is grayed out (no `on_press`) when a real LED panel
+            // is connected (`--serial-port`). Opening a sim window in that
+            // configuration would compete with the physical display.
+            let btn = make_button(fl!("open-new-display")).style(light_gray_button);
+            if has_led_panel {
+                btn
+            } else {
+                btn.on_press(Message::OpenNewDisplay)
+            }
+        }]
         .spacing(SPACING)
         .height(Length::Fill),
         row![horizontal_space()].height(Length::Fill),

--- a/refbox/src/app/view_builders/game_info.rs
+++ b/refbox/src/app/view_builders/game_info.rs
@@ -22,6 +22,7 @@ pub(in super::super) fn build_game_info_page<'a>(
         clock_running,
         teams,
         portal_indicator,
+        has_led_panel: _,
     } = data;
 
     let middle_item: Element<_> = if using_uwhportal {

--- a/refbox/src/app/view_builders/list_selector.rs
+++ b/refbox/src/app/view_builders/list_selector.rs
@@ -34,6 +34,7 @@ pub(in super::super) fn build_list_selector_page<'a>(
         clock_running,
         teams,
         portal_indicator,
+        has_led_panel: _,
     } = data;
 
     let title = match param {

--- a/refbox/src/app/view_builders/main_view.rs
+++ b/refbox/src/app/view_builders/main_view.rs
@@ -26,6 +26,7 @@ pub(in super::super) fn build_main_view<'a>(
         clock_running,
         teams,
         portal_indicator,
+        has_led_panel: _,
     } = data;
 
     let time_button =

--- a/refbox/src/app/view_data.rs
+++ b/refbox/src/app/view_data.rs
@@ -14,4 +14,8 @@ pub(super) struct ViewData<'a, 'b> {
     /// unlinked); the feature is dormant, the tile is not rendered, and
     /// the time banner falls back to the pre-feature layout.
     pub(super) portal_indicator: Option<PortalIndicatorState>,
+    /// `true` when the refbox was launched with `--serial-port` (real LED
+    /// panel connected). Used to gray out controls that only make sense
+    /// without a real panel — currently just "Open New Display".
+    pub(super) has_led_panel: bool,
 }


### PR DESCRIPTION
## What changed
The new **Open New Display** button (added in #884) is now rendered as a disabled (grayed-out) button when the refbox is launched with `--serial-port` — i.e. when a real LED panel is connected. A defensive check in the message handler also rejects the message with a `warn!` log if it somehow fires despite the gating.

## Why
On a Raspberry Pi at a tournament, the refbox runs with `--serial-port` pointing at the real LED panel. Without this gate, pressing the button on a Pi would spawn a simulator window on the Pi's display that competes with the main refbox window for screen real estate and could mislead an operator into thinking the sim feed is the panel feed. The simulator is a development/testing aid for setups without a real panel — it shouldn't be available when the real panel is present.

This was identified during review of #884 after merge — the original feature shipped without the gate. This PR closes that gap.

## Scope
Changes limited to:
- `refbox/src/app/mod.rs` — capture `has_led_panel = !serial_ports.is_empty()` at startup; defensive check in the `Message::OpenNewDisplay` handler
- `refbox/src/app/view_data.rs` — new `has_led_panel: bool` field on `ViewData`
- `refbox/src/app/view_builders/configuration.rs` — render the button without `on_press` when `has_led_panel == true` (same pattern as the Apply button in `make_cancel_apply_footer`)
- `refbox/src/app/view_builders/{game_info,list_selector,main_view}.rs` — add `has_led_panel: _` to exhaustive `ViewData` destructures so they still compile

No changes to `uwh-common`, wire format, the game state machine, the wireless remote, or any other crate.

## How to verify
**Without a real LED panel (e.g. dev laptop, default refbox launch):**
- Open USER OPTIONS → DISPLAY OPTIONS → button still works as before, spawns new sim windows on each press.

**With a real LED panel (Pi setup, refbox launched with `--serial-port /dev/ttyUSB0` or similar):**
- Open USER OPTIONS → DISPLAY OPTIONS → button is visibly grayed out, doesn't react to taps.
- If the button somehow fires (e.g. unexpected event source), the log shows:
  *"Ignoring OpenNewDisplay: a serial LED panel is connected; simulator windows are disabled in this configuration"*

The no-LED-panel path is smoke-tested in WSL (button stays enabled, all six original verification scenarios from #884 still pass). The LED-panel path could not be smoke-tested in the dev environment (no serial device, `socat` not installed) — the gating uses the same conditional-`on_press` idiom as the existing Apply button in `make_cancel_apply_footer`, so the risk is low, but final visual confirmation should happen on real Pi hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)