### PR TITLE
fix(refbox): disable brightness button when no panel connected

### DIFF
--- a/docs/superpowers/plans/2026-06-05-brightness-button-disable-no-panel.md
+++ b/docs/superpowers/plans/2026-06-05-brightness-button-disable-no-panel.md
@@ -1,0 +1,110 @@
+# Disable Player Display Brightness Button Without Panel — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Grey out the Player Display Brightness button on the display-config settings page when the refbox was started without a real LED panel.
+
+**Architecture:** A single conditional in one view builder. The brightness button's press action becomes `Some(...)` only when `has_led_panel` is true, otherwise `None`. The existing `make_value_button` helper already renders a `None` action as a greyed, non-pressable button that still shows its value.
+
+**Tech Stack:** Rust 2024, `iced` 0.13, project `just` commands.
+
+---
+
+## Spec
+
+See `docs/superpowers/specs/2026-06-05-brightness-button-disable-no-panel-design.md`.
+
+## Process note (testing)
+
+This is a mechanical `refbox` UI change with no new logic and no testable return value — view
+builders return an opaque `iced` `Element`, so there is no clean unit-test seam, and per
+`.claude/rules/plan-execution.md` (lean process) this class of change is verified by
+compilation + `just check` + manual observation rather than an added automated test. No
+behaviour changes when a panel *is* connected.
+
+## File Structure
+
+- Modify: `refbox/src/app/view_builders/configuration.rs` — the brightness button inside
+  `make_display_config_page` (currently ~line 964). `has_led_panel` is already in scope here
+  (the "Open New Display" button below it already uses it).
+
+---
+
+### Task 1: Make the brightness button's action conditional on `has_led_panel`
+
+**Files:**
+- Modify: `refbox/src/app/view_builders/configuration.rs` (~line 1031 on master)
+
+- [ ] **Step 1: Make the edit**
+
+Find this exact block:
+
+```rust
+    let brightness_btn = make_value_button(
+        fl!("player-display-brightness"),
+        fl!("brightness", brightness = brightness.to_string()),
+        (false, true),
+        Some(Message::CycleParameter(CyclingParameter::Brightness)),
+    );
+```
+
+Replace the action argument so it is conditional:
+
+```rust
+    let brightness_btn = make_value_button(
+        fl!("player-display-brightness"),
+        fl!("brightness", brightness = brightness.to_string()),
+        (false, true),
+        if has_led_panel {
+            Some(Message::CycleParameter(CyclingParameter::Brightness))
+        } else {
+            None
+        },
+    );
+```
+
+Note: the condition is the *opposite direction* from the "Open New Display" button just below
+(that one disables when `has_led_panel` is true; brightness disables when it is false). Leave
+"Open New Display" untouched.
+
+- [ ] **Step 2: Build the crate**
+
+Run: `cargo build -p refbox`
+Expected: builds successfully, no errors.
+
+- [ ] **Step 3: Lint (mirrors CI / `just lint` for this bin crate)**
+
+Run: `cargo clippy -p refbox -- -D warnings`
+Expected: no warnings, no errors.
+
+- [ ] **Step 4: Full project check**
+
+Run: `just check`
+Expected: fmt, lint, tests, audit all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add refbox/src/app/view_builders/configuration.rs
+git commit -m "fix(refbox): disable brightness button when no panel connected"
+```
+
+---
+
+## Manual verification (operator-observable)
+
+- Start the refbox normally (no LED panel):
+  - WSL native: `WAYLAND_DISPLAY= cargo run -p refbox`
+  - Open Settings → display page → confirm Player Display Brightness is greyed and does not
+    respond to clicks, but still shows its current level (e.g. "Medium").
+- Start the refbox with a serial port (panel present): `cargo run -p refbox -- --serial-port <port>`
+  - Confirm the same button is fully usable and cycles brightness as before.
+
+## Self-Review
+
+- **Spec coverage:** Spec's single behaviour (disable when no panel, unchanged when panel
+  present, using `has_led_panel`) is implemented by Task 1. No gaps.
+- **Placeholder scan:** None — the full edited code block is shown.
+- **Type consistency:** `has_led_panel: bool`, `Message::CycleParameter(CyclingParameter::Brightness)`,
+  and `make_value_button(label, value, flags, Option<Message>)` all match the existing call site
+  and the neighbouring "Open New Display" usage.

--- a/docs/superpowers/specs/2026-06-05-brightness-button-disable-no-panel-design.md
+++ b/docs/superpowers/specs/2026-06-05-brightness-button-disable-no-panel-design.md
@@ -1,0 +1,80 @@
+# Design: Disable Player Display Brightness button when no panel is connected
+
+Date: 2026-06-05
+Crate: `refbox` (only)
+
+## Problem
+
+The display-config settings page has a **Player Display Brightness** button. Brightness only
+affects the physical LED scoreboard panel. When the refbox is started without a real panel, the
+button does nothing useful, yet it is still pressable. We intended to grey it out in the last
+display-modes PR set, but the change did not land. We want it in before publishing v0.4.2.
+
+## Behaviour
+
+- When the refbox is started **without** a real LED panel, the Player Display Brightness button
+  is greyed out and non-pressable. It still shows the current brightness level (e.g. "Medium")
+  — it just cannot be changed.
+- When the refbox is started **with** a real panel, the button works exactly as it does today.
+
+"Panel connected" uses the existing, settled convention: the `has_led_panel` flag, which is
+`true` when the refbox was launched with `--serial-port`. This is the same signal the
+neighbouring "Open New Display" button already keys off. No new or live detection is added.
+
+## Implementation
+
+Single change, single file: `refbox/src/app/view_builders/configuration.rs`, the
+`brightness_btn` binding in `make_display_config_page` (~line 1031 on master).
+
+Today the button always passes a press action:
+
+```rust
+let brightness_btn = make_value_button(
+    fl!("player-display-brightness"),
+    fl!("brightness", brightness = brightness.to_string()),
+    (false, true),
+    Some(Message::CycleParameter(CyclingParameter::Brightness)),
+);
+```
+
+Make the action conditional on `has_led_panel`:
+
+```rust
+let brightness_btn = make_value_button(
+    fl!("player-display-brightness"),
+    fl!("brightness", brightness = brightness.to_string()),
+    (false, true),
+    if has_led_panel {
+        Some(Message::CycleParameter(CyclingParameter::Brightness))
+    } else {
+        None
+    },
+);
+```
+
+`make_value_button` already renders a `None` action as a greyed-out, non-pressable button that
+still displays its value — the identical idiom used by the disabled-volume buttons on the sound
+page. `has_led_panel` is already in scope in this function (the "Open New Display" block uses it).
+
+Note the condition direction is the *opposite* of "Open New Display": that button is disabled
+when a panel *is* present (it can't open a sim window then); brightness is disabled when a panel
+is *absent*.
+
+## Scope boundary
+
+- Only `refbox`. One file, one button.
+- Not touching `uwh-common`, the wire format, or `wireless-remote`.
+- Not changing brightness behaviour when a panel *is* connected.
+- Not changing any other settings button or the page layout.
+- Not adding live plug/unplug detection.
+
+## How to verify
+
+- Start the refbox normally (no LED panel) → Settings → display page → the Player Display
+  Brightness button is greyed and does not respond to clicks, but still shows its level.
+- Start the refbox with `--serial-port` (real panel) → the same button is fully usable.
+
+## Process note
+
+Lean process (per `.claude/rules/plan-execution.md`): `refbox` UI, low blast radius. Compilation
+plus `just check` is sufficient; no heavy per-task verification ceremony required.

--- a/refbox/src/app/view_builders/configuration.rs
+++ b/refbox/src/app/view_builders/configuration.rs
@@ -1032,7 +1032,11 @@ fn make_display_config_page<'a>(
         fl!("player-display-brightness"),
         fl!("brightness", brightness = brightness.to_string()),
         (false, true),
-        Some(Message::CycleParameter(CyclingParameter::Brightness)),
+        if has_led_panel {
+            Some(Message::CycleParameter(CyclingParameter::Brightness))
+        } else {
+            None
+        },
     );
 
     // The button is grayed out (no `on_press`) when a real LED panel is connected


### PR DESCRIPTION
## What changed
On the Display Options settings page, the **Player Display Brightness** button is now greyed out and unclickable whenever the refbox is started **without** a real LED scoreboard panel connected. It still shows the current brightness level (e.g. "Medium") — it just can't be changed. When a panel **is** connected, the button works exactly as it does today.

## Why
Brightness only affects the physical LED panel. With no panel connected, changing the brightness does nothing, so the button being pressable was misleading. We intended to disable it in the display-modes work but it didn't make it into that PR set; this adds it before v0.4.2 is published.

"Panel connected" uses the existing, settled convention already used by the neighbouring "Open New Display" button: the `has_led_panel` flag, which is true when the refbox was launched with `--serial-port`. No new or live hardware detection is added.

## Scope
Changes are limited to `refbox` — a single conditional on one button in `refbox/src/app/view_builders/configuration.rs`, plus the design spec and plan under `docs/superpowers/`. No changes to `uwh-common`, the wire format, the wireless remote, the brightness behaviour when a panel is present, or any other settings button.

## How to verify
- Start the refbox normally (no LED panel) → open Settings → Display Options → the Player Display Brightness button is greyed and does not respond to clicks, but still shows its level.
- Start the refbox with `--serial-port <port>` (real panel) → the same button is fully usable and cycles brightness as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
