### PR TITLE
fix(refbox): put fouls left of warnings on summary page

### DIFF
--- a/refbox/src/app/view_builders/warnings_fouls_summary.rs
+++ b/refbox/src/app/view_builders/warnings_fouls_summary.rs
@@ -79,8 +79,8 @@ pub(in super::super) fn build_warnings_summary_page<'a>(
     .height(Length::Fill);
 
     let warnings_and_fouls_row = row![
-        warnings_container.width(Length::Fill),
-        fouls_container.width(Length::Fill)
+        fouls_container.width(Length::Fill),
+        warnings_container.width(Length::Fill)
     ]
     .spacing(SPACING)
     .width(Length::Fill);
@@ -101,14 +101,14 @@ pub(in super::super) fn build_warnings_summary_page<'a>(
                 .style(red_button)
                 .width(Length::Fill)
                 .on_press(Message::ConfigEditComplete),
-            make_button(fl!("edit-warnings"))
-                .style(blue_button)
-                .width(Length::Fill)
-                .on_press(Message::WarningOverview),
             make_button(fl!("edit-fouls"))
                 .style(orange_button)
                 .width(Length::Fill)
                 .on_press(Message::FoulOverview),
+            make_button(fl!("edit-warnings"))
+                .style(blue_button)
+                .width(Length::Fill)
+                .on_press(Message::WarningOverview),
         ]
         .spacing(SPACING)
         .width(Length::Fill),


### PR DESCRIPTION
## What changed
On the Fouls & Warnings summary page, the two panels are swapped so **Fouls is on the left and Warnings on the right**, and the bottom buttons are reordered to match (**Edit Fouls before Edit Warnings**). Each button keeps its existing colour and action.

## Why
The main page orders these as Fouls-then-Warnings (the Foul button sits to the left of the Warning button). The summary page had them the other way round; this makes the two screens consistent.

## Scope
One file, view-only: `refbox/src/app/view_builders/warnings_fouls_summary.rs`. No behaviour, data, or translation changes. Black-left / white-right ordering within each panel is unchanged.

## How to verify
1. Enable "track fouls and warnings".
2. On the main page, tap the Warnings area to open the Fouls & Warnings summary page.
3. Confirm **Fouls is on the left, Warnings on the right**, and the bottom buttons read **Back · Edit Fouls · Edit Warnings**.
4. `just check` passes (fmt, clippy `-D warnings`, 263 refbox tests + others, audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
