### PR TITLE
fix(refbox): keep panel-sim TCP open under transient back-pressure

### DIFF
--- a/refbox/src/app/update_sender.rs
+++ b/refbox/src/app/update_sender.rs
@@ -296,9 +296,15 @@ impl WorkerHandle {
 }
 
 fn error_formatter<T: Debug>(old: TrySendError<T>) -> TrySendError<String> {
+    // Preserve the Full vs Closed distinction. A Full channel is a
+    // transient back-pressure signal — the worker is briefly busy and
+    // the next snapshot will get through. A Closed channel is terminal
+    // — the worker has exited and the client connection is gone.
+    // Conflating the two would close live connections under temporary
+    // load (the v0.4.1 Windows + BeepTest panel-sim regression).
     match old {
         TrySendError::Closed(o) => TrySendError::Closed(format!("{o:?}")),
-        TrySendError::Full(o) => TrySendError::Closed(format!("{o:?}")),
+        TrySendError::Full(o) => TrySendError::Full(format!("{o:?}")),
     }
 }
 
@@ -473,11 +479,19 @@ impl Server {
                 self.white_on_right,
                 self.brightness,
             ) {
-                if matches!(e, TrySendError::Closed(_)) {
-                    info!("Worker channel closed");
-                    to_drop.push(*id);
-                } else {
-                    error!("Error sending to worker: {e:?}");
+                match e {
+                    TrySendError::Closed(_) => {
+                        info!("Worker channel closed");
+                        to_drop.push(*id);
+                    }
+                    TrySendError::Full(_) => {
+                        // Back-pressure: the worker hasn't drained yet
+                        // (e.g. the sim is still initialising). Drop
+                        // this snapshot; the next tick re-sends fresh
+                        // state. Keep the handle — the connection is
+                        // still alive.
+                        warn!("Worker channel full, dropping snapshot");
+                    }
                 }
             }
         }
@@ -988,5 +1002,16 @@ mod test {
 
         assert_eq!(expected_binary_bytes, binary_read_so_far);
         assert_eq!(binary_expected, binary_result);
+    }
+
+    #[test]
+    fn error_formatter_preserves_full_vs_closed_variant() {
+        // Treating Full as Closed tears down a live panel-sim TCP
+        // connection whenever the worker briefly can't keep up — root
+        // cause of the v0.4.1 Windows + BeepTest sim regression.
+        let full: TrySendError<i32> = TrySendError::Full(42);
+        let closed: TrySendError<i32> = TrySendError::Closed(99);
+        assert!(matches!(error_formatter(full), TrySendError::Full(_)));
+        assert!(matches!(error_formatter(closed), TrySendError::Closed(_)));
     }
 }

