### PR TITLE
fix(refbox): skip directory fsync on windows in updater markers

### DIFF
--- a/refbox/src/updater/marker.rs
+++ b/refbox/src/updater/marker.rs
@@ -210,12 +210,20 @@ pub fn decide_on_startup(dir: &Path) -> StartupDecision {
 
 /// fsync the directory itself so that renames/removals are durable.
 ///
-/// On some filesystems the rename is not persisted until the containing
-/// directory's metadata is fsynced. This mirrors the pattern used in
-/// `portal_manager/queue.rs`.
+/// On some filesystems a rename is not persisted until the containing
+/// directory's metadata is fsynced.
+#[cfg(unix)]
 fn fsync_dir(dir: &Path) -> io::Result<()> {
     let d = fs::File::open(dir)?;
     d.sync_all()?;
+    Ok(())
+}
+
+/// Windows cannot open a directory as a file handle for fsync (it returns
+/// "Access is denied"), and directory fsync is not the durability mechanism
+/// there, so this is a no-op. (Same approach taken by tempfile/atomicwrites.)
+#[cfg(not(unix))]
+fn fsync_dir(_dir: &Path) -> io::Result<()> {
     Ok(())
 }
 


### PR DESCRIPTION
## What changed
The updater saves small "marker" files that drive the auto-revert safety net. After saving each one, it flushed the containing folder to disk by opening the folder as a file — a step that works on Linux/Mac but Windows rejects with "Access is denied". This makes that folder-flush a no-op on Windows (where it is neither permitted nor needed), exactly mirroring how the updater already handles another Linux-only operation (`set_executable`). One function, split by platform.

## Why
PR #1089 (self-update) was merged while CI was red. The first follow-up (#1097) fixed the Windows *compile* error, which then exposed **6 Windows *test* failures** in the marker logic — all caused by this folder-flush step. `master` is currently red on Windows because of them. This makes those tests pass and restores `master` to green. There is no behaviour change on Linux/Mac/Pi.

## Scope
One function (`fsync_dir`) in `refbox/src/updater/marker.rs`. No other code touched. Raspberry Pi (Linux) behaviour is unchanged.

## How to verify
- All automated checks pass, including the Windows tests currently failing on `master` (`updater::marker::tests::*`).
- Locally on Linux: `cargo test -p refbox` — all 262 tests pass, including the 8 marker tests.
- No behaviour change: on Linux/Pi the folder-flush still runs exactly as before; on Windows it is skipped (directory fsync is not the durability mechanism there).
