### PR TITLE
fix(refbox): don't panic when display channel is full

### DIFF
--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -434,13 +434,16 @@ impl RefBoxApp {
         new_snapshot.event_id = self.current_event_id.clone();
 
         self.maybe_play_sound(&new_snapshot);
-        self.update_sender
-            .send_snapshot(
-                new_snapshot.clone(),
-                self.config.hardware.white_on_right,
-                self.config.hardware.brightness,
-            )
-            .unwrap();
+        if let Err(e) = self.update_sender.send_snapshot(
+            new_snapshot.clone(),
+            self.config.hardware.white_on_right,
+            self.config.hardware.brightness,
+        ) {
+            // Channel-full or closed: the next snapshot re-sends fresh state,
+            // so dropping one is acceptable -- never crash the refbox over a
+            // slow/stalled display consumer.
+            warn!("Failed to send snapshot to displays: {e:?}");
+        }
         self.snapshot = new_snapshot;
         task
     }


### PR DESCRIPTION
## What changed
When the refbox sends a game-state update to the displays (LED panel / stream overlay / simulator) and that channel is momentarily full — a slow or stalled display consumer — the refbox now **logs a warning and skips that one update** instead of crashing. The next update re-sends the full current state, so nothing is permanently lost, and the operator's own screen keeps updating normally.

## Why
Previously a full display channel caused a **hard crash (panic) of the whole refbox** — observed live (the app exited with a panic in `apply_snapshot`). A slow or stalled display must never be able to crash the timing console mid-game. The fix mirrors an existing graceful handler already used for the beep-test display path in the same file.

## Scope
One file: `refbox/src/app/mod.rs` (the `apply_snapshot` send site). No change to snapshot content, snapshot frequency, channel capacity, or any other crate.

## How to verify
- This guards a condition that's hard to reproduce on demand (it needs a stalled display consumer), so the evidence is: `just check` fully green (263 refbox tests + others, fmt, clippy `-D warnings`, audit), and the fix is a direct mirror of the existing, already-working beep-test graceful handler.
- Code-reviewed (Senior-reviewer pass): no Critical or Important issues; confirmed it handles both "full" and "closed" channels and keeps the local screen updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
