### PR TITLE
fix(refbox): make View Mode button half-width on User Options page

### DIFF
--- a/refbox/src/app/view_builders/configuration.rs
+++ b/refbox/src/app/view_builders/configuration.rs
@@ -467,7 +467,9 @@ fn make_user_config_page<'a>(
             portal_indicator
         ),
         tiles,
-        row![view_mode_button].height(Length::Fill),
+        row![view_mode_button, horizontal_space()]
+            .spacing(SPACING)
+            .height(Length::Fill),
         row![horizontal_space()].height(Length::Fill),
         row![horizontal_space()].height(Length::Fill),
         row![


### PR DESCRIPTION
## What changed
On the User Options page, the **VIEW MODE** button is now **half-width** (left half of its row, with empty space to the right), matching the DISPLAY OPTIONS / SOUND OPTIONS tiles and the OPEN NEW DISPLAY button. Previously it spanned the full width.

## Why
Visual consistency — the full-width VIEW MODE button looked out of place beside the half-width tiles on that page.

## Scope
`refbox` crate only — a single layout change in `refbox/src/app/view_builders/configuration.rs` (`make_user_config_page`). **No behaviour change:** VIEW MODE still cycles the display mode (Light → Dark → High Contrast).

## How to verify
1. Open **Options → User Options**.
2. **VIEW MODE** sits in the left half of its row with empty space to the right (like OPEN NEW DISPLAY); it no longer spans the full width.
3. Pressing it still cycles the display mode as before.
4. `just check` passes (fmt, clippy, tests, audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
