### PR TITLE
fix(uwh-common): restore no_std build

### DIFF
--- a/uwh-common/src/bundles.rs
+++ b/uwh-common/src/bundles.rs
@@ -85,10 +85,10 @@ impl<'a, T> IntoIterator for &'a BlackWhiteBundle<T> {
 
 impl<T> IntoIterator for BlackWhiteBundle<T> {
     type Item = (Color, T);
-    type IntoIter = std::vec::IntoIter<Self::Item>;
+    type IntoIter = core::array::IntoIter<Self::Item, 2>;
 
     fn into_iter(self) -> Self::IntoIter {
-        vec![(Color::Black, self.black), (Color::White, self.white)].into_iter()
+        [(Color::Black, self.black), (Color::White, self.white)].into_iter()
     }
 }
 
@@ -205,10 +205,10 @@ impl<'a, T> IntoIterator for &'a OptColorBundle<T> {
 
 impl<T> IntoIterator for OptColorBundle<T> {
     type Item = (Option<Color>, T);
-    type IntoIter = std::vec::IntoIter<Self::Item>;
+    type IntoIter = core::array::IntoIter<Self::Item, 3>;
 
     fn into_iter(self) -> Self::IntoIter {
-        vec![
+        [
             (Some(Color::Black), self.black),
             (None, self.equal),
             (Some(Color::White), self.white),

--- a/uwh-common/src/game_snapshot.rs
+++ b/uwh-common/src/game_snapshot.rs
@@ -1,10 +1,8 @@
-use crate::{
-    bundles::{BlackWhiteBundle, OptColorBundle},
-    color::Color,
-    drawing_support::*,
-};
+use crate::{bundles::BlackWhiteBundle, drawing_support::*};
 #[cfg(feature = "std")]
 use crate::{
+    bundles::OptColorBundle,
+    color::Color,
     config::Game,
     uwhportal::schedule::{EventId, GameNumber},
 };


### PR DESCRIPTION
## What changed
Restores the shared `uwh-common` library's ability to compile without the standard library (its "no_std" / embedded build). Two bundle iterators were allocating a heap `Vec`, and one module imported standard-library-only types without gating them — neither works in the no_std build, which has no heap allocator. The iterators now use fixed-size stack arrays (these bundles always have a constant number of elements), and the std-only imports are gated behind the `std` feature.

## Why
`cargo build -p uwh-common --no-default-features` (the no_std build documented in the crate's own guide) was failing on the current release. Regular CI did not catch it: `cargo build --all --no-default-features` re-enables `std` on `uwh-common` through Cargo feature unification (its std-using siblings pull it in), so the breakage only appears when the crate is built in isolation.

## Scope
- `uwh-common/src/bundles.rs` — array-based `IntoIterator` impls (no heap allocation)
- `uwh-common/src/game_snapshot.rs` — gate std-only imports behind the `std` feature

No behaviour change in the normal (std) build.

## How to verify
- `cargo build -p uwh-common --no-default-features` — compiles (was failing).
- `cargo clippy -p uwh-common --no-default-features -- -D warnings` — clean.
- `cargo build -p matrix-drawing --no-default-features` — clean.
- `just check` — still green (std build and tests unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
