### PR TITLE
feat(refbox): redesign team-timeout settings page

### DIFF
--- a/refbox/src/app/message.rs
+++ b/refbox/src/app/message.rs
@@ -123,6 +123,10 @@ pub enum Message {
     ParameterSelected(ListableParameter, String),
     ToggleBoolParameter(BoolGameParameter),
     CycleParameter(CyclingParameter),
+    /// Set the team-timeout count directly (team-timeout edit page 0/1 toggle).
+    SetTeamTimeoutCount(u32),
+    /// Set the team-timeout length to a preset value (team-timeout edit page).
+    SetTeamTimeoutLength(Duration),
     /// Advance the on-screen display mode (Light → Dark → High Contrast → …).
     /// Commits immediately; not part of the DONE/Apply settings round-trip.
     CycleDisplayMode,
@@ -369,7 +373,9 @@ impl Message {
             | Self::UpdatesVerified(_)
             | Self::UpdatesInstalled(_)
             | Self::UpdatesBack
-            | Self::UpdaterHealthyCheck => false,
+            | Self::UpdaterHealthyCheck
+            | Self::SetTeamTimeoutCount(_)
+            | Self::SetTeamTimeoutLength(_) => false,
         }
     }
 }
@@ -565,6 +571,8 @@ impl PartialEq for Message {
             (Self::RecvSchedule(a, b), Self::RecvSchedule(c, d)) => a == c && b == d,
             (Self::RecvPortalToken(a), Self::RecvPortalToken(b)) => a == b,
             (Self::RecvTokenValid(a), Self::RecvTokenValid(b)) => a == b,
+            (Self::SetTeamTimeoutCount(a), Self::SetTeamTimeoutCount(b)) => a == b,
+            (Self::SetTeamTimeoutLength(a), Self::SetTeamTimeoutLength(b)) => a == b,
             (Self::UpdatesCheckDone(a), Self::UpdatesCheckDone(b)) => a == b,
             (Self::UpdatesDownloaded(a), Self::UpdatesDownloaded(b)) => a == b,
             (Self::UpdatesVerified(a), Self::UpdatesVerified(b)) => a == b,
@@ -683,6 +691,8 @@ impl PartialEq for Message {
             | (Self::UpdatesInstalled(_), _)
             | (Self::UpdatesBack, _)
             | (Self::UpdaterHealthyCheck, _)
+            | (Self::SetTeamTimeoutCount(_), _)
+            | (Self::SetTeamTimeoutLength(_), _)
             | (Self::NoAction, _) => false,
         }
     }

--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -2140,6 +2140,28 @@ impl RefBoxApp {
                 trace!("AppState changed to {:?}", self.app_state);
                 Task::none()
             }
