### PR TITLE
chore(refbox): don't panic in Drop if a sim child's wait() fails

### DIFF
--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -1059,7 +1059,10 @@ impl Drop for RefBoxApp {
     fn drop(&mut self) {
         for mut child in self.sim_children.drain(..) {
             info!("Waiting for sim child");
-            child.wait().unwrap();
+            // Best-effort: a wait() failure here (e.g. the child was
+            // already reaped) must not panic inside Drop, which would
+            // mask the real shutdown reason.
+            let _ = child.wait();
         }
     }
 }


### PR DESCRIPTION
## What changed
In the `Drop` implementation for `RefBoxApp`, replace `child.wait().unwrap()` with `let _ = child.wait();` for each tracked simulator child. The refbox no longer panics during shutdown if a `wait()` call fails.

## Why
A `wait()` failure during normal shutdown — e.g. the child was already reaped by signal handling, or the OS returned an unexpected error — would cause the refbox process to panic inside `Drop`. Panics in `Drop` are particularly bad because:
1. They abort the shutdown sequence partway through, potentially leaving other resources unreleased.
2. The panic message becomes the user-visible "what happened" instead of the real shutdown reason that was already underway.
3. With the recent open-new-display button work, the refbox can now have many sim children, so the surface area for a `wait()` failure went up.

This was a pre-existing risk that the post-feature code review (`superpowers:requesting-code-review`) flagged on PR #884 as a recommended follow-up. Scoping it to its own branch per `.claude/rules/scope.md`.

## Scope
A single 4-line change in `refbox/src/app/mod.rs` inside the `Drop for RefBoxApp` impl. No other files touched.

## How to verify
- `just check` passes (formatting, lint, tests, audit).
- Manual: launch the refbox, open a few sim windows via Open New Display, then quit. The refbox should shut down cleanly with no panic in the log, same as before.
- Manual (negative path): not directly testable without forcing a `wait()` failure — but the change strictly removes a panic path; it cannot make shutdown worse than before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)