### PR TITLE
feat(refbox): show team timeouts compactly as 0, 1/HALF, or 1/GAME

### DIFF
--- a/refbox/src/app/view_builders/game_info.rs
+++ b/refbox/src/app/view_builders/game_info.rs
@@ -238,17 +238,14 @@ fn details_strings(
         left_string += "\n";
     };
 
-    left_string += &if config.timeouts_counted_per_half {
-        fl!(
-            "team-timeouts-per-half",
-            team_timeouts = config.num_team_timeouts_allowed
-        )
+    let team_timeouts_value = if config.num_team_timeouts_allowed == 0 {
+        "0".to_string()
+    } else if config.timeouts_counted_per_half {
+        format!("{}/{}", config.num_team_timeouts_allowed, fl!("half"))
     } else {
-        fl!(
-            "team-timeouts-per-game",
-            team_timeouts = config.num_team_timeouts_allowed
-        )
+        format!("{}/{}", config.num_team_timeouts_allowed, fl!("game"))
     };
+    left_string += &fl!("team-timeouts", value = team_timeouts_value);
     left_string += "\n";
 
     if config.num_team_timeouts_allowed != 0 {

--- a/refbox/src/app/view_builders/shared_elements.rs
+++ b/refbox/src/app/view_builders/shared_elements.rs
@@ -934,19 +934,15 @@ pub(super) fn config_string(
         )
     };
 
-    if config.timeouts_counted_per_half {
-        result += "\n";
-        result += &fl!(
-            "team-timeouts-per-half",
-            team_timeouts = config.num_team_timeouts_allowed
-        );
+    let team_timeouts_value = if config.num_team_timeouts_allowed == 0 {
+        "0".to_string()
+    } else if config.timeouts_counted_per_half {
+        format!("{}/{}", config.num_team_timeouts_allowed, fl!("half"))
     } else {
-        result += "\n";
-        result += &fl!(
-            "team-timeouts-per-game",
-            team_timeouts = config.num_team_timeouts_allowed
-        );
-    }
+        format!("{}/{}", config.num_team_timeouts_allowed, fl!("game"))
+    };
+    result += "\n";
+    result += &fl!("team-timeouts", value = team_timeouts_value);
 
     let stop_clock = if let Some(sched) = schedule {
         if let Some(timing_rule) = sched.get_game_timing(&game_number) {

--- a/refbox/translations/de-DE/refbox.ftl
+++ b/refbox/translations/de-DE/refbox.ftl
@@ -41,7 +41,7 @@ team-warning-line-2 = VERWARNUNG
 # Konfiguration
 none-selected = Nichts ausgewählt
 loading = Wird geladen...
-game-select = Spiel:
+game-select = SPIEL:
 game-options = SPIELOPTIONEN
 app-options = APP-OPTIONEN
 display-options = ANZEIGEOPTIONEN
@@ -294,8 +294,7 @@ teams = { -dark-team-name } Mannschaft: { $dark_team }
     { -light-team-name } Mannschaft: { $light_team }
 game-config = Halbzeitdauer: { $half_len },  Halbzeitpausendauer: { $half_time_len }
     Plötzlicher Tod Erlaubt: { $sd_allowed },  Verlängerung Erlaubt: { $ot_allowed }
-team-timeouts-per-half = Mannschafts-Auszeiten pro Halbzeit: { $team_timeouts }
-team-timeouts-per-game = Mannschafts-Auszeiten pro Spiel: { $team_timeouts }
+team-timeouts = Mannschafts-Auszeiten: { $value }
 stop-clock-last-2 = Uhr in den letzten 2 Minuten stoppen: { $stop_clock }
 ref-list = Hauptschiedsrichter: { $chief_ref }
     Zeitnehmer: { $timer }

--- a/refbox/translations/en-US/refbox.ftl
+++ b/refbox/translations/en-US/refbox.ftl
@@ -40,7 +40,7 @@ team-warning-line-2 = WARNING
 # Configuration
 none-selected = None Selected
 loading = Loading...
-game-select = Game:
+game-select = GAME:
 game-options = GAME OPTIONS
 app-options = APP OPTIONS
 display-options = DISPLAY OPTIONS
@@ -303,8 +303,7 @@ teams = { -dark-team-name } Team: { $dark_team }
     { -light-team-name } Team: { $light_team }
 game-config = Half Length: { $half_len },  Half Time Length: { $half_time_len }
     Sudden Death Allowed: { $sd_allowed },  Overtime Allowed: { $ot_allowed }
-team-timeouts-per-half = Team Timeouts Allowed Per Half: { $team_timeouts }
-team-timeouts-per-game = Team Timeouts Allowed Per Game: { $team_timeouts }
+team-timeouts = Team Timeouts: { $value }
 stop-clock-last-2 = Stop Clock in Last 2 Minutes: { $stop_clock }
 ref-list = Chief Ref: { $chief_ref }
     Timer: { $timer }

--- a/refbox/translations/es/refbox.ftl
+++ b/refbox/translations/es/refbox.ftl
@@ -40,7 +40,7 @@ team-warning-line-2 = DE EQUIPO
 # Configuration
 none-selected = Ninguno seleccionado
 loading = Cargando...
-game-select = Juego:
+game-select = JUEGO:
 game-options = OPCIONES DE JUEGO
 app-options = OPCIONES DE APP
 display-options = OPCIONES DE PANTALLA
@@ -305,8 +305,7 @@ teams = { -dark-team-name } Equipo: { $dark_team }
     { -light-team-name } Equipo: { $light_team }
 game-config = Duración de la mitad: { $half_len },  Duración del medio tiempo: { $half_time_len }
     Muerte súbita permitida: { $sd_allowed },  Tiempo Extra Permitido: { $ot_allowed }
-team-timeouts-per-half = Tiempos muertos de equipo permitidos por mitad: { $team_timeouts }
-team-timeouts-per-game = Tiempos muertos de equipo permitidos por juego: { $team_timeouts }
+team-timeouts = Tiempos muertos de equipo: { $value }
 stop-clock-last-2 = Detener reloj en los Últimos 2 minutos: { $stop_clock }
 ref-list = Árbitro principal: { $chief_ref }
     Timer: { $timer }

--- a/refbox/translations/fr/refbox.ftl
+++ b/refbox/translations/fr/refbox.ftl
@@ -296,8 +296,7 @@ teams = Équipe { -dark-team-name }: { $dark_team }
     Équipe { -light-team-name }: { $light_team }
 game-config = Durée de la Pér.: { $half_len },  Mi-temps: { $half_time_len }
     Mort Subite: { $sd_allowed },  Prolongations: { $ot_allowed }
-team-timeouts-per-half = Temps Morts d'Équipe Autorisés par Période: { $team_timeouts }
-team-timeouts-per-game = Temps Morts d'Équipe Autorisés par Match: { $team_timeouts }
+team-timeouts = Temps Morts d'Équipe: { $value }
 stop-clock-last-2 = Arrêter le temps dans les 2 dernières minutes: { $stop_clock }
 ref-list = Arbitre en Chef: { $chief_ref }
     Chronométreur: { $timer }

--- a/refbox/translations/id-ID/refbox.ftl
+++ b/refbox/translations/id-ID/refbox.ftl
@@ -41,7 +41,7 @@ team-warning-line-2 = TIM
 # Konfigurasi
 none-selected = Tidak Ada Dipilih
 loading = Memuat...
-game-select = Pertandingan:
+game-select = PERTANDINGAN:
 game-options = OPSI PERTANDINGAN
 app-options = OPSI APLIKASI
 display-options = OPSI TAMPILAN
@@ -294,8 +294,7 @@ teams = Tim { -dark-team-name }: { $dark_team }
     Tim { -light-team-name }: { $light_team }
 game-config = Durasi Babak: { $half_len },  Durasi Jeda Babak: { $half_time_len }
     Sudden Death Diizinkan: { $sd_allowed },  Perpanjangan Waktu Diizinkan: { $ot_allowed }
-team-timeouts-per-half = Time-out Tim yang Diizinkan Per Babak: { $team_timeouts }
-team-timeouts-per-game = Time-out Tim yang Diizinkan Per Pertandingan: { $team_timeouts }
+team-timeouts = Time-out Tim: { $value }
 stop-clock-last-2 = Hentikan Jam di 2 Menit Terakhir: { $stop_clock }
 ref-list = Wasit Kepala: { $chief_ref }
     Pencatat Waktu: { $timer }

--- a/refbox/translations/it-IT/refbox.ftl
+++ b/refbox/translations/it-IT/refbox.ftl
@@ -41,7 +41,7 @@ team-warning-line-2 = DI SQUADRA
 # Configurazione
 none-selected = Nessuno Selezionato
 loading = Caricamento...
-game-select = Partita:
+game-select = PARTITA:
 game-options = OPZIONI PARTITA
 app-options = OPZIONI APP
 display-options = OPZIONI DISPLAY
@@ -294,8 +294,7 @@ teams = Squadra { -dark-team-name }: { $dark_team }
     Squadra { -light-team-name }: { $light_team }
 game-config = Durata Tempo: { $half_len },  Durata Intervallo: { $half_time_len }
     Morte Improvvisa Consentita: { $sd_allowed },  Tempi Suppl. Consentiti: { $ot_allowed }
-team-timeouts-per-half = Time-out di Squadra Consentiti per Tempo: { $team_timeouts }
-team-timeouts-per-game = Time-out di Squadra Consentiti per Partita: { $team_timeouts }
+team-timeouts = Time-out di Squadra: { $value }
 stop-clock-last-2 = Ferma Orologio negli Ultimi 2 Minuti: { $stop_clock }
 ref-list = Capo Arbitro: { $chief_ref }
     Cronometrista: { $timer }

--- a/refbox/translations/ja-JP/refbox.ftl
+++ b/refbox/translations/ja-JP/refbox.ftl
@@ -294,8 +294,7 @@ teams = { -dark-team-name }チーム: { $dark_team }
     { -light-team-name }チーム: { $light_team }
 game-config = ハーフ時間: { $half_len },  ハーフタイム時間: { $half_time_len }
     サドンデス許可: { $sd_allowed },  延長戦許可: { $ot_allowed }
-team-timeouts-per-half = 1ハーフあたりのチームタイムアウト数: { $team_timeouts }
-team-timeouts-per-game = 1試合あたりのチームタイムアウト数: { $team_timeouts }
+team-timeouts = チームタイムアウト: { $value }
 stop-clock-last-2 = 残り2分でクロック停止: { $stop_clock }
 ref-list = 主審: { $chief_ref }
     タイムキーパー: { $timer }

--- a/refbox/translations/ko-KR/refbox.ftl
+++ b/refbox/translations/ko-KR/refbox.ftl
@@ -296,8 +296,7 @@ teams = { -dark-team-name } 팀: { $dark_team }
     { -light-team-name } 팀: { $light_team }
 game-config = 전반 시간: { $half_len },  하프타임 시간: { $half_time_len }
     서든 데스 허용: { $sd_allowed },  연장전 허용: { $ot_allowed }
-team-timeouts-per-half = 전반당 팀 타임아웃 허용 횟수: { $team_timeouts }
-team-timeouts-per-game = 경기당 팀 타임아웃 허용 횟수: { $team_timeouts }
+team-timeouts = 팀 타임아웃: { $value }
 stop-clock-last-2 = 마지막 2분 시계 정지: { $stop_clock }
 ref-list = 주심: { $chief_ref }
     계시원: { $timer }

--- a/refbox/translations/ms-MY/refbox.ftl
+++ b/refbox/translations/ms-MY/refbox.ftl
@@ -41,7 +41,7 @@ team-warning-line-2 = PASUKAN
 # Konfigurasi
 none-selected = Tiada Dipilih
 loading = Memuatkan...
-game-select = Perlawanan:
+game-select = PERLAWANAN:
 game-options = PILIHAN PERLAWANAN
 app-options = PILIHAN APLIKASI
 display-options = PILIHAN PAPARAN
@@ -294,8 +294,7 @@ teams = Pasukan { -dark-team-name }: { $dark_team }
     Pasukan { -light-team-name }: { $light_team }
 game-config = Panjang Separuh: { $half_len },  Panjang Rehat Separuh Masa: { $half_time_len }
     Sudden Death Dibenarkan: { $sd_allowed },  Masa Tambahan Dibenarkan: { $ot_allowed }
-team-timeouts-per-half = Masa Rehat Pasukan Dibenarkan Per Separuh: { $team_timeouts }
-team-timeouts-per-game = Masa Rehat Pasukan Dibenarkan Per Perlawanan: { $team_timeouts }
+team-timeouts = Masa Rehat Pasukan: { $value }
 stop-clock-last-2 = Hentikan Jam 2 Minit Terakhir: { $stop_clock }
 ref-list = Ketua Pengadil: { $chief_ref }
     Pencatat Masa: { $timer }

--- a/refbox/translations/nl-NL/refbox.ftl
+++ b/refbox/translations/nl-NL/refbox.ftl
@@ -41,7 +41,7 @@ team-warning-line-2 = WAARSCHUWING
 # Configuratie
 none-selected = Niets Geselecteerd
 loading = Laden...
-game-select = Wedstrijd:
+game-select = WEDSTRIJD:
 game-options = WEDSTRIJDOPTIES
 app-options = APP-OPTIES
 display-options = WEERGAVEOPTIES
@@ -294,8 +294,7 @@ teams = { -dark-team-name } Team: { $dark_team }
     { -light-team-name } Team: { $light_team }
 game-config = Duur Helft: { $half_len },  Duur Rust: { $half_time_len }
     Plotselinge Dood Toegestaan: { $sd_allowed },  Verlenging Toegestaan: { $ot_allowed }
-team-timeouts-per-half = Team Time-outs Toegestaan Per Helft: { $team_timeouts }
-team-timeouts-per-game = Team Time-outs Toegestaan Per Wedstrijd: { $team_timeouts }
+team-timeouts = Team Time-outs: { $value }
 stop-clock-last-2 = Klok Stoppen in Laatste 2 Minuten: { $stop_clock }
 ref-list = Hoofdscheidsrechter: { $chief_ref }
     Tijdwaarnemer: { $timer }

--- a/refbox/translations/pt-PT/refbox.ftl
+++ b/refbox/translations/pt-PT/refbox.ftl
@@ -41,7 +41,7 @@ team-warning-line-2 = EQUIPA
 # Configuração
 none-selected = Nenhum Selecionado
 loading = A carregar...
-game-select = Jogo:
+game-select = JOGO:
 game-options = OPÇÕES DE JOGO
 app-options = OPÇÕES DA APP
 display-options = OPÇÕES DE ECRÃ
@@ -294,8 +294,7 @@ teams = Equipa { -dark-team-name }: { $dark_team }
     Equipa { -light-team-name }: { $light_team }
 game-config = Duração do Tempo: { $half_len },  Duração do Intervalo: { $half_time_len }
     Morte Súbita Permitida: { $sd_allowed },  Prorrogação Permitida: { $ot_allowed }
-team-timeouts-per-half = Tempos de Equipa Permitidos Por Tempo: { $team_timeouts }
-team-timeouts-per-game = Tempos de Equipa Permitidos Por Jogo: { $team_timeouts }
+team-timeouts = Tempos de Equipa: { $value }
 stop-clock-last-2 = Parar Relógio nos Últimos 2 Minutos: { $stop_clock }
 ref-list = Árbitro Principal: { $chief_ref }
     Controlador de Tempo: { $timer }

--- a/refbox/translations/th-TH/refbox.ftl
+++ b/refbox/translations/th-TH/refbox.ftl
@@ -294,8 +294,7 @@ teams = { -dark-team-name }: { $dark_team }
     { -light-team-name }: { $light_team }
 game-config = ความยาวครึ่ง: { $half_len },  ความยาวพักครึ่ง: { $half_time_len }
     อนุญาตตายกะทันหัน: { $sd_allowed },  อนุญาตต่อเวลาพิเศษ: { $ot_allowed }
-team-timeouts-per-half = พักทีมที่อนุญาตต่อครึ่ง: { $team_timeouts }
-team-timeouts-per-game = พักทีมที่อนุญาตต่อเกม: { $team_timeouts }
+team-timeouts = พักทีม: { $value }
 stop-clock-last-2 = หยุดนาฬิกาใน 2 นาทีสุดท้าย: { $stop_clock }
 ref-list = หัวหน้าผู้ตัดสิน: { $chief_ref }
     กรรมการจับเวลา: { $timer }

--- a/refbox/translations/tl-PH/refbox.ftl
+++ b/refbox/translations/tl-PH/refbox.ftl
@@ -41,7 +41,7 @@ team-warning-line-2 = KOPONAN
 # Configuration
 none-selected = Wala na Pinili
 loading = Naglo-load...
-game-select = Laro:
+game-select = LARO:
 game-options = MGA OPSYON SA LARO
 app-options = MGA OPSYON SA APP
 display-options = MGA OPSYON SA DISPLAY
@@ -294,8 +294,7 @@ teams = Koponan ng { -dark-team-name }: { $dark_team }
     Koponan ng { -light-team-name }: { $light_team }
 game-config = Haba ng Kalahati: { $half_len },  Haba ng Pahinga: { $half_time_len }
     Sudden Death Pinahintulutan: { $sd_allowed },  Overtime Pinahintulutan: { $ot_allowed }
-team-timeouts-per-half = Mga Timeout ng Koponan na Pinahintulutan Bawat Kalahati: { $team_timeouts }
-team-timeouts-per-game = Mga Timeout ng Koponan na Pinahintulutan Bawat Laro: { $team_timeouts }
+team-timeouts = Mga Timeout ng Koponan: { $value }
 stop-clock-last-2 = Ihinto ang Orasan sa Huling 2 Minuto: { $stop_clock }
 ref-list = Punong Ref: { $chief_ref }
     Timer: { $timer }

--- a/refbox/translations/tr-TR/refbox.ftl
+++ b/refbox/translations/tr-TR/refbox.ftl
@@ -41,7 +41,7 @@ team-warning-line-2 = UYARISI
 # Yapılandırma
 none-selected = Seçim Yok
 loading = Yükleniyor...
-game-select = Oyun:
+game-select = OYUN:
 game-options = OYUN SEÇENEKLERİ
 app-options = UYGULAMA SEÇENEKLERİ
 display-options = GÖRÜNTÜ SEÇENEKLERİ
@@ -294,8 +294,7 @@ teams = { -dark-team-name } Takım: { $dark_team }
     { -light-team-name } Takım: { $light_team }
 game-config = Devre Süresi: { $half_len },  Devre Arası Süresi: { $half_time_len }
     Ani Ölüm İzin Verildi: { $sd_allowed },  Uzatma İzin Verildi: { $ot_allowed }
-team-timeouts-per-half = Devre Başına İzin Verilen Takım Molaları: { $team_timeouts }
-team-timeouts-per-game = Oyun Başına İzin Verilen Takım Molaları: { $team_timeouts }
+team-timeouts = Takım Molaları: { $value }
 stop-clock-last-2 = Son 2 Dakikada Saati Durdur: { $stop_clock }
 ref-list = Başhakem: { $chief_ref }
     Zaman Ayarlayıcı: { $timer }

--- a/refbox/translations/zh-CN/refbox.ftl
+++ b/refbox/translations/zh-CN/refbox.ftl
@@ -294,8 +294,7 @@ teams = { -dark-team-name }：{ $dark_team }
     { -light-team-name }：{ $light_team }
 game-config = 半场时长：{ $half_len }，  中场时长：{ $half_time_len }
     允许突然死亡：{ $sd_allowed }，  允许加时赛：{ $ot_allowed }
-team-timeouts-per-half = 每半场允许队伍暂停次数：{ $team_timeouts }
-team-timeouts-per-game = 每场允许队伍暂停次数：{ $team_timeouts }
+team-timeouts = 队伍暂停：{ $value }
 stop-clock-last-2 = 最后2分钟停钟：{ $stop_clock }
 ref-list = 主裁判：{ $chief_ref }
     计时员：{ $timer }


### PR DESCRIPTION
## What changed
The team-timeout line on the **Main page** and the **Game Information page** is now compact. Instead of the old full sentence ("Team Timeouts Allowed Per Half: N" / "...Per Game: N"), it reads:

- `Team Timeouts: 0` when none are allowed
- `Team Timeouts: 1/HALF` when one per half
- `Team Timeouts: 1/GAME` when one per game

This is applied in all 15 languages, with the period word (HALF/GAME) translated per locale.

Additionally, the `GAME:` label in the settings-page footer (the middle button between CANCEL and APPLY) is capitalized to match the all-caps convention of the surrounding labels on that page.

## Why
The previous line was long and wordy. A compact, consistent label is quicker to read at a glance, and the footer label was the only one on that page that wasn't capitalized.

## Scope
Changes are limited to the `refbox` crate:
- `refbox/src/app/view_builders/shared_elements.rs` and `game_info.rs` (the two render sites)
- the 15 locale `.ftl` translation files

No changes to game logic, the `GameConfig` data model, or any other crate. The period word reuses the existing `half` / `game` translation keys (already used by the timeout-edit toggle buttons), so the display stays in sync with those buttons.

## How to verify
1. Open the app. On the **Main page** and the **Game Information page**, the configuration summary shows `Team Timeouts: 1/HALF` with default settings.
2. On the **settings page**, the footer button between CANCEL and APPLY reads `GAME: <n>` (capitalized).
3. Toggle team timeouts from per-half to per-game to see it flip to `1/GAME`; set the allowed count to 0 to see `0`.
