### PR TITLE
chore(refbox): make "open new display" button half width

### DIFF
--- a/refbox/src/app/view_builders/configuration.rs
+++ b/refbox/src/app/view_builders/configuration.rs
@@ -950,17 +950,20 @@ fn make_display_config_page<'a>(
         ]
         .spacing(SPACING)
         .height(Length::Fill),
-        row![{
-            // The button is grayed out (no `on_press`) when a real LED panel
-            // is connected (`--serial-port`). Opening a sim window in that
-            // configuration would compete with the physical display.
-            let btn = make_button(fl!("open-new-display")).style(light_gray_button);
-            if has_led_panel {
-                btn
-            } else {
-                btn.on_press(Message::OpenNewDisplay)
-            }
-        }]
+        row![
+            {
+                // The button is grayed out (no `on_press`) when a real LED panel
+                // is connected (`--serial-port`). Opening a sim window in that
+                // configuration would compete with the physical display.
+                let btn = make_button(fl!("open-new-display")).style(light_gray_button);
+                if has_led_panel {
+                    btn
+                } else {
+                    btn.on_press(Message::OpenNewDisplay)
+                }
+            },
+            horizontal_space(),
+        ]
         .spacing(SPACING)
         .height(Length::Fill),
         row![horizontal_space()].height(Length::Fill),


### PR DESCRIPTION
## What changed
On the Display Options tab, the **Open New Display** button (added in #884) now takes half the row width instead of the full width. An empty `horizontal_space()` fills the right half.

## Why
The other operator-facing buttons on that page — `Hide Time For` and `Player Display Brightness` — sit side-by-side at half width each, which is the established visual rhythm for the Display Options page. The new button was the only full-width button below them, which made it stand out inconsistently.

## Scope
Changes are limited to one block in `refbox/src/app/view_builders/configuration.rs` inside `make_display_config_page`. No new widgets, no new helpers, no new patterns — just an existing `horizontal_space()` added as a second child in the button's row.

## How to verify
- `just check` passes.
- Manually: launch the refbox → USER OPTIONS → DISPLAY OPTIONS → the **OPEN NEW DISPLAY** button now sits in the left half of its row, matching the width of the brightness/hide-time buttons above it. The right half is empty.
- The gating from #892 still applies: the button is still grayed out when `--serial-port` is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)