### PR TITLE
fix(refbox): game block calculation, pre-game delay, info-page game block

### DIFF
--- a/refbox/src/app/view_builders/game_info.rs
+++ b/refbox/src/app/view_builders/game_info.rs
@@ -192,6 +192,14 @@ fn details_strings(
         }
     }
 
+    // Game Block (the start-to-start slot) sits right after the team names and before
+    // the play-length lines -- matching the main page layout.
+    left_string += &fl!(
+        "game-block-info",
+        game_block = time_string(config.game_block)
+    );
+    left_string += "\n";
+
     left_string += &if config.single_half {
         // Single-period game: show "Game Length" and omit the half-time line.
         fl!(
@@ -250,13 +258,6 @@ fn details_strings(
         );
         left_string += "\n";
     };
-    if !using_uwhportal {
-        left_string += &fl!(
-            "game-block-info",
-            game_block = time_string(config.game_block)
-        );
-        left_string += "\n";
-    }
     left_string += &fl!(
         "min-brk-btwn-games",
         min_brk_time = time_string(config.minimum_break)

--- a/refbox/src/tournament_manager/mod.rs
+++ b/refbox/src/tournament_manager/mod.rs
@@ -2078,6 +2078,14 @@ impl TournamentManager {
     /// docs/superpowers/specs/2026-06-06-behind-schedule-indicator-design.md.
     pub fn behind_schedule(&self, now: Instant) -> Duration {
         if self.current_period == GamePeriod::BetweenGames {
+            // Before the first game has started there is no schedule anchor yet, so the
+            // event cannot be "behind". (The in-game branch below applies the same guard
+            // via `current_scheduled_start`.) Without this, the pre-game break countdown
+            // projects ~= the scheduled start and clock granularity leaks a sub-minute
+            // positive value, shown as "DELAY -0:0".
+            if self.current_scheduled_start.is_none() {
+                return Duration::ZERO;
+            }
             // Project the next game's start from the *live* break clock. While the
             // break counts down normally the projection holds steady (frozen);
             // pausing it, sitting past zero, or editing it slides the projection --
@@ -3119,6 +3127,27 @@ mod test {
         tm.end_game(end);
         // No panic, and the absurdly-distant next start reads as on-time.
         assert_eq!(tm.behind_schedule(end), Duration::ZERO);
+    }
+
+    #[test]
+    fn test_behind_schedule_zero_before_first_game() {
+        // Pre-first-game: a portal schedule is loaded and the between-games countdown
+        // is running toward game 1, but NO game has started yet (current_scheduled_start
+        // is None). Even when the projection would compute a positive delta, the figure
+        // must be ZERO -- you cannot be "behind" before the first game (Bug: "DELAY -0:0").
+        initialize();
+        let mut tm = TournamentManager::new(behind_test_config());
+        let now = Instant::now();
+        assert!(
+            tm.current_scheduled_start.is_none(),
+            "no game has started yet"
+        );
+        // In the between-games countdown to the first game, with 20s left on the break...
+        tm.set_period_and_game_clock_time(GamePeriod::BetweenGames, Duration::from_secs(20));
+        // ...and the grid saying the first game is scheduled 5s from now. Without the
+        // guard, projected (now+20) is 15s past the scheduled start (now+5) => 15s behind.
+        tm.next_scheduled_start = Some(now + Duration::from_secs(5));
+        assert_eq!(tm.behind_schedule(now), Duration::ZERO);
     }
 
     #[test]

--- a/uwh-common/src/uwhportal/schedule.rs
+++ b/uwh-common/src/uwhportal/schedule.rs
@@ -317,13 +317,17 @@ impl Into<GameConfig> for TimingRule {
             nominal_break,
             minimum_break,
             game_block: game_block.unwrap_or_else(|| {
-                // No portal-sent Game Block: derive from this rule's play durations.
+                // No portal-sent Game Block: derive from this rule's play durations
+                // plus the schedule's own minimum break (the gap the portal packs
+                // games at). This matches schedule-processor's slot math. Using the
+                // refbox default nominal_break here was the bug: the portal never
+                // sends nominal_break, so it injected a 15-min default gap.
                 let regulation = if half_time_duration == Duration::ZERO {
                     half_play_duration
                 } else {
                     2 * half_play_duration + half_time_duration
                 };
-                regulation + nominal_break
+                regulation + minimum_break
             }),
         }
     }
@@ -944,13 +948,13 @@ mod tests {
 
     #[test]
     fn test_timing_rule_game_block_absent_is_derived() {
-        // Portal payload WITHOUT gameBlock (today's case): derive game_block = regulation + nominal_break.
+        // Portal payload WITHOUT gameBlock (today's case): derive game_block = regulation + minimum_break.
         let json = r#"{"name":"RR","teamTimeoutCount":1,"teamTimeoutsCountedPerHalf":true,"overtimeAllowed":true,"suddenDeathAllowed":true,"halfPlayDuration":900,"halfTimeDuration":180,"teamTimeoutDuration":60,"overtimeHalfPlayDuration":300,"overtimeHalfTimeDuration":180,"preOvertimeBreak":180,"preSuddenDeathDuration":60,"minimumBreak":240}"#;
         let rule: TimingRule = serde_json::from_str(json).unwrap();
         assert_eq!(rule.game_block, None);
         let config: GameConfig = rule.into();
-        // regulation = 2*900 + 180 = 1980; nominal_break default = 900 -> 2880
-        assert_eq!(config.game_block, Duration::from_secs(2880));
+        // regulation = 2*900 + 180 = 1980; minimum_break = 240 -> 2220
+        assert_eq!(config.game_block, Duration::from_secs(2220));
     }
 
     #[test]
@@ -968,8 +972,20 @@ mod tests {
         let json = r#"{"name":"RR","teamTimeoutCount":0,"teamTimeoutsCountedPerHalf":false,"overtimeAllowed":false,"suddenDeathAllowed":false,"halfPlayDuration":600,"halfTimeDuration":0,"teamTimeoutDuration":0,"overtimeHalfPlayDuration":0,"overtimeHalfTimeDuration":0,"preOvertimeBreak":0,"preSuddenDeathDuration":0,"minimumBreak":120}"#;
         let rule: TimingRule = serde_json::from_str(json).unwrap();
         let config: GameConfig = rule.into();
-        // single half: regulation = 600; nominal_break default = 900 -> 1500
-        assert_eq!(config.game_block, Duration::from_secs(1500));
+        // single half: regulation = 600; minimum_break = 120 -> 720
+        assert_eq!(config.game_block, Duration::from_secs(720));
+    }
+
+    #[test]
+    fn test_timing_rule_game_block_uses_schedule_minimum_break() {
+        // Reported bug: 10-min halves + 2-min half-time + 4-min gap must derive a
+        // 26:00 Game Block (regulation 1320 + minimum_break 240 = 1560), NOT 37:00
+        // (which is regulation + the 15-min default nominal_break).
+        let json = r#"{"name":"RR","teamTimeoutCount":0,"teamTimeoutsCountedPerHalf":false,"overtimeAllowed":false,"suddenDeathAllowed":false,"halfPlayDuration":600,"halfTimeDuration":120,"teamTimeoutDuration":0,"overtimeHalfPlayDuration":0,"overtimeHalfTimeDuration":0,"preOvertimeBreak":0,"preSuddenDeathDuration":0,"minimumBreak":240}"#;
+        let rule: TimingRule = serde_json::from_str(json).unwrap();
+        assert_eq!(rule.game_block, None);
+        let config: GameConfig = rule.into();
+        assert_eq!(config.game_block, Duration::from_secs(1560)); // 26:00
     }
 
     #[test]


### PR DESCRIPTION
## What changed
Three fixes to the recent draft release:

1. **Game Block now shows 26:00, not 37:00.** When a portal schedule doesn't include a game-block figure, the refbox calculates one itself. It was adding its built-in 15-minute "between games" default instead of the schedule's actual 4-minute gap (22 + 15 = 37 instead of 22 + 4 = 26). It now uses the schedule's own gap. This also corrects the next-game countdown and the behind-schedule tracking, which were based on the too-long block.

2. **No "DELAY" before the first game.** The behind-schedule indicator showed "DELAY -0:0" during the pre-game countdown, before any game had started. The figure is now forced to zero until the first game starts — the same rule already applied during games. You cannot be "behind" before the event begins.

3. **Game Block shown on the Game Information page.** It appeared on the main page but was hidden on the Game Information page whenever a portal schedule was loaded (the normal tournament case). It now appears there too, right after the team names, matching the main page.

## Why
All three were reported on the v0.4.2 draft release. The 37-minute block was mathematically wrong for the uploaded schedule, the pre-game "DELAY" is impossible (no game has run yet), and the missing Game Block line was an inconsistency between two screens.

## Scope
- `uwh-common/src/uwhportal/schedule.rs` — portal game-block derivation + tests
- `refbox/src/tournament_manager/mod.rs` — behind-schedule guard + test
- `refbox/src/app/view_builders/game_info.rs` — game-info page display

## How to verify
1. Load a portal schedule with 10-min halves, 2-min half-time, 4-min between-games (no overtime/sudden-death/timeouts).
2. Main page: "Game Block" reads **26:00**, and **no "DELAY"** is shown before the first game starts.
3. Open the Game Information page: it now shows **Game Block: 26:00** right after the team names.
4. Start a game and let it run long: the DELAY indicator still appears when genuinely behind schedule.
5. `just check` passes; new tests cover the 37→26 derivation and the pre-game zero-delay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
