### PR TITLE
fix(refbox): gate updater test import to unix to fix windows build

### DIFF
--- a/refbox/src/updater/net.rs
+++ b/refbox/src/updater/net.rs
@@ -92,6 +92,7 @@ fn set_executable(_path: &std::path::Path) -> std::io::Result<()> {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(unix)]
     use super::*;
 
     #[cfg(unix)]


### PR DESCRIPTION
## What changed
A test in the self-update code checks a Linux/Mac-only behaviour (marking a downloaded file as a runnable program) and is correctly switched off on Windows. But one line at the top of that test section — which borrows tools from the surrounding code — was left switched on for all platforms. On Windows, with the only test that used it switched off, that line became unused, and the project treats unused code as a hard build error. This switches that line off on Windows too, matching the test it serves. One line, test-only.

## Why
PR #1089 (the built-in self-update feature) was merged while its Windows build was failing for exactly this reason, so `master`'s automated Windows build is currently red. This restores it to green. There is no change to how the updater — or anything else — behaves.

## Scope
One line in `refbox/src/updater/net.rs`, inside a test-only section. No runtime or logic changes.

## How to verify
- The automated checks (CI) all pass on this PR, including the Windows build that is currently failing on `master`.
- Functionally nothing changes: the updater (check / install / revert / auto-revert) behaves exactly as before. The Linux/Mac and Raspberry Pi builds were never affected.