+            Message::SetTeamTimeoutCount(count) => {
+                if let AppState::KeypadPage(KeypadPage::TeamTimeouts(_, _), ref mut val) =
+                    self.app_state
+                {
+                    *val = count;
+                } else {
+                    unreachable!()
+                }
+                trace!("AppState changed to {:?}", self.app_state);
+                Task::none()
+            }
+            Message::SetTeamTimeoutLength(new_len) => {
+                if let AppState::KeypadPage(KeypadPage::TeamTimeouts(ref mut dur, _), _) =
+                    self.app_state
+                {
+                    *dur = new_len;
+                } else {
+                    unreachable!()
+                }
+                trace!("AppState changed to {:?}", self.app_state);
+                Task::none()
+            }
             Message::ChangeColor(new_color) => {
                 match self.app_state {
                     AppState::KeypadPage(KeypadPage::AddScore(ref mut color), _)

--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -2094,9 +2094,11 @@ impl RefBoxApp {
                         .player_number
                         .map(|n| n.into())
                         .unwrap_or(0),
-                    KeypadPage::TeamTimeouts(_, _) => {
-                        self.config.game.num_team_timeouts_allowed as u32
-                    }
+                    KeypadPage::TeamTimeouts(_, _) => self
+                        .edited_settings
+                        .as_ref()
+                        .map(|s| s.config.num_team_timeouts_allowed as u32)
+                        .unwrap_or(self.config.game.num_team_timeouts_allowed as u32),
                     KeypadPage::GameNumber => self
                         .edited_settings
                         .as_ref()

--- a/refbox/src/app/view_builders/configuration.rs
+++ b/refbox/src/app/view_builders/configuration.rs
@@ -815,12 +815,16 @@ fn make_event_config_page<'a>(
             .push(
                 row![
                     make_value_button(
-                        if config.timeouts_counted_per_half {
-                            fl!("num-tos-per-half")
+                        fl!("team-timeouts-label"),
+                        // Compact value, matching the "0 / 1/HALF / 1/GAME"
+                        // representation used on the Main and Game Info pages.
+                        if config.num_team_timeouts_allowed == 0 {
+                            "0".to_string()
+                        } else if config.timeouts_counted_per_half {
+                            format!("{}/{}", config.num_team_timeouts_allowed, fl!("half"))
                         } else {
-                            fl!("num-tos-per-game")
+                            format!("{}/{}", config.num_team_timeouts_allowed, fl!("game"))
                         },
-                        config.num_team_timeouts_allowed.to_string(),
                         (false, true),
                         Some(Message::KeypadPage(KeypadPage::TeamTimeouts(
                             config.team_timeout_duration,

--- a/refbox/src/app/view_builders/keypad_pages/mod.rs
+++ b/refbox/src/app/view_builders/keypad_pages/mod.rs
@@ -55,6 +55,27 @@ pub(in super::super) fn build_keypad_page<'a>(
         _ => true,
     };
 
+    // The team-timeout settings page does not use the shared number pad; it
+    // renders as a full-width panel below the game-time bar.
+    if let KeypadPage::TeamTimeouts(dur, per_half) = &page {
+        let (dur, per_half) = (*dur, *per_half);
+        return column![
+            make_game_time_button(
+                snapshot,
+                false,
+                false,
+                mode,
+                clock_running,
+                portal_indicator,
+                None
+            ),
+            make_team_timeout_edit_page(dur, per_half, player_num),
+        ]
+        .spacing(SPACING)
+        .height(Length::Fill)
+        .into();
+    }
+
     let setup_keypad_button =
         |button: Button<'a, Message>, message: Message| -> Button<'a, Message> {
             let button = if enabled {
@@ -204,8 +225,9 @@ pub(in super::super) fn build_keypad_page<'a>(
                     )
                 }
                 KeypadPage::GameNumber => make_game_number_edit_page(),
-                KeypadPage::TeamTimeouts(dur, per_half) =>
-                    make_team_timeout_edit_page(dur, per_half),
+                KeypadPage::TeamTimeouts(_, _) => {
+                    unreachable!("TeamTimeouts is handled by the early return above")
+                }
                 KeypadPage::FoulAdd {
                     origin,
                     color,

--- a/refbox/src/app/view_builders/keypad_pages/team_timeout_edit.rs
+++ b/refbox/src/app/view_builders/keypad_pages/team_timeout_edit.rs
@@ -3,7 +3,7 @@ use iced::{
     Length, Theme,
     widget::{
         button::{Status, Style},
-        column, row, text, vertical_space,
+        column, horizontal_space, row, text, vertical_space,
     },
 };
 use std::time::Duration;
@@ -11,13 +11,7 @@ use std::time::Duration;
 type StyleFn = fn(&Theme, Status) -> Style;
 
 /// Length presets shown on the team-timeout edit page: (label, seconds).
-const LENGTH_PRESETS: [(&str, u64); 5] = [
-    ("0:30", 30),
-    ("0:45", 45),
-    ("1:00", 60),
-    ("1:15", 75),
-    ("1:30", 90),
-];
+const LENGTH_PRESETS: [(&str, u64); 3] = [("0:30", 30), ("1:00", 60), ("1:30", 90)];
 
 pub(super) fn make_team_timeout_edit_page<'a>(
     duration: Duration,
@@ -33,10 +27,10 @@ pub(super) fn make_team_timeout_edit_page<'a>(
     let (zero_style, zero_msg): (StyleFn, _) = if zero_selected {
         (blue_selected_button, Message::NoAction)
     } else {
-        (blue_button, Message::SetTeamTimeoutCount(0))
+        (light_gray_button, Message::SetTeamTimeoutCount(0))
     };
     let (one_style, one_msg): (StyleFn, _) = if zero_selected {
-        (blue_button, Message::SetTeamTimeoutCount(1))
+        (light_gray_button, Message::SetTeamTimeoutCount(1))
     } else {
         (blue_selected_button, Message::NoAction)
     };
@@ -64,10 +58,10 @@ pub(super) fn make_team_timeout_edit_page<'a>(
     let half_style: StyleFn = if timeouts_counted_per_half {
         blue_selected_button
     } else {
-        blue_button
+        light_gray_button
     };
     let game_style: StyleFn = if timeouts_counted_per_half {
-        blue_button
+        light_gray_button
     } else {
         blue_selected_button
     };
@@ -111,9 +105,11 @@ pub(super) fn make_team_timeout_edit_page<'a>(
         let style: StyleFn = if selected {
             blue_selected_button
         } else {
-            blue_button
+            light_gray_button
         };
-        let mut b = make_button(label).style(style).width(Length::Fill);
+        let mut b = make_button(label)
+            .style(style)
+            .width(Length::FillPortion(2));
         if count_enabled {
             b = b.on_press(if selected {
                 Message::NoAction
@@ -124,35 +120,31 @@ pub(super) fn make_team_timeout_edit_page<'a>(
         b.into()
     };
 
-    let presets_row = row![
+    // Length label + the three presets share one row: the label takes 1/3
+    // (matching the labels above) and the three presets share the other 2/3.
+    let length_row = row![
+        text(fl!("timeout-length"))
+            .size(SMALL_PLUS_TEXT)
+            .width(Length::FillPortion(3))
+            .height(Length::Fixed(MIN_BUTTON_SIZE))
+            .align_y(Vertical::Center),
         make_preset(LENGTH_PRESETS[0].0, LENGTH_PRESETS[0].1),
         make_preset(LENGTH_PRESETS[1].0, LENGTH_PRESETS[1].1),
         make_preset(LENGTH_PRESETS[2].0, LENGTH_PRESETS[2].1),
-        make_preset(LENGTH_PRESETS[3].0, LENGTH_PRESETS[3].1),
-        make_preset(LENGTH_PRESETS[4].0, LENGTH_PRESETS[4].1),
-    ]
-    .spacing(SPACING);
-
-    let length_block = column![
-        text(fl!("timeout-length"))
-            .size(SMALL_PLUS_TEXT)
-            .height(Length::Fixed(MIN_BUTTON_SIZE))
-            .align_y(Vertical::Center),
-        presets_row,
     ]
     .spacing(SPACING);
 
     column![
         count_row,
         counted_per_row,
-        vertical_space(),
-        length_block,
+        length_row,
         vertical_space(),
         row![
             make_button(fl!("cancel"))
                 .style(red_button)
                 .width(Length::Fill)
                 .on_press(Message::ParameterEditComplete { canceled: true }),
+            horizontal_space(),
             make_button(fl!("apply"))
                 .style(green_button)
                 .width(Length::Fill)

--- a/refbox/src/app/view_builders/keypad_pages/team_timeout_edit.rs
+++ b/refbox/src/app/view_builders/keypad_pages/team_timeout_edit.rs
@@ -3,63 +3,157 @@ use iced::{
     Length, Theme,
     widget::{
         button::{Status, Style},
-        column, horizontal_space, row, vertical_space,
+        column, row, text, vertical_space,
     },
 };
 use std::time::Duration;
 
 type StyleFn = fn(&Theme, Status) -> Style;
 
+/// Length presets shown on the team-timeout edit page: (label, seconds).
+const LENGTH_PRESETS: [(&str, u64); 5] = [
+    ("0:30", 30),
+    ("0:45", 45),
+    ("1:00", 60),
+    ("1:15", 75),
+    ("1:30", 90),
+];
+
 pub(super) fn make_team_timeout_edit_page<'a>(
     duration: Duration,
     timeouts_counted_per_half: bool,
+    count: u32,
 ) -> Element<'a, Message> {
-    let (half_style, half_message, game_style, game_message): (StyleFn, _, StyleFn, _) =
-        if timeouts_counted_per_half {
-            (
-                blue_selected_button,
-                Message::NoAction,
-                blue_button,
-                Message::ToggleBoolParameter(BoolGameParameter::TimeoutsCountedPerHalf),
-            )
+    // Count 0 means "no team timeouts": the period and length controls are
+    // meaningless, so they render disabled (greyed, non-pressable). The count
+    // buttons themselves stay active. Any non-zero count shows "1" selected.
+    let zero_selected = count == 0;
+    let count_enabled = !zero_selected;
+
+    let (zero_style, zero_msg): (StyleFn, _) = if zero_selected {
+        (blue_selected_button, Message::NoAction)
+    } else {
+        (blue_button, Message::SetTeamTimeoutCount(0))
+    };
+    let (one_style, one_msg): (StyleFn, _) = if zero_selected {
+        (blue_button, Message::SetTeamTimeoutCount(1))
+    } else {
+        (blue_selected_button, Message::NoAction)
+    };
+
+    let count_row = row![
+        text(fl!("team-timeout-count"))
+            .size(SMALL_PLUS_TEXT)
+            .width(Length::Fill)
+            .height(Length::Fixed(MIN_BUTTON_SIZE))
+            .align_y(Vertical::Center),
+        make_button("0")
+            .style(zero_style)
+            .width(Length::Fill)
+            .on_press(zero_msg),
+        make_button("1")
+            .style(one_style)
+            .width(Length::Fill)
+            .on_press(one_msg),
+    ]
+    .spacing(SPACING);
+
+    // HALF/GAME toggle. Styles always reflect the current selection so the
+    // operator can still see the chosen period while disabled; on_press is
+    // only attached when the count is non-zero.
+    let half_style: StyleFn = if timeouts_counted_per_half {
+        blue_selected_button
+    } else {
+        blue_button
+    };
+    let game_style: StyleFn = if timeouts_counted_per_half {
+        blue_button
+    } else {
+        blue_selected_button
+    };
+    let (half_msg, game_msg) = if timeouts_counted_per_half {
+        (
+            Message::NoAction,
+            Message::ToggleBoolParameter(BoolGameParameter::TimeoutsCountedPerHalf),
+        )
+    } else {
+        (
+            Message::ToggleBoolParameter(BoolGameParameter::TimeoutsCountedPerHalf),
+            Message::NoAction,
+        )
+    };
+    let mut half_button = make_button(fl!("half"))
+        .style(half_style)
+        .width(Length::Fill);
+    let mut game_button = make_button(fl!("game"))
+        .style(game_style)
+        .width(Length::Fill);
+    if count_enabled {
+        half_button = half_button.on_press(half_msg);
+        game_button = game_button.on_press(game_msg);
+    }
+
+    let counted_per_row = row![
+        text(fl!("timeouts-counted-per"))
+            .size(SMALL_PLUS_TEXT)
+            .width(Length::Fill)
+            .height(Length::Fixed(MIN_BUTTON_SIZE))
+            .align_y(Vertical::Center),
+        half_button,
+        game_button,
+    ]
+    .spacing(SPACING);
+
+    // Length presets. Selected = the preset matching the current duration.
+    let make_preset = |label: &'a str, secs: u64| -> Element<'a, Message> {
+        let preset_dur = Duration::from_secs(secs);
+        let selected = duration == preset_dur;
+        let style: StyleFn = if selected {
+            blue_selected_button
         } else {
-            (
-                blue_button,
-                Message::ToggleBoolParameter(BoolGameParameter::TimeoutsCountedPerHalf),
-                blue_selected_button,
-                Message::NoAction,
-            )
+            blue_button
         };
+        let mut b = make_button(label).style(style).width(Length::Fill);
+        if count_enabled {
+            b = b.on_press(if selected {
+                Message::NoAction
+            } else {
+                Message::SetTeamTimeoutLength(preset_dur)
+            });
+        }
+        b.into()
+    };
+
+    let presets_row = row![
+        make_preset(LENGTH_PRESETS[0].0, LENGTH_PRESETS[0].1),
+        make_preset(LENGTH_PRESETS[1].0, LENGTH_PRESETS[1].1),
+        make_preset(LENGTH_PRESETS[2].0, LENGTH_PRESETS[2].1),
+        make_preset(LENGTH_PRESETS[3].0, LENGTH_PRESETS[3].1),
+        make_preset(LENGTH_PRESETS[4].0, LENGTH_PRESETS[4].1),
+    ]
+    .spacing(SPACING);
+
+    let length_block = column![
+        text(fl!("timeout-length"))
+            .size(SMALL_PLUS_TEXT)
+            .height(Length::Fixed(MIN_BUTTON_SIZE))
+            .align_y(Vertical::Center),
+        presets_row,
+    ]
+    .spacing(SPACING);
 
     column![
-        row![
-            text(fl!("timeouts-counted-per"))
-                .size(SMALL_PLUS_TEXT)
-                .height(Length::Fixed(MIN_BUTTON_SIZE))
-                .align_y(Vertical::Center),
-            make_button(fl!("half"))
-                .style(half_style)
-                .width(Length::Fill)
-                .on_press(half_message),
-            make_button(fl!("game"))
-                .style(game_style)
-                .width(Length::Fill)
-                .on_press(game_message),
-        ]
-        .spacing(SPACING),
+        count_row,
+        counted_per_row,
         vertical_space(),
-        row![
-            horizontal_space(),
-            make_time_editor(fl!("timeout-length"), duration, false, None),
-            horizontal_space()
-        ],
+        length_block,
         vertical_space(),
         row![
             make_button(fl!("cancel"))
                 .style(red_button)
                 .width(Length::Fill)
                 .on_press(Message::ParameterEditComplete { canceled: true }),
-            make_button(fl!("done"))
+            make_button(fl!("apply"))
                 .style(green_button)
                 .width(Length::Fill)
                 .on_press(Message::ParameterEditComplete { canceled: false }),
@@ -67,5 +161,6 @@ pub(super) fn make_team_timeout_edit_page<'a>(
         .spacing(SPACING),
     ]
     .spacing(SPACING)
+    .height(Length::Fill)
     .into()
 }

--- a/refbox/src/app/view_builders/shared_elements.rs
+++ b/refbox/src/app/view_builders/shared_elements.rs
@@ -1175,23 +1175,22 @@ where
 {
     let mut button = button(
         row![
-            text(first_label)
-                .size(if large_text.0 {
-                    MEDIUM_TEXT
-                } else {
-                    SMALL_TEXT
-                })
-                .height(Length::Fill)
-                .align_y(Vertical::Center),
+            // Do NOT pair `align_y(Center)` with `height(Fill)` on these text
+            // widgets: that caches a paragraph-position anchor that bleeds
+            // across renders (iced 0.13 bug; see portal_detail::row_text_centered
+            // and the time-view fix in this file). The row's `.align_y(Center)`
+            // below handles the vertical centering instead.
+            text(first_label).size(if large_text.0 {
+                MEDIUM_TEXT
+            } else {
+                SMALL_TEXT
+            }),
             horizontal_space(),
-            text(second_label)
-                .size(if large_text.1 {
-                    MEDIUM_TEXT
-                } else {
-                    SMALL_TEXT
-                })
-                .height(Length::Fill)
-                .align_y(Vertical::Center),
+            text(second_label).size(if large_text.1 {
+                MEDIUM_TEXT
+            } else {
+                SMALL_TEXT
+            }),
         ]
         .spacing(SPACING)
         .align_y(Alignment::Center)

--- a/refbox/translations/de-DE/refbox.ftl
+++ b/refbox/translations/de-DE/refbox.ftl
@@ -30,7 +30,7 @@ penalty-kind = {$kind ->
 
 # Auszeit-Bearbeitung
 timeout-length = AUSZEIT
-    DAUER
+    DAUER:
 team-timeout-count = AUSZEIT
     ANZAHL:
 
@@ -306,6 +306,8 @@ teams = { -dark-team-name } Mannschaft: { $dark_team }
 game-config = Halbzeitdauer: { $half_len },  Halbzeitpausendauer: { $half_time_len }
     Plötzlicher Tod Erlaubt: { $sd_allowed },  Verlängerung Erlaubt: { $ot_allowed }
 team-timeouts = Mannschafts-Auszeiten: { $value }
+team-timeouts-label = MANNSCHAFTS-
+    AUSZEITEN:
 stop-clock-last-2 = Uhr in den letzten 2 Minuten stoppen: { $stop_clock }
 ref-list = Hauptschiedsrichter: { $chief_ref }
     Zeitnehmer: { $timer }

--- a/refbox/translations/de-DE/refbox.ftl
+++ b/refbox/translations/de-DE/refbox.ftl
@@ -31,6 +31,8 @@ penalty-kind = {$kind ->
 # Auszeit-Bearbeitung
 timeout-length = AUSZEIT
     DAUER
+team-timeout-count = AUSZEIT
+    ANZAHL:
 
 # Verwarnung hinzufügen
 team-warning = MANNSCHAFT

--- a/refbox/translations/en-US/refbox.ftl
+++ b/refbox/translations/en-US/refbox.ftl
@@ -30,6 +30,8 @@ penalty-kind = {$kind ->
 # Team Timeout Edit
 timeout-length = TEAM TIMEOUT
     LENGTH
+team-timeout-count = TEAM TIMEOUT
+    COUNT:
 
 # Warning Add
 team-warning = TEAM

--- a/refbox/translations/en-US/refbox.ftl
+++ b/refbox/translations/en-US/refbox.ftl
@@ -29,7 +29,7 @@ penalty-kind = {$kind ->
 
 # Team Timeout Edit
 timeout-length = TEAM TIMEOUT
-    LENGTH
+    LENGTH:
 team-timeout-count = TEAM TIMEOUT
     COUNT:
 
@@ -315,6 +315,8 @@ teams = { -dark-team-name } Team: { $dark_team }
 game-config = Half Length: { $half_len },  Half Time Length: { $half_time_len }
     Sudden Death Allowed: { $sd_allowed },  Overtime Allowed: { $ot_allowed }
 team-timeouts = Team Timeouts: { $value }
+team-timeouts-label = TEAM
+    TIMEOUTS:
 stop-clock-last-2 = Stop Clock in Last 2 Minutes: { $stop_clock }
 ref-list = Chief Ref: { $chief_ref }
     Timer: { $timer }

--- a/refbox/translations/es/refbox.ftl
+++ b/refbox/translations/es/refbox.ftl
@@ -30,6 +30,8 @@ penalty-kind = {$kind ->
 # Team Timeout Edit
 timeout-length = DURACIÓN DEL
     TIEMPO DE ESPERA
+team-timeout-count = NÚMERO DE
+    TIEMPOS DE ESPERA:
 
 # Warning Add
 team-warning = AVISO

--- a/refbox/translations/es/refbox.ftl
+++ b/refbox/translations/es/refbox.ftl
@@ -29,7 +29,7 @@ penalty-kind = {$kind ->
 
 # Team Timeout Edit
 timeout-length = DURACIÓN DEL
-    TIEMPO DE ESPERA
+    TIEMPO DE ESPERA:
 team-timeout-count = NÚMERO DE
     TIEMPOS DE ESPERA:
 
@@ -317,6 +317,8 @@ teams = { -dark-team-name } Equipo: { $dark_team }
 game-config = Duración de la mitad: { $half_len },  Duración del medio tiempo: { $half_time_len }
     Muerte súbita permitida: { $sd_allowed },  Tiempo Extra Permitido: { $ot_allowed }
 team-timeouts = Tiempos muertos de equipo: { $value }
+team-timeouts-label = TIEMPOS MUERTOS
+    DE EQUIPO:
 stop-clock-last-2 = Detener reloj en los Últimos 2 minutos: { $stop_clock }
 ref-list = Árbitro principal: { $chief_ref }
     Timer: { $timer }

--- a/refbox/translations/fr/refbox.ftl
+++ b/refbox/translations/fr/refbox.ftl
@@ -29,6 +29,8 @@ penalty-kind = {$kind ->
 
 # Team Timeout Edit
 timeout-length = DURÉE DU TEMPS MORT
+team-timeout-count = NOMBRE DE
+    TEMPS MORTS:
 
 # Warning Add
 team-warning = AVERT. D'ÉQUIPE

--- a/refbox/translations/fr/refbox.ftl
+++ b/refbox/translations/fr/refbox.ftl
@@ -28,7 +28,7 @@ penalty-kind = {$kind ->
 }
 
 # Team Timeout Edit
-timeout-length = DURÉE DU TEMPS MORT
+timeout-length = DURÉE DU TEMPS MORT:
 team-timeout-count = NOMBRE DE
     TEMPS MORTS:
 
@@ -308,6 +308,8 @@ teams = Équipe { -dark-team-name }: { $dark_team }
 game-config = Durée de la Pér.: { $half_len },  Mi-temps: { $half_time_len }
     Mort Subite: { $sd_allowed },  Prolongations: { $ot_allowed }
 team-timeouts = Temps Morts d'Équipe: { $value }
+team-timeouts-label = TEMPS MORTS
+    D'ÉQUIPE:
 stop-clock-last-2 = Arrêter le temps dans les 2 dernières minutes: { $stop_clock }
 ref-list = Arbitre en Chef: { $chief_ref }
     Chronométreur: { $timer }

--- a/refbox/translations/id-ID/refbox.ftl
+++ b/refbox/translations/id-ID/refbox.ftl
@@ -30,7 +30,7 @@ penalty-kind = {$kind ->
 
 # Edit Time-out Tim
 timeout-length = TIME-OUT TIM
-    DURASI
+    DURASI:
 team-timeout-count = JUMLAH
     TIME-OUT TIM:
 
@@ -306,6 +306,8 @@ teams = Tim { -dark-team-name }: { $dark_team }
 game-config = Durasi Babak: { $half_len },  Durasi Jeda Babak: { $half_time_len }
     Sudden Death Diizinkan: { $sd_allowed },  Perpanjangan Waktu Diizinkan: { $ot_allowed }
 team-timeouts = Time-out Tim: { $value }
+team-timeouts-label = TIME-OUT
+    TIM:
 stop-clock-last-2 = Hentikan Jam di 2 Menit Terakhir: { $stop_clock }
 ref-list = Wasit Kepala: { $chief_ref }
     Pencatat Waktu: { $timer }

--- a/refbox/translations/id-ID/refbox.ftl
+++ b/refbox/translations/id-ID/refbox.ftl
@@ -31,6 +31,8 @@ penalty-kind = {$kind ->
 # Edit Time-out Tim
 timeout-length = TIME-OUT TIM
     DURASI
+team-timeout-count = JUMLAH
+    TIME-OUT TIM:
 
 # Tambah Peringatan
 team-warning = PERINGATAN

--- a/refbox/translations/it-IT/refbox.ftl
+++ b/refbox/translations/it-IT/refbox.ftl
@@ -30,7 +30,7 @@ penalty-kind = {$kind ->
 
 # Modifica Time-out di Squadra
 timeout-length = TIME-OUT DI
-    SQUADRA
+    SQUADRA:
 team-timeout-count = NUMERO DI
     TIME-OUT:
 
@@ -306,6 +306,8 @@ teams = Squadra { -dark-team-name }: { $dark_team }
 game-config = Durata Tempo: { $half_len },  Durata Intervallo: { $half_time_len }
     Morte Improvvisa Consentita: { $sd_allowed },  Tempi Suppl. Consentiti: { $ot_allowed }
 team-timeouts = Time-out di Squadra: { $value }
+team-timeouts-label = TIME-OUT DI
+    SQUADRA:
 stop-clock-last-2 = Ferma Orologio negli Ultimi 2 Minuti: { $stop_clock }
 ref-list = Capo Arbitro: { $chief_ref }
     Cronometrista: { $timer }

--- a/refbox/translations/it-IT/refbox.ftl
+++ b/refbox/translations/it-IT/refbox.ftl
@@ -31,6 +31,8 @@ penalty-kind = {$kind ->
 # Modifica Time-out di Squadra
 timeout-length = TIME-OUT DI
     SQUADRA
+team-timeout-count = NUMERO DI
+    TIME-OUT:
 
 # Aggiunta Ammonizione
 team-warning = AMMONIZIONE

--- a/refbox/translations/ja-JP/refbox.ftl
+++ b/refbox/translations/ja-JP/refbox.ftl
@@ -30,7 +30,7 @@ penalty-kind = {$kind ->
 
 # チームタイムアウト編集
 timeout-length = チームタイムアウト
-    時間
+    時間:
 team-timeout-count = チームタイムアウト
     回数:
 
@@ -306,6 +306,8 @@ teams = { -dark-team-name }チーム: { $dark_team }
 game-config = ハーフ時間: { $half_len },  ハーフタイム時間: { $half_time_len }
     サドンデス許可: { $sd_allowed },  延長戦許可: { $ot_allowed }
 team-timeouts = チームタイムアウト: { $value }
+team-timeouts-label = チーム
+    タイムアウト:
 stop-clock-last-2 = 残り2分でクロック停止: { $stop_clock }
 ref-list = 主審: { $chief_ref }
     タイムキーパー: { $timer }

--- a/refbox/translations/ja-JP/refbox.ftl
+++ b/refbox/translations/ja-JP/refbox.ftl
@@ -31,6 +31,8 @@ penalty-kind = {$kind ->
 # チームタイムアウト編集
 timeout-length = チームタイムアウト
     時間
+team-timeout-count = チームタイムアウト
+    回数:
 
 # 警告追加
 team-warning = チーム

--- a/refbox/translations/ko-KR/refbox.ftl
+++ b/refbox/translations/ko-KR/refbox.ftl
@@ -33,6 +33,8 @@ penalty-kind = {$kind ->
 # 팀 타임아웃 편집
 timeout-length = 팀 타임아웃
     시간
+team-timeout-count = 팀 타임아웃
+    횟수:
 
 # 경고 추가
 team-warning = 팀

--- a/refbox/translations/ko-KR/refbox.ftl
+++ b/refbox/translations/ko-KR/refbox.ftl
@@ -32,7 +32,7 @@ penalty-kind = {$kind ->
 
 # 팀 타임아웃 편집
 timeout-length = 팀 타임아웃
-    시간
+    시간:
 team-timeout-count = 팀 타임아웃
     횟수:
 
@@ -308,6 +308,8 @@ teams = { -dark-team-name } 팀: { $dark_team }
 game-config = 전반 시간: { $half_len },  하프타임 시간: { $half_time_len }
     서든 데스 허용: { $sd_allowed },  연장전 허용: { $ot_allowed }
 team-timeouts = 팀 타임아웃: { $value }
+team-timeouts-label = 팀
+    타임아웃:
 stop-clock-last-2 = 마지막 2분 시계 정지: { $stop_clock }
 ref-list = 주심: { $chief_ref }
     계시원: { $timer }

--- a/refbox/translations/ms-MY/refbox.ftl
+++ b/refbox/translations/ms-MY/refbox.ftl
@@ -30,7 +30,7 @@ penalty-kind = {$kind ->
 
 # Edit Masa Rehat Pasukan
 timeout-length = MASA REHAT
-    PASUKAN
+    PASUKAN:
 team-timeout-count = BILANGAN
     MASA REHAT:
 
@@ -306,6 +306,8 @@ teams = Pasukan { -dark-team-name }: { $dark_team }
 game-config = Panjang Separuh: { $half_len },  Panjang Rehat Separuh Masa: { $half_time_len }
     Sudden Death Dibenarkan: { $sd_allowed },  Masa Tambahan Dibenarkan: { $ot_allowed }
 team-timeouts = Masa Rehat Pasukan: { $value }
+team-timeouts-label = MASA REHAT
+    PASUKAN:
 stop-clock-last-2 = Hentikan Jam 2 Minit Terakhir: { $stop_clock }
 ref-list = Ketua Pengadil: { $chief_ref }
     Pencatat Masa: { $timer }

--- a/refbox/translations/ms-MY/refbox.ftl
+++ b/refbox/translations/ms-MY/refbox.ftl
@@ -31,6 +31,8 @@ penalty-kind = {$kind ->
 # Edit Masa Rehat Pasukan
 timeout-length = MASA REHAT
     PASUKAN
+team-timeout-count = BILANGAN
+    MASA REHAT:
 
 # Tambah Amaran
 team-warning = AMARAN

--- a/refbox/translations/nl-NL/refbox.ftl
+++ b/refbox/translations/nl-NL/refbox.ftl
@@ -30,7 +30,7 @@ penalty-kind = {$kind ->
 
 # Team time-out bewerken
 timeout-length = TEAM TIME-OUT
-    DUUR
+    DUUR:
 team-timeout-count = AANTAL
     TEAM TIME-OUTS:
 
@@ -306,6 +306,8 @@ teams = { -dark-team-name } Team: { $dark_team }
 game-config = Duur Helft: { $half_len },  Duur Rust: { $half_time_len }
     Plotselinge Dood Toegestaan: { $sd_allowed },  Verlenging Toegestaan: { $ot_allowed }
 team-timeouts = Team Time-outs: { $value }
+team-timeouts-label = TEAM
+    TIME-OUTS:
 stop-clock-last-2 = Klok Stoppen in Laatste 2 Minuten: { $stop_clock }
 ref-list = Hoofdscheidsrechter: { $chief_ref }
     Tijdwaarnemer: { $timer }

--- a/refbox/translations/nl-NL/refbox.ftl
+++ b/refbox/translations/nl-NL/refbox.ftl
@@ -31,6 +31,8 @@ penalty-kind = {$kind ->
 # Team time-out bewerken
 timeout-length = TEAM TIME-OUT
     DUUR
+team-timeout-count = AANTAL
+    TEAM TIME-OUTS:
 
 # Waarschuwing toevoegen
 team-warning = TEAM-

--- a/refbox/translations/pt-PT/refbox.ftl
+++ b/refbox/translations/pt-PT/refbox.ftl
@@ -30,7 +30,7 @@ penalty-kind = {$kind ->
 
 # Edição de Tempo de Equipa
 timeout-length = DURAÇÃO DO
-    TEMPO DE EQUIPA
+    TEMPO DE EQUIPA:
 team-timeout-count = NÚMERO DE
     TEMPOS DE EQUIPA:
 
@@ -306,6 +306,8 @@ teams = Equipa { -dark-team-name }: { $dark_team }
 game-config = Duração do Tempo: { $half_len },  Duração do Intervalo: { $half_time_len }
     Morte Súbita Permitida: { $sd_allowed },  Prorrogação Permitida: { $ot_allowed }
 team-timeouts = Tempos de Equipa: { $value }
+team-timeouts-label = TEMPOS DE
+    EQUIPA:
 stop-clock-last-2 = Parar Relógio nos Últimos 2 Minutos: { $stop_clock }
 ref-list = Árbitro Principal: { $chief_ref }
     Controlador de Tempo: { $timer }

--- a/refbox/translations/pt-PT/refbox.ftl
+++ b/refbox/translations/pt-PT/refbox.ftl
@@ -31,6 +31,8 @@ penalty-kind = {$kind ->
 # Edição de Tempo de Equipa
 timeout-length = DURAÇÃO DO
     TEMPO DE EQUIPA
+team-timeout-count = NÚMERO DE
+    TEMPOS DE EQUIPA:
 
 # Adicionar Aviso
 team-warning = AVISO DE

--- a/refbox/translations/th-TH/refbox.ftl
+++ b/refbox/translations/th-TH/refbox.ftl
@@ -30,7 +30,7 @@ penalty-kind = {$kind ->
 
 # แก้ไขพักทีม
 timeout-length = ระยะเวลา
-    พักทีม
+    พักทีม:
 team-timeout-count = จำนวน
     พักทีม:
 
@@ -306,6 +306,7 @@ teams = { -dark-team-name }: { $dark_team }
 game-config = ความยาวครึ่ง: { $half_len },  ความยาวพักครึ่ง: { $half_time_len }
     อนุญาตตายกะทันหัน: { $sd_allowed },  อนุญาตต่อเวลาพิเศษ: { $ot_allowed }
 team-timeouts = พักทีม: { $value }
+team-timeouts-label = พักทีม:
 stop-clock-last-2 = หยุดนาฬิกาใน 2 นาทีสุดท้าย: { $stop_clock }
 ref-list = หัวหน้าผู้ตัดสิน: { $chief_ref }
     กรรมการจับเวลา: { $timer }

--- a/refbox/translations/th-TH/refbox.ftl
+++ b/refbox/translations/th-TH/refbox.ftl
@@ -31,6 +31,8 @@ penalty-kind = {$kind ->
 # แก้ไขพักทีม
 timeout-length = ระยะเวลา
     พักทีม
+team-timeout-count = จำนวน
+    พักทีม:
 
 # เพิ่มการเตือน
 team-warning = การเตือน

--- a/refbox/translations/tl-PH/refbox.ftl
+++ b/refbox/translations/tl-PH/refbox.ftl
@@ -31,6 +31,8 @@ penalty-kind = {$kind ->
 # Pag-edit ng Timeout ng Koponan
 timeout-length = TIMEOUT NG
     KOPONAN
+team-timeout-count = BILANG NG
+    TIMEOUT:
 
 # Pagdagdag ng Babala
 team-warning = BABALA NG

--- a/refbox/translations/tl-PH/refbox.ftl
+++ b/refbox/translations/tl-PH/refbox.ftl
@@ -30,7 +30,7 @@ penalty-kind = {$kind ->
 
 # Pag-edit ng Timeout ng Koponan
 timeout-length = TIMEOUT NG
-    KOPONAN
+    KOPONAN:
 team-timeout-count = BILANG NG
     TIMEOUT:
 
@@ -306,6 +306,8 @@ teams = Koponan ng { -dark-team-name }: { $dark_team }
 game-config = Haba ng Kalahati: { $half_len },  Haba ng Pahinga: { $half_time_len }
     Sudden Death Pinahintulutan: { $sd_allowed },  Overtime Pinahintulutan: { $ot_allowed }
 team-timeouts = Mga Timeout ng Koponan: { $value }
+team-timeouts-label = MGA TIMEOUT
+    NG KOPONAN:
 stop-clock-last-2 = Ihinto ang Orasan sa Huling 2 Minuto: { $stop_clock }
 ref-list = Punong Ref: { $chief_ref }
     Timer: { $timer }

--- a/refbox/translations/tr-TR/refbox.ftl
+++ b/refbox/translations/tr-TR/refbox.ftl
@@ -31,6 +31,8 @@ penalty-kind = {$kind ->
 # Takım Molası Düzenleme
 timeout-length = TAKIM MOLASI
     SÜRESİ
+team-timeout-count = TAKIM MOLASI
+    SAYISI:
 
 # Uyarı Ekleme
 team-warning = TAKIM

--- a/refbox/translations/tr-TR/refbox.ftl
+++ b/refbox/translations/tr-TR/refbox.ftl
@@ -30,7 +30,7 @@ penalty-kind = {$kind ->
 
 # Takım Molası Düzenleme
 timeout-length = TAKIM MOLASI
-    SÜRESİ
+    SÜRESİ:
 team-timeout-count = TAKIM MOLASI
     SAYISI:
 
@@ -306,6 +306,8 @@ teams = { -dark-team-name } Takım: { $dark_team }
 game-config = Devre Süresi: { $half_len },  Devre Arası Süresi: { $half_time_len }
     Ani Ölüm İzin Verildi: { $sd_allowed },  Uzatma İzin Verildi: { $ot_allowed }
 team-timeouts = Takım Molaları: { $value }
+team-timeouts-label = TAKIM
+    MOLALARI:
 stop-clock-last-2 = Son 2 Dakikada Saati Durdur: { $stop_clock }
 ref-list = Başhakem: { $chief_ref }
     Zaman Ayarlayıcı: { $timer }

--- a/refbox/translations/zh-CN/refbox.ftl
+++ b/refbox/translations/zh-CN/refbox.ftl
@@ -31,6 +31,8 @@ penalty-kind = {$kind ->
 # 队伍暂停编辑
 timeout-length = 队伍暂停
     时长
+team-timeout-count = 队伍暂停
+    次数:
 
 # 警告添加
 team-warning = 队伍

--- a/refbox/translations/zh-CN/refbox.ftl
+++ b/refbox/translations/zh-CN/refbox.ftl
@@ -30,7 +30,7 @@ penalty-kind = {$kind ->
 
 # 队伍暂停编辑
 timeout-length = 队伍暂停
-    时长
+    时长：
 team-timeout-count = 队伍暂停
     次数:
 
@@ -306,6 +306,7 @@ teams = { -dark-team-name }：{ $dark_team }
 game-config = 半场时长：{ $half_len }，  中场时长：{ $half_time_len }
     允许突然死亡：{ $sd_allowed }，  允许加时赛：{ $ot_allowed }
 team-timeouts = 队伍暂停：{ $value }
+team-timeouts-label = 队伍暂停：
 stop-clock-last-2 = 最后2分钟停钟：{ $stop_clock }
 ref-list = 主裁判：{ $chief_ref }
     计时员：{ $timer }


### PR DESCRIPTION
## What changed
- Redesigned the team-timeout settings page into a clean full-width panel:
  a 0 / 1 count toggle, a HALF / GAME toggle, and preset length buttons
  (0:30 / 1:00 / 1:30) — replacing the number pad and the +/- length editor.
- Unselected options render grey (selected blue), the Cancel/Apply footer
  matches the other settings pages, and when the count is 0 the period and
  length controls grey out (selections are remembered if you switch back to 1).
- The Game Parameters screen's team-timeout tile now reads "TEAM TIMEOUTS:"
  with a compact value (0, 1/HALF, or 1/GAME) instead of "NUM OF TEAM T/Os
  PER HALF: 1".
- Fix: the count now keeps your in-progress value when you reopen the page
  mid-edit (it used to revert to the last-saved value).
- Fix: a rendering glitch where a settings tile's value could show a stale,
  garbled box after returning from an editor (iced cached-anchor bug).
- Added two translation keys and a colon to the length label across all 15
  locales (best-guess translations — worth a community sanity-check).

## Why
A 0-or-1 setting didn't need a full number pad, and the page now matches the
app's settings-panel style. The compact tile shows the current setting at a glance.

## Scope
refbox only: team_timeout_edit.rs, configuration.rs, shared_elements.rs,
app/mod.rs, app/message.rs, and translations/. No uwh-common, no wire format,
no timing/state-machine logic.

## How to verify
1. Game Parameters → the team-timeout tile reads "TEAM TIMEOUTS:" with 0 / 1/HALF / 1/GAME.
2. Open it: full-width panel, no number pad; 0/1, HALF/GAME, and 0:30/1:00/1:30 rows.
3. Set 0 → HALF/GAME and length presets grey out; Cancel/Apply still work.
4. Set a value, Apply, reopen → your value persists.
5. After returning to Game Parameters, no leftover box over any tile.
6. Other keypad pages (score, penalty) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
