### PR TITLE
fix(refbox): guard next-game time calc against Instant overflow

### DIFF
--- a/refbox/src/tournament_manager/mod.rs
+++ b/refbox/src/tournament_manager/mod.rs
@@ -895,7 +895,9 @@ impl TournamentManager {
                 info!("Calculated time to next game: {time_to_game}");
 
                 match time_to_game.try_into() {
-                    Ok(dur) => Instant::now() + dur,
+                    // Guard against Instant overflow on an absurd scheduled time;
+                    // fall back to `now` (matching the conversion-error arm below).
+                    Ok(dur) => Instant::now().checked_add(dur).unwrap_or(now),
                     Err(e) => {
                         error!("Failed to calculate time to next game start: {e}");
                         now


### PR DESCRIPTION
## What changed
A defensive guard so the refbox can't crash on a nonsensical scheduled game time. The routine that decides how long the break before the next game should last reads the next game's scheduled start; if that value were ever absurd (e.g. a date typo putting a game far in the future), one time calculation (`Instant::now() + dur`) could in theory overflow and panic. It now uses a checked add that falls back to "now" instead — mirroring the fallback already used in the same function when the conversion fails. Real tournament times are completely unaffected.

## Why
Pre-existing latent issue in `calc_time_to_next_game`. It sits in the clock-driving path (it sets the between-games countdown), so a crash there would be disruptive. It was surfaced during the behind-schedule review and kept on its own branch because it's independent of that feature.

## Scope
One line (plus a comment) in `refbox/src/tournament_manager/mod.rs`. No behaviour change for any valid scheduled time.

## How to verify
This is a purely defensive, internal change with **no observable effect on valid data** — so there is no new visible behaviour and no new test (a panic cannot be triggered with any realistic `OffsetDateTime` on the target platforms; constructing one that overflows `Instant` isn't portably possible). It is still worth doing because the figure feeds the clock-driving break and is now operator-visible via the behind-schedule indicator. Verified by `just check` (fmt, lint, all tests, audit) passing green, and by the change matching the existing conversion-error fallback in the same function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
