### PR TITLE
fix(refbox): warn yellow when Game Block exactly meets the minimum

### DIFF
--- a/refbox/src/app/view_builders/configuration.rs
+++ b/refbox/src/app/view_builders/configuration.rs
@@ -519,7 +519,10 @@ enum GameBlockValidity {
 fn game_block_validity(cfg: &GameConfig) -> GameBlockValidity {
     if cfg.game_block < cfg.game_block_minimum() {
         GameBlockValidity::TooShort
-    } else if cfg.game_block_buffer() < cfg.team_timeout_allotment() {
+    } else if cfg.game_block_buffer() <= cfg.team_timeout_allotment() {
+        // `<=`: a Game Block that exactly covers the game, break, and full timeout
+        // allotment is "barely sufficient" (no slack to recover if running behind),
+        // so it warns yellow rather than reading as comfortably Ok.
         GameBlockValidity::Tight
     } else {
         GameBlockValidity::Ok
@@ -2568,9 +2571,16 @@ mod tests {
             ..base.clone()
         };
         assert_eq!(game_block_validity(&tight), GameBlockValidity::Tight);
-        // buffer >= allotment => Ok (22 + 240 = 262).
-        let ok = GameConfig {
+        // Exactly minimum + allotment (22 + 240 = 262): barely sufficient, no slack
+        // to recover if running behind => Tight (yellow), not Ok.
+        let barely = GameConfig {
             game_block: Duration::from_secs(262),
+            ..base.clone()
+        };
+        assert_eq!(game_block_validity(&barely), GameBlockValidity::Tight);
+        // Above minimum + allotment (263) => Ok (green).
+        let ok = GameConfig {
+            game_block: Duration::from_secs(263),
             ..base.clone()
         };
         assert_eq!(game_block_validity(&ok), GameBlockValidity::Ok);


### PR DESCRIPTION
## What changed
The Game Block field now shows a yellow warning when the Game Block is set
to exactly the time needed for the game, the minimum break, and every
allowed team timeout. Previously that exact value showed no warning. Blocks
with time to spare are unchanged (no warning); blocks too short for even the
game plus minimum break still show red and can't be saved.

## Why
A Game Block sitting exactly at that minimum is "barely sufficient" — there
is no slack to recover if a game runs behind. Reading it as fine implied
headroom that isn't there; yellow flags it as tight.

## Scope
Limited to refbox/src/app/view_builders/configuration.rs (the
game_block_validity threshold + its test). No timeout/duration math changed;
no tournament-manager or uwh-common changes.

## How to verify
`cargo test -p refbox test_game_block_validity_thresholds`. Or in the app:
Settings → Game Options → set Game Block to exactly (game + minimum break +
all team timeouts) and confirm it warns yellow; one second more clears it,
below game+break shows red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
