### PR TITLE
feat(refbox): move length-parameter help text to a dedicated page

### DIFF
--- a/refbox/src/app/message.rs
+++ b/refbox/src/app/message.rs
@@ -108,6 +108,8 @@ pub enum Message {
     PortalGoToLogin,
     RequestPortalRefresh,
     ShowWarnings,
+    ShowParameterHelp,
+    CloseParameterHelp,
     EditGameConfig,
     ChangeConfigPage(ConfigPage),
     ApplyConfigPage(ConfigPage),
@@ -287,6 +289,8 @@ impl Message {
             | Self::PortalGoToLogin
             | Self::RequestPortalRefresh
             | Self::ShowWarnings
+            | Self::ShowParameterHelp
+            | Self::CloseParameterHelp
             | Self::EditGameConfig
             | Self::ChangeConfigPage(_)
             | Self::ApplyConfigPage(_)
@@ -361,6 +365,8 @@ impl PartialEq for Message {
             | (Self::PortalGoToLogin, Self::PortalGoToLogin)
             | (Self::RequestPortalRefresh, Self::RequestPortalRefresh)
             | (Self::ShowWarnings, Self::ShowWarnings)
+            | (Self::ShowParameterHelp, Self::ShowParameterHelp)
+            | (Self::CloseParameterHelp, Self::CloseParameterHelp)
             | (Self::EditGameConfig, Self::EditGameConfig)
             | (Self::ConfigEditComplete, Self::ConfigEditComplete)
             | (Self::RequestRemoteId, Self::RequestRemoteId)
@@ -563,6 +569,8 @@ impl PartialEq for Message {
             | (Self::PortalGoToLogin, _)
             | (Self::RequestPortalRefresh, _)
             | (Self::ShowWarnings, _)
+            | (Self::ShowParameterHelp, _)
+            | (Self::CloseParameterHelp, _)
             | (Self::EditGameConfig, _)
             | (Self::ChangeConfigPage(_), _)
             | (Self::ApplyConfigPage(_), _)

--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -193,6 +193,7 @@ enum AppState {
     // LengthParameter::Half (the 2 Halves / 1 Period selector). Carried here so
     // it commits on Done and is discarded on Cancel, like the edited Duration.
     ParameterEditor(LengthParameter, Duration, bool),
+    ParameterEditorHelp(LengthParameter, Duration, bool),
     ParameterList(ListableParameter, usize),
     ConfirmationPage(ConfirmationKind),
     ConfirmScores(BlackWhiteBundle<u8>),
@@ -2394,6 +2395,20 @@ impl RefBoxApp {
                 trace!("AppState changed to {:?}", self.app_state);
                 Task::none()
             }
+            Message::ShowParameterHelp => {
+                if let AppState::ParameterEditor(param, dur, single_half) = self.app_state {
+                    self.app_state = AppState::ParameterEditorHelp(param, dur, single_half);
+                    trace!("AppState changed to {:?}", self.app_state);
+                }
+                Task::none()
+            }
+            Message::CloseParameterHelp => {
+                if let AppState::ParameterEditorHelp(param, dur, single_half) = self.app_state {
+                    self.app_state = AppState::ParameterEditor(param, dur, single_half);
+                    trace!("AppState changed to {:?}", self.app_state);
+                }
+                Task::none()
+            }
             Message::SelectParameter(param) => {
                 let index = match param {
                     ListableParameter::Event => Some(0),
@@ -3863,6 +3878,9 @@ impl RefBoxApp {
                     .as_ref()
                     .map_or(&self.config.game, |s| &s.config),
             ),
+            AppState::ParameterEditorHelp(param, dur, single_half) => {
+                build_parameter_help_page(data, param, dur, single_half)
+            }
             AppState::ParameterList(param, index) => build_list_selector_page(
                 data,
                 param,

--- a/refbox/src/app/view_builders/configuration.rs
+++ b/refbox/src/app/view_builders/configuration.rs
@@ -1418,28 +1418,21 @@ pub(in super::super) fn build_game_parameter_editor<'a>(
         ..
     } = data;
 
-    let (title, hint) = match param {
-        LengthParameter::Half => (
+    let title = match param {
+        LengthParameter::Half => {
             if single_half {
                 fl!("game-len")
             } else {
                 fl!("half-length")
-            },
-            if single_half {
-                fl!("length-of-game-during-regular-play")
-            } else {
-                fl!("length-of-half-during-regular-play")
-            },
-        ),
-        LengthParameter::HalfTime => (fl!("half-time-lenght"), fl!("length-of-half-time-period")),
-        LengthParameter::GameBlock => (fl!("game-block"), fl!("game-block-help")),
-        LengthParameter::MinimumBetweenGame => (fl!("min-break"), fl!("min-time-btwn-games")),
-        LengthParameter::PreOvertime => (fl!("pre-ot-break-abreviated"), fl!("pre-sd-brk")),
-        LengthParameter::OvertimeHalf => (fl!("ot-half-len"), fl!("time-during-ot")),
-        LengthParameter::OvertimeHalfTime => {
-            (fl!("ot-half-tm-len"), fl!("len-of-overtime-halftime"))
+            }
         }
-        LengthParameter::PreSuddenDeath => (fl!("pre-sd-break"), fl!("pre-sd-len")),
+        LengthParameter::HalfTime => fl!("half-time-lenght"),
+        LengthParameter::GameBlock => fl!("game-block"),
+        LengthParameter::MinimumBetweenGame => fl!("min-break"),
+        LengthParameter::PreOvertime => fl!("pre-ot-break-abreviated"),
+        LengthParameter::OvertimeHalf => fl!("ot-half-len"),
+        LengthParameter::OvertimeHalfTime => fl!("ot-half-tm-len"),
+        LengthParameter::PreSuddenDeath => fl!("pre-sd-break"),
     };
 
     // Live Game Block validation: build a staged copy of the config with the
@@ -1539,15 +1532,27 @@ pub(in super::super) fn build_game_parameter_editor<'a>(
         col = col.push(selector);
     }
 
+    let help_button = make_small_button("?", MEDIUM_TEXT)
+        .style(blue_button)
+        .on_press(Message::ShowParameterHelp);
+
+    // Time editor stays centred between two balancing spacers; the ? button sits
+    // top-right (its width matched by the fixed-width spacer on the left), and
+    // align_y(Top) pins it to the top of the row.
+    let editor_row = row![
+        horizontal_space().width(Length::Fixed(MIN_BUTTON_SIZE)),
+        horizontal_space(),
+        make_time_editor(title, length, false, value_color),
+        horizontal_space(),
+        help_button,
+    ]
+    .spacing(SPACING)
+    .align_y(Vertical::Top);
+
     col = col
         .push(vertical_space())
-        .push(make_time_editor(title, length, false, value_color))
-        .push(vertical_space())
-        .push(
-            text(fl!("help") + &hint)
-                .size(SMALL_TEXT)
-                .align_x(Horizontal::Center),
-        );
+        .push(editor_row)
+        .push(vertical_space());
 
     if let Some(note) = validity_note {
         col = col.push(note);
@@ -1572,6 +1577,74 @@ pub(in super::super) fn build_game_parameter_editor<'a>(
             .spacing(SPACING),
         )
         .into()
+}
+
+pub(in super::super) fn build_parameter_help_page<'a>(
+    data: ViewData<'_, '_>,
+    param: LengthParameter,
+    _length: Duration,
+    single_half: bool,
+) -> Element<'a, Message> {
+    let ViewData {
+        snapshot,
+        mode,
+        clock_running,
+        portal_indicator,
+        ..
+    } = data;
+
+    // Title reuses the editor's short, already-translated label; body is the
+    // existing hint string. No new translation keys are introduced.
+    let (title, body) = match param {
+        LengthParameter::Half => (
+            if single_half {
+                fl!("game-len")
+            } else {
+                fl!("half-length")
+            },
+            if single_half {
+                fl!("length-of-game-during-regular-play")
+            } else {
+                fl!("length-of-half-during-regular-play")
+            },
+        ),
+        LengthParameter::HalfTime => (fl!("half-time-lenght"), fl!("length-of-half-time-period")),
+        LengthParameter::GameBlock => (fl!("game-block"), fl!("game-block-help")),
+        LengthParameter::MinimumBetweenGame => (fl!("min-break"), fl!("min-time-btwn-games")),
+        LengthParameter::PreOvertime => (fl!("pre-ot-break-abreviated"), fl!("pre-sd-brk")),
+        LengthParameter::OvertimeHalf => (fl!("ot-half-len"), fl!("time-during-ot")),
+        LengthParameter::OvertimeHalfTime => {
+            (fl!("ot-half-tm-len"), fl!("len-of-overtime-halftime"))
+        }
+        LengthParameter::PreSuddenDeath => (fl!("pre-sd-break"), fl!("pre-sd-len")),
+    };
+    let body = body.replace('\n', " ");
+
+    column![
+        make_game_time_button(
+            snapshot,
+            false,
+            false,
+            mode,
+            clock_running,
+            portal_indicator,
+            None
+        ),
+        container(text(title).size(MEDIUM_TEXT)).center_x(Length::Fill),
+        text(body).size(SMALL_TEXT).width(Length::Fill),
+        vertical_space(),
+        row![
+            make_button(fl!("back"))
+                .style(red_button)
+                .width(Length::Fill)
+                .on_press(Message::CloseParameterHelp),
+            horizontal_space(),
+            horizontal_space(),
+        ]
+        .spacing(SPACING),
+    ]
+    .spacing(SPACING)
+    .into()
 }
 
 fn font_family_id(lang: Language) -> u8 {


### PR DESCRIPTION
## What changed
On each length-parameter edit screen (Half Length, Game Block, Half Time, Minimum Break, the overtime/sudden-death breaks, etc.), the block of "HELP:" explanation text that used to sit between the time keypad and the Cancel/Done buttons has been moved off that screen. In its place is a small blue **?** button in the top-right corner. Tapping it opens a dedicated help page that shows the same explanation with a red **BACK** button; BACK returns to the exact editor you left, with your value and your 2 Halves / 1 Period choice unchanged.

The 2 Halves / 1 Period selector and the Game Block live validation (red value + disabled Done when too short, plus the "too short"/"tight" note) are unchanged.

## Why
When the help text was long — which happens most in longer-running languages like German and Italian — it wrapped onto several lines and pushed the Cancel and Done buttons off the bottom of the screen, making the editor impossible to use without restarting. First observed on the Nominal Break screen (now Game Block). Putting the help on its own page means the editor's height no longer depends on how long the translated help string is, so Cancel/Done always stay on-screen. (This realises the design recorded in ADR 007.)

No new wording and no new translations were needed — the help page reuses titles and explanation text that already exist in all 15 languages.

## Scope
Changes are limited to the `refbox` crate, three files:
- `refbox/src/app/message.rs` — two new actions (open/close the help page)
- `refbox/src/app/mod.rs` — a new screen state and its open/close handling
- `refbox/src/app/view_builders/configuration.rs` — the editor's ? button and the new help page

No `uwh-common`, no wire format, no other crate. No new dependencies. No translation files changed.

## How to verify
1. Game Options → tap **Half Length**. The editor shows the keypad with a small blue **?** top-right, and Cancel/Done both visible. The old inline "HELP:" line is gone.
2. The **2 HALVES / 1 PERIOD** selector still appears and toggles.
3. Tap **?** → the help page opens (title, explanation, red BACK). Nothing overflows.
4. Tap **BACK** → returns to the same editor, same value, same 2 Halves / 1 Period choice.
5. Switch language to **German** or **Italian**, repeat on **Game Block** (longest help text) → Cancel/Done stay on-screen throughout.
6. On the **Game Block** editor, confirm a too-short value still turns the number red, disables Done, and shows the "too short"/"tight" note.
7. Change a value and tap **Done** → it saves as before.

Automated checks on the branch: `cargo build -p refbox`, `cargo clippy -p refbox -- -D warnings`, `cargo fmt --all --check`, and `cargo test -p refbox` (226 tests) all pass.
