### PR TITLE
fix(refbox): harden restart resilience (serial/TCP retry, bounded sound shutdown, drift guard)

### DIFF
--- a/refbox/src/app/update_sender.rs
+++ b/refbox/src/app/update_sender.rs
@@ -16,7 +16,7 @@ use tokio::{
     select,
     sync::mpsc::{self, error::TrySendError},
     task::{self, JoinHandle},
-    time::{Duration, Instant, sleep_until, timeout},
+    time::{Duration, Instant, sleep, sleep_until, timeout},
 };
 use tokio_serial::{SerialPortBuilder, SerialPortBuilderExt, SerialStream};
 use uwh_common::game_snapshot::{EncodingError, GamePeriod, GameSnapshot, GameSnapshotNoHeap};
@@ -667,22 +667,61 @@ impl Drop for Server {
     }
 }
 
+/// Time budget + initial backoff for retrying a transient (port-in-use) bind.
+/// 🔧 PI: confirm/tune on the spare Pi during the 5×-restart test.
+const TCP_BIND_RETRY_BUDGET: Duration = Duration::from_millis(2000);
+const TCP_BIND_RETRY_INITIAL: Duration = Duration::from_millis(100);
+
+/// A bind failure is worth retrying only when the address is momentarily still
+/// in use (e.g. held by the exiting process during a restart).
+fn is_transient_bind_error(e: &io::Error) -> bool {
+    matches!(e.kind(), std::io::ErrorKind::AddrInUse)
+}
+
+/// Bind a TCP listener, retrying an `AddrInUse` failure within `budget` (with
+/// exponential backoff from `initial`) before giving up and returning `None`.
+/// Any non-transient error gives up immediately. Never panics.
+async fn bind_with_retry(
+    addr: (&str, u16),
+    label: &str,
+    budget: Duration,
+    initial: Duration,
+) -> Option<TcpListener> {
+    let deadline = Instant::now() + budget;
+    let mut backoff = initial;
+    loop {
+        match TcpListener::bind(addr).await {
+            Ok(listener) => return Some(listener),
+            Err(e) => {
+                if is_transient_bind_error(&e) && Instant::now() < deadline {
+                    warn!("{label} port {} in use, retrying in {backoff:?}", addr.1);
+                    sleep(backoff).await;
+                    backoff = (backoff * 2).min(budget);
+                    continue;
+                }
+                error!("Failed to bind {label} port {}: {e:?}", addr.1);
+                return None;
+            }
+        }
+    }
+}
+
 async fn listener_loop(tx: mpsc::Sender<ServerMessage>, binary_port: u16, json_port: u16) {
     info!("Starting Listeners for JSON (port {json_port}) and binary (port {binary_port})");
-    let binary_listener_v6 = match TcpListener::bind(("::", binary_port)).await {
-        Ok(listener) => Some(listener),
-        Err(e) => {
-            error!("Failed to bind to binary port {binary_port}: {e:?}");
-            None
-        }
-    };
-    let json_listener_v6 = match TcpListener::bind(("::", json_port)).await {
-        Ok(listener) => Some(listener),
-        Err(e) => {
-            error!("Failed to bind to JSON port {json_port}: {e:?}");
-            None
-        }
-    };
+    let binary_listener_v6 = bind_with_retry(
+        ("::", binary_port),
+        "binary",
+        TCP_BIND_RETRY_BUDGET,
+        TCP_BIND_RETRY_INITIAL,
+    )
+    .await;
+    let json_listener_v6 = bind_with_retry(
+        ("::", json_port),
+        "JSON",
+        TCP_BIND_RETRY_BUDGET,
+        TCP_BIND_RETRY_INITIAL,
+    )
+    .await;
 
     // On some OSs, we must separately listen on IPv4, but on other OSs that
     // that isn't allowed, so we just try to listen on IPv4
@@ -1140,5 +1179,40 @@ mod test {
         // An absent / unknown device must be skipped immediately, not retried.
         let absent = SerialError::new(SerialErrorKind::NoDevice, "no device");
         assert!(!is_transient_serial_error(&absent));
+    }
+
+    #[test]
+    fn transient_bind_error_only_for_addr_in_use() {
+        assert!(is_transient_bind_error(&std::io::Error::from(
+            std::io::ErrorKind::AddrInUse
+        )));
+        assert!(!is_transient_bind_error(&std::io::Error::from(
+            std::io::ErrorKind::PermissionDenied
+        )));
+    }
+
+    #[tokio::test]
+    async fn bind_with_retry_gives_up_on_held_port_within_budget() {
+        // Hold an ephemeral port, then try to bind it again: the second bind
+        // fails AddrInUse, so bind_with_retry must retry then give up (None)
+        // within roughly its budget — never hang or panic.
+        let held = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let port = held.local_addr().unwrap().port();
+        let start = Instant::now();
+        let result = bind_with_retry(
+            ("127.0.0.1", port),
+            "test",
+            Duration::from_millis(150),
+            Duration::from_millis(50),
+        )
+        .await;
+        assert!(
+            result.is_none(),
+            "a held port must yield None, not a listener"
+        );
+        assert!(
+            start.elapsed() < Duration::from_secs(1),
+            "must give up within roughly the budget"
+        );
     }
 }

