### PR TITLE
fix(ci): download Pi binary to clean path for standalone release asset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,9 +123,13 @@ jobs:
         curl -L "https://drive.usercontent.google.com/download?id=1FLtJwc8gb5vuSRVPUNLxKhT1ufcOSa-w&export=download" -o "release/Refbox User Manual with Fouls.pdf"
     - name: Zip release
       run: cd release && zip -r ../refbox.zip .
+    - uses: actions/download-artifact@v5
+      with:
+        name: refbox-rpi
+        path: pi-standalone
     - name: Stage standalone Pi assets
       run: |
-        cp "release/Raspberry Pi/refbox" refbox-aarch64-linux
+        cp pi-standalone/refbox refbox-aarch64-linux
         cp release/rpi-sha256/refbox.sha256 refbox-aarch64-linux.sha256
     - uses: softprops/action-gh-release@v2
       with:


### PR DESCRIPTION
## What changed
The release process now downloads the Raspberry Pi program into a plain-named folder (`pi-standalone/`) before packaging it as the standalone updater file, instead of copying it out of a folder whose name had a mismatched escaped space.

## Why
The step that publishes the separate Pi files for the in-app updater (added with the self-update feature, commit `f6612b43`) had **never run until the first release from the new code** — and it failed: it looked for the Pi program at `release/Raspberry Pi/refbox`, but the binary had been downloaded into a differently-escaped folder name, so the copy couldn't find it and **no release was created**. This blocks publishing *any* release with the updater's standalone files (including v0.4.2).

## Scope
One step in `.github/workflows/release.yml` (the release/CI workflow). No application code changes; builds and tests are unaffected.

## How to verify
- A release workflow can only be exercised by cutting a release. After this merges, re-cutting **v0.4.2** should complete the "Upload release artifacts" job and produce a draft release that includes `refbox-aarch64-linux` + `refbox-aarch64-linux.sha256` (alongside `refbox.zip`).
- The failing run (before this fix): https://github.com/AtlantisSports/uwh-refbox-rs/actions/runs/27541308091 — step "Stage standalone Pi assets" errored with `cp: cannot stat 'release/Raspberry Pi/refbox'`.