--- a/refbox/src/sim_app/mod.rs
+++ b/refbox/src/sim_app/mod.rs
@@ -1,4 +1,3 @@
-use arrayref::array_ref;
 use iced::{
     Element, Length, Point, Rectangle, Renderer, Size, Subscription, Task, Theme,
     application::Appearance,
@@ -247,19 +246,19 @@ fn snapshot_listener() -> impl futures_lite::Stream<Item = Message> {
 
         if let Some(mut stream) = stream {
             loop {
-                // Make the buffer longer than needed so that we can detect messages that are too long
-                let mut buffer = [0u8; TransmittedData::ENCODED_LEN + 1];
+                // TCP is a byte stream, so a single `read` call may return a
+                // partial message (fragmentation) or part of two messages
+                // (coalescing — observed on Windows under BeepTest's 10 Hz
+                // send rate). `read_exact` over a buffer sized to exactly one
+                // frame waits for the right number of bytes before decoding.
+                let mut buffer = [0u8; TransmittedData::ENCODED_LEN];
 
-                match stream.read(&mut buffer).await {
-                    Ok(val) if val == TransmittedData::ENCODED_LEN => {}
-                    Ok(0) => {
+                match stream.read_exact(&mut buffer).await {
+                    Ok(_) => {}
+                    Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
                         error!("Sim: TCP connection closed, stopping");
                         msg_tx.send(Message::Stop).await.unwrap();
                         break;
-                    }
-                    Ok(val) => {
-                        warn!("Sim: Received message of wrong length: {val}");
-                        continue;
                     }
                     Err(e) => {
                         error!("Sim: TCP error: {e:?}");
@@ -269,11 +268,7 @@ fn snapshot_listener() -> impl futures_lite::Stream<Item = Message> {
                     }
                 }
 
-                let data = match TransmittedData::decode(array_ref![
-                    buffer,
-                    0,
-                    TransmittedData::ENCODED_LEN
-                ]) {
+                let data = match TransmittedData::decode(&buffer) {
                     Ok(val) => val,
                     Err(e) => {
                         warn!("Sim: Decoding error: {e:?}");


### PR DESCRIPTION
## What changed

Two small fixes inside the refbox's panel-simulator data path.

1. **The data-sending pipeline used to drop the connection to the simulator whenever its internal queue briefly filled up**, even though the connection was still healthy. It now correctly distinguishes between *busy* (drop just this one snapshot, the next tick re-sends fresh state) and *gone* (terminate the connection).

2. **The simulator's network reader used to assume each kernel read returned exactly one panel frame.** On Windows that assumption breaks under fast send rates — TCP can coalesce two frames into one read or fragment one frame across reads. The reader now waits for a full frame's worth of bytes before decoding.

## Why

The v0.4.1 Windows zip's BeepTest panel-simulator regression was caused by fix #1.

- BeepTest mode sends snapshots **10 times per second**.
- On Windows, the simulator's renderer takes **~1.5 seconds** to initialize (wgpu/DirectX startup).
- In that window, ~15 snapshots stack up in the parent's send queue.
- The worker channel has capacity 4. The 5th-onwards send returns "Full" (busy).
- The bug treated "Full" as "Closed" (gone) and tore the connection down.
- The sim then saw the closed connection and quit — that's the "sim window opens and closes immediately" symptom from the released Windows zip.

Hockey and Rugby modes don't hit this because they send snapshots only on clock-state changes — at most about one per second when idle. Linux doesn't hit it because its `tiny-skia` renderer initialises instantly, so the sim's first read happens before the queue can fill.

Fix #2 prevents the related "sim opens but stays blank" symptom that's also visible in the Windows logs — `read()` was returning 21 / 19 / 18 bytes (a full frame plus part of the next, then the leftover), neither of which matched the expected 20-byte frame, so the sim dropped every snapshot.

## Scope

Changes are limited to:

- ``refbox/src/app/update_sender.rs`` — distinguish Full vs Closed in the error formatter; drop the handle only on Closed; warn on Full.
- ``refbox/src/sim_app/mod.rs`` — switch the snapshot reader from ``read`` to ``read_exact`` with a buffer sized to exactly one frame.

No changes to ``uwh-common``, wire format, state machines, or the wireless-remote.

## How to verify

**On Linux** (verifiable now, before merge):
- ``just check`` passes (fmt, clippy ``-D warnings``, tests, audit).
- A new unit test in ``update_sender.rs`` (``error_formatter_preserves_full_vs_closed_variant``) fails on master and passes on this branch.
- Existing ``test_update_sender`` and ``binary_port_emits_beep_test_flag_when_constructed_in_beep_test_mode`` integration tests still pass.
- Hockey/Rugby/BeepTest panel sim still works the same on Linux as before.

**On Windows** (verifiable after merge + re-tag + release pipeline rebuild):
- Download the freshly-built Windows ``refbox.zip``.
- Launch ``refbox.exe`` with mode set to BeepTest.
- Expected: the panel-simulator window opens **and stays open**, showing the BeepTest panel content (lap count in the visible score column, time in the centre).
- Then switch to each of Hockey 6V6, Hockey 3V3, and Rugby in turn. Expected: sim window behaves identically to v0.4.0 (still works in all three modes).