### PR TITLE
fix(refbox): preserve CLI args on in-app restart

### DIFF
--- a/refbox/src/app/update_sender.rs
+++ b/refbox/src/app/update_sender.rs
@@ -21,6 +21,22 @@ use tokio::{
 use tokio_serial::{SerialPortBuilder, SerialPortBuilderExt, SerialStream};
 use uwh_common::game_snapshot::{EncodingError, GamePeriod, GameSnapshot, GameSnapshotNoHeap};
 
+/// Open each serial port, skipping (and logging) any that fail to open instead
+/// of panicking. A missing or still-held port simply means the LED panel is
+/// unavailable — it must never crash startup or a restart.
+fn open_serial_ports(builders: Vec<SerialPortBuilder>) -> Vec<SerialStream> {
+    builders
+        .into_iter()
+        .filter_map(|builder| match builder.open_native_async() {
+            Ok(port) => Some(port),
+            Err(e) => {
+                error!("Failed to open serial port; the LED panel will be unavailable: {e}");
+                None
+            }
+        })
+        .collect()
+}
+
 const TIMEOUT: Duration = Duration::from_millis(500);
 const SERIAL_SEND_SPACING: Duration = Duration::from_millis(100);
 const WORKER_CHANNEL_LEN: usize = 4;
@@ -45,10 +61,7 @@ impl UpdateSender {
     ) -> Self {
         let (tx, rx) = mpsc::channel(8);
 
-        let initial = initial
-            .into_iter()
-            .map(|builder| builder.open_native_async().unwrap())
-            .collect();
+        let initial = open_serial_ports(initial);
 
         let server_join =
             task::spawn(Server::new(rx, initial, hide_time, beep_test, initial_layout).run_loop());
@@ -1057,5 +1070,21 @@ mod test {
         let closed: TrySendError<i32> = TrySendError::Closed(99);
         assert!(matches!(error_formatter(full), TrySendError::Full(_)));
         assert!(matches!(error_formatter(closed), TrySendError::Closed(_)));
+    }
+
+    #[tokio::test]
+    async fn open_serial_ports_skips_ports_that_fail_to_open() {
+        let bad = tokio_serial::new("/dev/refbox_nonexistent_test_port", 115200);
+        let opened = open_serial_ports(vec![bad]);
+        assert!(
+            opened.is_empty(),
+            "an unopenable port must be skipped, not panic"
+        );
+    }
+
+    #[tokio::test]
+    async fn open_serial_ports_empty_input_is_empty() {
+        let opened = open_serial_ports(Vec::new());
+        assert!(opened.is_empty());
     }
 }

--- a/refbox/src/main.rs
+++ b/refbox/src/main.rs
@@ -596,7 +596,11 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         match std::env::current_exe() {
             Ok(exe) => {
                 info!("Restart requested: respawning {exe:?} with args {restart_argv:?}");
-                if let Err(e) = std::process::Command::new(exe).args(&restart_argv).spawn() {
+                if let Err(e) = std::process::Command::new(exe)
+                    .args(&restart_argv)
+                    .stdin(Stdio::null())
+                    .spawn()
+                {
                     error!("Failed to respawn refbox on restart: {e}");
                 }
             }
@@ -652,10 +656,17 @@ mod restart_argv_tests {
     }
 
     #[test]
-    fn never_replays_language_or_is_simulator() {
-        let argv = argv_from(&["--language", "fr", "--is-simulator"]);
+    fn never_replays_language_is_simulator_or_capture_previews() {
+        let argv = argv_from(&[
+            "--language",
+            "fr",
+            "--is-simulator",
+            "--capture-previews",
+            "/tmp/previews",
+        ]);
         assert!(!argv.contains(&"--language".to_string()));
         assert!(!argv.contains(&"--is-simulator".to_string()));
+        assert!(!argv.contains(&"--capture-previews".to_string()));
     }
 
     #[test]

--- a/refbox/src/main.rs
+++ b/refbox/src/main.rs
@@ -227,9 +227,6 @@ pub fn build_sim_argv(config: &SimSpawnConfig) -> Vec<String> {
 ///  - `--is-simulator`: this relaunches the main app, never a simulator child.
 ///  - `--capture-previews`: a dev-only flag that renders preview PNGs and exits
 ///    immediately; replaying it would make the restarted process exit at once.
-///
-/// NOTE: wired into `main()` in the Task 2 commit.
-#[allow(dead_code)]
 pub(crate) fn build_restart_argv(args: &Cli) -> Vec<String> {
     let mut argv: Vec<String> = Vec::new();
 
@@ -293,6 +290,10 @@ pub(crate) fn spawn_sim_child(config: &SimSpawnConfig) -> std::io::Result<std::p
 
 fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let args = Cli::parse();
+
+    // Capture the argv needed to relaunch this same configuration on an in-app
+    // restart, before any field of `args` is moved below.
+    let restart_argv = build_restart_argv(&args);
 
     if let Some(lang) = args.language {
         *LANGUAGE_OVERRIDE.lock().unwrap() = Some(lang);
@@ -592,8 +593,14 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // a clean slate without overlapping the old windows. See
     // `app::RESTART_PENDING` for the trigger sites.
     if app::RESTART_PENDING.load(std::sync::atomic::Ordering::Relaxed) {
-        if let Ok(exe) = std::env::current_exe() {
-            let _ = std::process::Command::new(exe).spawn();
+        match std::env::current_exe() {
+            Ok(exe) => {
+                info!("Restart requested: respawning {exe:?} with args {restart_argv:?}");
+                if let Err(e) = std::process::Command::new(exe).args(&restart_argv).spawn() {
+                    error!("Failed to respawn refbox on restart: {e}");
+                }
+            }
+            Err(e) => error!("Failed to locate current exe for restart respawn: {e}"),
         }
     }
 

--- a/refbox/src/main.rs
+++ b/refbox/src/main.rs
@@ -216,6 +216,71 @@ pub fn build_sim_argv(config: &SimSpawnConfig) -> Vec<String> {
     args
 }
 
+/// Build the argv used to relaunch the MAIN app on an in-app restart so the new
+/// process inherits the same command-line settings the operator started with
+/// (fullscreen, serial/LED-panel port, real-hardware mode, ports, logging).
+///
+/// Deliberately NOT replayed:
+///  - `--language`: a restart is often triggered BY a language change. The new
+///    language is persisted to the config file and must drive startup; replaying
+///    the old `--language` would override it.
+///  - `--is-simulator`: this relaunches the main app, never a simulator child.
+///  - `--capture-previews`: a dev-only flag that renders preview PNGs and exits
+///    immediately; replaying it would make the restarted process exit at once.
+///
+/// NOTE: wired into `main()` in the Task 2 commit.
+#[allow(dead_code)]
+pub(crate) fn build_restart_argv(args: &Cli) -> Vec<String> {
+    let mut argv: Vec<String> = Vec::new();
+
+    if args.no_simulate {
+        argv.push("--no-simulate".to_string());
+    }
+    for _ in 0..args.verbose {
+        argv.push("--verbose".to_string());
+    }
+    argv.push("--scale".to_string());
+    argv.push(args.scale.to_string());
+    if let Some(spacing) = args.spacing {
+        argv.push("--spacing".to_string());
+        argv.push(spacing.to_string());
+    }
+    if args.fullscreen {
+        argv.push("--fullscreen".to_string());
+    }
+    argv.push("--binary-port".to_string());
+    argv.push(args.binary_port.to_string());
+    argv.push("--json-port".to_string());
+    argv.push(args.json_port.to_string());
+    if let Some(port) = &args.serial_port {
+        argv.push("--serial-port".to_string());
+        argv.push(port.clone());
+        argv.push("--baud-rate".to_string());
+        argv.push(args.baud_rate.to_string());
+    }
+    if args.allow_http {
+        argv.push("--allow-http".to_string());
+    }
+    if args.all_events {
+        argv.push("--all-events".to_string());
+    }
+    if let Some(loc) = &args.log_location {
+        argv.push("--log-location".to_string());
+        // Matches the original main.rs behaviour and `build_sim_argv`. A
+        // non-UTF-8 log path would already have panicked at startup before here.
+        argv.push(loc.to_str().unwrap().to_string());
+    }
+    argv.push("--log-max-file-size".to_string());
+    argv.push(args.log_max_file_size.to_string());
+    argv.push("--num-old-logs".to_string());
+    argv.push(args.num_old_logs.to_string());
+    if args.simulate_sunlight_display {
+        argv.push("--simulate-sunlight-display".to_string());
+    }
+
+    argv
+}
+
 pub(crate) fn spawn_sim_child(config: &SimSpawnConfig) -> std::io::Result<std::process::Child> {
     let bin_name = std::env::current_exe()?.into_os_string();
     let argv = build_sim_argv(config);
@@ -533,6 +598,66 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     }
 
     result.map_err(|e| e.into())
+}
+
+#[cfg(test)]
+mod restart_argv_tests {
+    use super::*;
+
+    fn argv_from(extra: &[&str]) -> Vec<String> {
+        let mut argv = vec!["refbox"];
+        argv.extend_from_slice(extra);
+        let cli = Cli::parse_from(argv);
+        build_restart_argv(&cli)
+    }
+
+    #[test]
+    fn replays_fullscreen_only_when_set() {
+        assert!(argv_from(&["--fullscreen"]).contains(&"--fullscreen".to_string()));
+        assert!(!argv_from(&[]).contains(&"--fullscreen".to_string()));
+    }
+
+    #[test]
+    fn replays_serial_port_and_baud_when_set() {
+        let argv = argv_from(&["--serial-port", "/dev/ttyUSB0", "--baud-rate", "57600"]);
+        assert!(argv.contains(&"--serial-port".to_string()));
+        assert!(argv.contains(&"/dev/ttyUSB0".to_string()));
+        assert!(argv.contains(&"--baud-rate".to_string()));
+        assert!(argv.contains(&"57600".to_string()));
+    }
+
+    #[test]
+    fn omits_serial_port_when_not_set() {
+        let argv = argv_from(&[]);
+        assert!(!argv.contains(&"--serial-port".to_string()));
+    }
+
+    #[test]
+    fn replays_no_simulate_when_set() {
+        assert!(argv_from(&["--no-simulate"]).contains(&"--no-simulate".to_string()));
+        assert!(!argv_from(&[]).contains(&"--no-simulate".to_string()));
+    }
+
+    #[test]
+    fn repeats_verbose_per_count() {
+        let argv = argv_from(&["-v", "-v"]);
+        assert_eq!(argv.iter().filter(|a| a.as_str() == "--verbose").count(), 2);
+    }
+
+    #[test]
+    fn never_replays_language_or_is_simulator() {
+        let argv = argv_from(&["--language", "fr", "--is-simulator"]);
+        assert!(!argv.contains(&"--language".to_string()));
+        assert!(!argv.contains(&"--is-simulator".to_string()));
+    }
+
+    #[test]
+    fn replays_log_location_when_set_and_omits_when_unset() {
+        let argv = argv_from(&["--log-location", "/tmp/test-logs"]);
+        assert!(argv.contains(&"--log-location".to_string()));
+        assert!(argv.contains(&"/tmp/test-logs".to_string()));
+        assert!(!argv_from(&[]).contains(&"--log-location".to_string()));
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What changed

When the refbox restarts itself from inside the app (after a language change, an app-mode change, or the equivalent BeepTest changes), it now relaunches with **the same start-up settings it was originally given** — full-screen, the LED-panel serial port, real-hardware mode, the network ports, and the log location.

Previously, an in-app restart relaunched the program with **no settings at all**, so on a Raspberry Pi it would come back **windowed, with no LED-panel connection, and in simulation mode**. This PR fixes that. It also:

- Logs the restart (and any failure to relaunch) instead of silently leaving no running app.
- Stops the app from crashing on start-up if the LED-panel serial port is missing or briefly busy — it now logs and carries on (the panel simply reconnects), which also lets a restart survive the moment when the old copy is still releasing the port.

The new language deliberately still wins after a language-change restart (the new language is read from the saved settings; the old `--language` is intentionally not replayed).

## Why

This repairs a real, latent problem in the **already-shipped** in-app restarts (language and mode changes): on a tournament Pi they would currently come back without the scoreboard and not full-screen. It is also the prerequisite for the planned in-app self-update feature, which relies on a restart that faithfully comes back the way it was launched.

## Scope

`refbox` crate only — two files:
- `refbox/src/main.rs` (reconstruct the start-up settings and use them on restart; log failures)
- `refbox/src/app/update_sender.rs` (don't crash if a serial port can't be opened)

No changes to `uwh-common`, the wire format, or any other crate.

## How to verify

- **Automated:** `cargo test -p refbox` — 238 pass (8 new tests covering the settings reconstruction and the graceful serial-port handling). `cargo clippy -p refbox -- -D warnings` is clean.
- **On hardware (the important one):** on a spare Raspberry Pi wired like a tournament Pi, launch the refbox the normal way (full-screen, scoreboard, real-hardware mode), then change the language to one with a different font (forcing a restart). Confirm the app comes back **full-screen, with the scoreboard reconnected and the buzzer working**, and the logs continue in the same place. Full steps: `docs/superpowers/specs/2026-06-10-refbox-self-update-hardware-test-script.md` (Test A).

> Note: this is dev-tested and review-clean, but the restart path has never run at a real event, so the spare-Pi smoke test above should be completed before relying on it at a tournament.