--- a/refbox/src/app/update_sender.rs
+++ b/refbox/src/app/update_sender.rs
@@ -21,19 +21,59 @@ use tokio::{
 use tokio_serial::{SerialPortBuilder, SerialPortBuilderExt, SerialStream};
 use uwh_common::game_snapshot::{EncodingError, GamePeriod, GameSnapshot, GameSnapshotNoHeap};
 
-/// Open each serial port, skipping (and logging) any that fail to open instead
-/// of panicking. A missing or still-held port simply means the LED panel is
-/// unavailable — it must never crash startup or a restart.
+/// Total time budget for retrying a *transient* serial-open failure, plus the
+/// initial backoff step (doubled each attempt, capped by the budget). Sized for
+/// the brief window during a restart where the exiting process is still
+/// releasing the port.
+/// 🔧 PI: confirm/tune on the spare Pi during the 5×-restart test.
+const SERIAL_OPEN_RETRY_BUDGET: Duration = Duration::from_millis(2000);
+const SERIAL_OPEN_RETRY_INITIAL: Duration = Duration::from_millis(100);
+
+/// Whether a serial-open error is worth retrying. `true` for a device that
+/// exists but is momentarily unavailable (e.g. still held by the exiting
+/// process during a restart); `false` for an absent/misconfigured device, which
+/// would only delay startup if retried.
+/// 🔧 PI: if a briefly-held port on the Pi surfaces a different `ErrorKind`,
+/// widen this allowlist (this is the single place to tune it).
+fn is_transient_serial_error(e: &tokio_serial::Error) -> bool {
+    use tokio_serial::ErrorKind;
+    matches!(
+        e.kind(),
+        ErrorKind::Io(std::io::ErrorKind::PermissionDenied)
+            | ErrorKind::Io(std::io::ErrorKind::WouldBlock)
+            | ErrorKind::Io(std::io::ErrorKind::TimedOut)
+    )
+}
+
+/// Open one serial port, retrying transient failures within a bounded budget,
+/// and skipping (logging) a permanent failure instead of panicking. A missing
+/// or unopenable port simply means the LED panel is unavailable — it must never
+/// crash startup or a restart.
+fn open_one_serial_port_with_retry(builder: SerialPortBuilder) -> Option<SerialStream> {
+    let deadline = std::time::Instant::now() + SERIAL_OPEN_RETRY_BUDGET;
+    let mut backoff = SERIAL_OPEN_RETRY_INITIAL;
+    loop {
+        match builder.clone().open_native_async() {
+            Ok(port) => return Some(port),
+            Err(e) => {
+                if is_transient_serial_error(&e) && std::time::Instant::now() < deadline {
+                    warn!("Serial port busy, retrying in {backoff:?}: {e}");
+                    std::thread::sleep(backoff);
+                    backoff = (backoff * 2).min(SERIAL_OPEN_RETRY_BUDGET);
+                    continue;
+                }
+                error!("Failed to open serial port; the LED panel will be unavailable: {e}");
+                return None;
+            }
+        }
+    }
+}
+
+/// Open each serial port (see `open_one_serial_port_with_retry`).
 fn open_serial_ports(builders: Vec<SerialPortBuilder>) -> Vec<SerialStream> {
     builders
         .into_iter()
-        .filter_map(|builder| match builder.open_native_async() {
-            Ok(port) => Some(port),
-            Err(e) => {
-                error!("Failed to open serial port; the LED panel will be unavailable: {e}");
-                None
-            }
-        })
+        .filter_map(open_one_serial_port_with_retry)
         .collect()
 }
 
@@ -1086,5 +1126,19 @@ mod test {
     async fn open_serial_ports_empty_input_is_empty() {
         let opened = open_serial_ports(Vec::new());
         assert!(opened.is_empty());
+    }
+
+    #[test]
+    fn transient_serial_error_retries_busy_but_not_absent() {
+        use tokio_serial::{Error as SerialError, ErrorKind as SerialErrorKind};
+        // A momentarily-held port (typical during a restart) is worth retrying.
+        let busy = SerialError::new(
+            SerialErrorKind::Io(std::io::ErrorKind::PermissionDenied),
+            "busy",
+        );
+        assert!(is_transient_serial_error(&busy));
+        // An absent / unknown device must be skipped immediately, not retried.
+        let absent = SerialError::new(SerialErrorKind::NoDevice, "no device");
+        assert!(!is_transient_serial_error(&absent));
     }
 }

--- a/refbox/src/app/update_sender.rs
+++ b/refbox/src/app/update_sender.rs
@@ -21,8 +21,10 @@ use tokio::{
 use tokio_serial::{SerialPortBuilder, SerialPortBuilderExt, SerialStream};
 use uwh_common::game_snapshot::{EncodingError, GamePeriod, GameSnapshot, GameSnapshotNoHeap};
 
-/// Total time budget for retrying a *transient* serial-open failure, plus the
-/// initial backoff step (doubled each attempt, capped by the budget). Sized for
+/// Time budget for retrying a *transient* serial-open failure, plus the initial
+/// backoff step (doubled each attempt, capped by the budget). This bounds when a
+/// new attempt may *start*; the final backoff sleep runs to completion, so
+/// worst-case wall time is up to one extra backoff beyond the budget. Sized for
 /// the brief window during a restart where the exiting process is still
 /// releasing the port.
 /// 🔧 PI: confirm/tune on the spare Pi during the 5×-restart test.
@@ -33,13 +35,21 @@ const SERIAL_OPEN_RETRY_INITIAL: Duration = Duration::from_millis(100);
 /// exists but is momentarily unavailable (e.g. still held by the exiting
 /// process during a restart); `false` for an absent/misconfigured device, which
 /// would only delay startup if retried.
-/// 🔧 PI: if a briefly-held port on the Pi surfaces a different `ErrorKind`,
-/// widen this allowlist (this is the single place to tune it).
+///
+/// A port held under the kernel's exclusive lock (`TIOCEXCL`) — the
+/// restart-overlap case we care about most — fails with `EBUSY`, which
+/// serialport 4.7.3 maps to `ErrorKind::Unknown` (it drops the raw errno), so
+/// `Unknown` MUST count as transient. An absent path fails with
+/// `Io(NotFound)`, which stays excluded so a missing panel skips immediately
+/// with no startup penalty.
+/// 🔧 PI: confirm on the spare Pi that a held port surfaces as `Unknown` (log
+/// the actual `ErrorKind`); adjust this allowlist if it differs.
 fn is_transient_serial_error(e: &tokio_serial::Error) -> bool {
     use tokio_serial::ErrorKind;
     matches!(
         e.kind(),
-        ErrorKind::Io(std::io::ErrorKind::PermissionDenied)
+        ErrorKind::Unknown
+            | ErrorKind::Io(std::io::ErrorKind::PermissionDenied)
             | ErrorKind::Io(std::io::ErrorKind::WouldBlock)
             | ErrorKind::Io(std::io::ErrorKind::TimedOut)
     )
@@ -668,6 +678,9 @@ impl Drop for Server {
 }
 
 /// Time budget + initial backoff for retrying a transient (port-in-use) bind.
+/// The budget bounds when a new attempt may *start*; the final backoff sleep
+/// runs to completion, so worst-case wall time is up to one extra backoff beyond
+/// the budget.
 /// 🔧 PI: confirm/tune on the spare Pi during the 5×-restart test.
 const TCP_BIND_RETRY_BUDGET: Duration = Duration::from_millis(2000);
 const TCP_BIND_RETRY_INITIAL: Duration = Duration::from_millis(100);
@@ -1170,14 +1183,22 @@ mod test {
     #[test]
     fn transient_serial_error_retries_busy_but_not_absent() {
         use tokio_serial::{Error as SerialError, ErrorKind as SerialErrorKind};
-        // A momentarily-held port (typical during a restart) is worth retrying.
-        let busy = SerialError::new(
+        // A port held under the kernel's exclusive lock during a restart fails
+        // with EBUSY, which serialport maps to `Unknown` (raw errno dropped) --
+        // this is the case we must retry.
+        let busy_exclusive = SerialError::new(SerialErrorKind::Unknown, "EBUSY: resource busy");
+        assert!(is_transient_serial_error(&busy_exclusive));
+        // A permission-class momentary failure is also retried.
+        let busy_perm = SerialError::new(
             SerialErrorKind::Io(std::io::ErrorKind::PermissionDenied),
             "busy",
         );
-        assert!(is_transient_serial_error(&busy));
-        // An absent / unknown device must be skipped immediately, not retried.
-        let absent = SerialError::new(SerialErrorKind::NoDevice, "no device");
+        assert!(is_transient_serial_error(&busy_perm));
+        // An absent device (nonexistent path -> NotFound) skips immediately.
+        let absent = SerialError::new(
+            SerialErrorKind::Io(std::io::ErrorKind::NotFound),
+            "no such file",
+        );
         assert!(!is_transient_serial_error(&absent));
     }
 

--- a/refbox/src/main.rs
+++ b/refbox/src/main.rs
@@ -228,50 +228,75 @@ pub fn build_sim_argv(config: &SimSpawnConfig) -> Vec<String> {
 ///  - `--capture-previews`: a dev-only flag that renders preview PNGs and exits
 ///    immediately; replaying it would make the restarted process exit at once.
 pub(crate) fn build_restart_argv(args: &Cli) -> Vec<String> {
+    // DRIFT GUARD: destructure every field with no `..`, so ANY future CLI field
+    // added to `Cli` breaks the build here until its author consciously decides
+    // whether it should be replayed across an in-app restart. This is what stops
+    // the "restart drops CLI args" bug (PR #1073) from silently re-appearing.
+    let Cli {
+        no_simulate,
+        verbose,
+        scale,
+        spacing,
+        fullscreen,
+        binary_port,
+        json_port,
+        serial_port,
+        baud_rate,
+        allow_http,
+        all_events,
+        log_location,
+        log_max_file_size,
+        num_old_logs,
+        simulate_sunlight_display,
+        // --- Deliberately NOT replayed (see this fn's doc comment) ---
+        language: _,         // a restart is often triggered BY a language change
+        is_simulator: _,     // this relaunches the MAIN app, never a sim child
+        capture_previews: _, // dev-only; replaying it would exit immediately
+    } = args;
+
     let mut argv: Vec<String> = Vec::new();
 
-    if args.no_simulate {
+    if *no_simulate {
         argv.push("--no-simulate".to_string());
     }
-    for _ in 0..args.verbose {
+    for _ in 0..*verbose {
         argv.push("--verbose".to_string());
     }
     argv.push("--scale".to_string());
-    argv.push(args.scale.to_string());
-    if let Some(spacing) = args.spacing {
+    argv.push(scale.to_string());
+    if let Some(spacing) = spacing {
         argv.push("--spacing".to_string());
         argv.push(spacing.to_string());
     }
-    if args.fullscreen {
+    if *fullscreen {
         argv.push("--fullscreen".to_string());
     }
     argv.push("--binary-port".to_string());
-    argv.push(args.binary_port.to_string());
+    argv.push(binary_port.to_string());
     argv.push("--json-port".to_string());
-    argv.push(args.json_port.to_string());
-    if let Some(port) = &args.serial_port {
+    argv.push(json_port.to_string());
+    if let Some(port) = serial_port {
         argv.push("--serial-port".to_string());
         argv.push(port.clone());
         argv.push("--baud-rate".to_string());
-        argv.push(args.baud_rate.to_string());
+        argv.push(baud_rate.to_string());
     }
-    if args.allow_http {
+    if *allow_http {
         argv.push("--allow-http".to_string());
     }
-    if args.all_events {
+    if *all_events {
         argv.push("--all-events".to_string());
     }
-    if let Some(loc) = &args.log_location {
+    if let Some(loc) = log_location {
         argv.push("--log-location".to_string());
-        // Matches the original main.rs behaviour and `build_sim_argv`. A
-        // non-UTF-8 log path would already have panicked at startup before here.
+        // A non-UTF-8 log path would already have panicked at startup before here.
         argv.push(loc.to_str().unwrap().to_string());
     }
     argv.push("--log-max-file-size".to_string());
-    argv.push(args.log_max_file_size.to_string());
+    argv.push(log_max_file_size.to_string());
     argv.push("--num-old-logs".to_string());
-    argv.push(args.num_old_logs.to_string());
-    if args.simulate_sunlight_display {
+    argv.push(num_old_logs.to_string());
+    if *simulate_sunlight_display {
         argv.push("--simulate-sunlight-display".to_string());
     }
 

--- a/refbox/src/sound_controller/mod.rs
+++ b/refbox/src/sound_controller/mod.rs
@@ -21,7 +21,7 @@ use tokio::{
         watch::{self, Sender},
     },
     task::{self, AbortHandle, JoinError, JoinHandle, JoinSet},
-    time::{Duration, Instant, sleep, sleep_until},
+    time::{Duration, Instant, sleep, sleep_until, timeout},
 };
 use toml::Table;
 use web_audio_api::{
@@ -608,19 +608,32 @@ impl SoundController {
     }
 }
 
+/// Maximum time the sound-controller teardown waits for its worker to finish
+/// before proceeding with shutdown/restart anyway. A hung audio shutdown must
+/// never be able to prevent the app from relaunching.
+/// 🔧 PI: confirm on the spare Pi during the 5×-restart test.
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Await the worker `JoinHandle`, but never longer than `limit`. On timeout,
+/// log and return so teardown (and the pending relaunch) can proceed.
+async fn await_handle_bounded(handle: JoinHandle<()>, limit: Duration) {
+    match timeout(limit, handle).await {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => error!("Sound controller thread failed: {e}"),
+        Err(_) => warn!("Sound controller shutdown timed out after {limit:?}; proceeding"),
+    }
+}
+
 impl Drop for SoundController {
     fn drop(&mut self) {
         if self.stop_tx.send(true).is_err() {
             return;
         }
 
-        tokio::runtime::Handle::current().block_on(async move {
-            if let Some(handle) = self.handle.take() {
-                if let Err(e) = handle.await {
-                    error!("Sound controller thread failed: {e}");
-                }
-            }
-        });
+        if let Some(handle) = self.handle.take() {
+            tokio::runtime::Handle::current()
+                .block_on(await_handle_bounded(handle, SHUTDOWN_TIMEOUT));
+        }
     }
 }
 
@@ -899,5 +912,25 @@ mod tests {
                 },
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn await_handle_bounded_returns_for_hung_task() {
+        // A worker that never finishes must not block teardown past the bound.
+        let handle = tokio::spawn(async { std::future::pending::<()>().await });
+        let start = Instant::now();
+        await_handle_bounded(handle, Duration::from_millis(150)).await;
+        assert!(
+            start.elapsed() < Duration::from_secs(1),
+            "bounded shutdown must return shortly after the timeout"
+        );
+    }
+
+    #[tokio::test]
+    async fn await_handle_bounded_returns_promptly_for_finished_task() {
+        let handle = tokio::spawn(async {});
+        let start = Instant::now();
+        await_handle_bounded(handle, Duration::from_secs(5)).await;
+        assert!(start.elapsed() < Duration::from_secs(1));
     }
 }


### PR DESCRIPTION
## What changed

The in-app restart (used today when you change the language or app mode, and the foundation the planned in-app self-update will build on) is now hardened against the brief moment when the closing copy of the app and the new copy overlap:

- **Scoreboard & overlay reconnect:** the new copy now waits and retries (up to ~2 seconds) to reconnect to the LED-panel serial cable and the stream-overlay network ports, instead of giving up instantly and silently coming back with a **dark scoreboard** or no overlay. If no scoreboard is attached at all, it still skips immediately with **no startup delay**.
- **Sound-shutdown safety cap:** a firm 2-second limit is placed on the sound system's shutdown, so a stalled audio shutdown can no longer prevent the app from relaunching at all (the old window closing with nothing coming back).
- **Restart drift guard:** a build-time safeguard so any future command-line option must be consciously handled on restart — the "restart forgets its settings" bug fixed in #1073 cannot silently return.

## Why

On a tournament Raspberry Pi the only restart recovery an operator has is a power cycle, so a restart that comes back windowed, without the scoreboard, without the buzzer, or not at all is a serious failure. #1073 made the restart preserve its command-line settings; this PR makes the restart survive the hardware/resource hand-off between the old and new process.

## Scope

Limited to the `refbox` crate, three files:
- `refbox/src/app/update_sender.rs` — serial-port and overlay-TCP reconnect retry
- `refbox/src/sound_controller/mod.rs` — bounded shutdown wait
- `refbox/src/main.rs` — restart-argv drift guard

No new dependencies; no public-API or wire-format changes.

## How to verify

- **Automated:** `just check` passes (243 tests, including new tests for the retry predicates, the bind-retry give-up behaviour, and the bounded shutdown).
- **On hardware — REQUIRED before relying on this at an event:** on a Pi with the LED scoreboard, wireless button, and overlay connected, trigger a restart by changing the language and confirm the app returns **full-screen with the scoreboard showing the clock, the buzzer working, and the overlay reconnected — repeated 5 times in a row**. The retry/timeout values are conservative defaults to confirm and tune during this test (in particular, that a briefly-held serial port surfaces as expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
