### PR TITLE
fix(refbox): add colon to Game Block label, gate Apply when too short

### DIFF
--- a/refbox/src/app/view_builders/configuration.rs
+++ b/refbox/src/app/view_builders/configuration.rs
@@ -838,7 +838,7 @@ fn make_event_config_page<'a>(
                         },
                     ),
                     make_value_button(
-                        fl!("game-block"),
+                        fl!("game-block-full"),
                         time_string(config.game_block),
                         (false, true),
                         Some(Message::EditParameter(LengthParameter::GameBlock)),
@@ -859,8 +859,16 @@ fn make_event_config_page<'a>(
     // make_cancel_apply_footer's gate so a click on Apply can't reach a
     // wasteful confirmation dialog).
     let apply_blocked = settings.uwhportal_incomplete();
-    let apply_enabled =
-        page_has_changes(ConfigPage::Game, settings, page_entry_snapshot) && !apply_blocked;
+    // A red (too-short) Game Block is invalid, so APPLY must be disabled until it
+    // is widened. Only gate this in portal-OFF mode — that is the only mode that
+    // renders the Game Block button, so the disabled APPLY always has a visible
+    // red button explaining it. Yellow ("tight") is a caution, not invalid, and
+    // does not block.
+    let game_block_too_short =
+        !using_uwhportal && matches!(game_block_validity(config), GameBlockValidity::TooShort);
+    let apply_enabled = page_has_changes(ConfigPage::Game, settings, page_entry_snapshot)
+        && !apply_blocked
+        && !game_block_too_short;
 
     let cancel_btn = make_button(fl!("cancel"))
         .style(red_button)

--- a/refbox/translations/de-DE/refbox.ftl
+++ b/refbox/translations/de-DE/refbox.ftl
@@ -145,6 +145,7 @@ half-time-lenght = HALBZEITPAUSE DAUER
 length-of-half-time-period = Die Dauer der Halbzeitpause
 nom-break = NOM. PAUSE
 game-block = SPIELBLOCK
+game-block-full = SPIELBLOCK:
 game-block-help = Zeit vom Beginn eines Spiels bis zum Beginn des nächsten
 game-block-too-short = Zu kurz für das Spiel plus die Mindestpause
 game-block-tight = Knapp — Auszeiten könnten die Spiele über ihren Zeitslot hinausschieben

--- a/refbox/translations/en-US/refbox.ftl
+++ b/refbox/translations/en-US/refbox.ftl
@@ -144,6 +144,7 @@ half-time-lenght = HALF TIME LEN
 length-of-half-time-period = The length of the Half Time period
 nom-break = NOM BREAK
 game-block = GAME BLOCK
+game-block-full = GAME BLOCK:
 game-block-help = Time from the start of one game to the start of the next
 game-block-too-short = Too short to fit the game plus the minimum break
 game-block-tight = Tight — team timeouts could push games past their slot

--- a/refbox/translations/es/refbox.ftl
+++ b/refbox/translations/es/refbox.ftl
@@ -147,6 +147,7 @@ half-time-lenght = DURACIÓN DEL
 length-of-half-time-period = La duración del período de medio tiempo
 nom-break = DESCANSO NOMINAL
 game-block = BLOQUE DE JUEGO
+game-block-full = BLOQUE DE JUEGO:
 game-block-help = Tiempo desde el inicio de un partido hasta el inicio del siguiente
 game-block-too-short = Demasiado corto para el partido más la pausa mínima
 game-block-tight = Ajustado — los tiempos muertos podrían retrasar los partidos fuera de su franja

--- a/refbox/translations/fr/refbox.ftl
+++ b/refbox/translations/fr/refbox.ftl
@@ -143,6 +143,7 @@ half-time-lenght = DURÉE MI-TEMPS
 length-of-half-time-period = La durée de la mi-temps
 nom-break = PAUSE NOMINALE
 game-block = BLOC DE JEU
+game-block-full = BLOC DE JEU:
 game-block-help = Temps entre le début d'un match et le début du suivant
 game-block-too-short = Trop court pour contenir le match et la pause minimale
 game-block-tight = Serré — les temps morts pourraient faire déborder les matchs de leur créneau

--- a/refbox/translations/id-ID/refbox.ftl
+++ b/refbox/translations/id-ID/refbox.ftl
@@ -145,6 +145,7 @@ half-time-lenght = DUR JEDA BABAK
 length-of-half-time-period = Durasi periode jeda babak
 nom-break = JEDA NOMINAL
 game-block = BLOK PERTANDINGAN
+game-block-full = BLOK PERTANDINGAN:
 game-block-help = Waktu dari awal satu pertandingan hingga awal pertandingan berikutnya
 game-block-too-short = Terlalu singkat untuk pertandingan ditambah jeda minimum
 game-block-tight = Terlalu ketat — time-out tim bisa membuat pertandingan melewati slot mereka

--- a/refbox/translations/it-IT/refbox.ftl
+++ b/refbox/translations/it-IT/refbox.ftl
@@ -145,6 +145,7 @@ half-time-lenght = DUR INTERVALLO
 length-of-half-time-period = La durata del periodo di intervallo
 nom-break = PAUSA NOM
 game-block = BLOCCO PARTITA
+game-block-full = BLOCCO PARTITA:
 game-block-help = Tempo dall'inizio di una partita all'inizio della successiva
 game-block-too-short = Troppo breve per contenere la partita più la pausa minima
 game-block-tight = Stretto — i timeout potrebbero far sforare le partite dal loro slot

--- a/refbox/translations/ja-JP/refbox.ftl
+++ b/refbox/translations/ja-JP/refbox.ftl
@@ -145,6 +145,7 @@ half-time-lenght = ハーフタイム時間
 length-of-half-time-period = ハーフタイムの長さ
 nom-break = 基準休憩
 game-block = ゲームブロック
+game-block-full = ゲームブロック:
 game-block-help = ある試合の開始から次の試合の開始までの時間
 game-block-too-short = 試合と最短休憩を収めるには短すぎます
 game-block-tight = タイト — チームタイムアウトにより試合が枠を超える可能性があります

--- a/refbox/translations/ko-KR/refbox.ftl
+++ b/refbox/translations/ko-KR/refbox.ftl
@@ -147,6 +147,7 @@ half-time-lenght = 하프타임 시간
 length-of-half-time-period = 하프타임 기간의 시간
 nom-break = 기준 휴식
 game-block = 게임 블록
+game-block-full = 게임 블록:
 game-block-help = 한 경기 시작부터 다음 경기 시작까지의 시간
 game-block-too-short = 경기와 최소 휴식을 담기에 너무 짧습니다
 game-block-tight = 빡빡함 — 팀 타임아웃으로 경기가 슬롯을 초과할 수 있습니다

--- a/refbox/translations/ms-MY/refbox.ftl
+++ b/refbox/translations/ms-MY/refbox.ftl
@@ -145,6 +145,7 @@ half-time-lenght = PANJANG REHAT SEPARUH MASA
 length-of-half-time-period = Panjang tempoh rehat separuh masa
 nom-break = REHAT NOMINAL
 game-block = BLOK PERLAWANAN
+game-block-full = BLOK PERLAWANAN:
 game-block-help = Masa dari permulaan satu perlawanan hingga permulaan perlawanan berikutnya
 game-block-too-short = Terlalu singkat untuk memuatkan perlawanan ditambah rehat minimum
 game-block-tight = Ketat — masa rehat pasukan boleh menyebabkan perlawanan melebihi slot mereka

--- a/refbox/translations/nl-NL/refbox.ftl
+++ b/refbox/translations/nl-NL/refbox.ftl
@@ -145,6 +145,7 @@ half-time-lenght = DUUR RUST
 length-of-half-time-period = De duur van de rustperiode
 nom-break = NOM PAUZE
 game-block = SPELBLOK
+game-block-full = SPELBLOK:
 game-block-help = Tijd van het begin van één wedstrijd tot het begin van de volgende
 game-block-too-short = Te kort voor de wedstrijd plus de minimale pauze
 game-block-tight = Krap — teamtime-outs kunnen wedstrijden buiten hun tijdslot duwen

--- a/refbox/translations/pt-PT/refbox.ftl
+++ b/refbox/translations/pt-PT/refbox.ftl
@@ -145,6 +145,7 @@ half-time-lenght = DUR INTERVALO
 length-of-half-time-period = A duração do período de intervalo
 nom-break = PAUSA NOM
 game-block = BLOCO DE JOGO
+game-block-full = BLOCO DE JOGO:
 game-block-help = Tempo desde o início de um jogo até ao início do seguinte
 game-block-too-short = Demasiado curto para o jogo mais a pausa mínima
 game-block-tight = Apertado — os tempos mortos podem fazer os jogos ultrapassar o seu slot

--- a/refbox/translations/th-TH/refbox.ftl
+++ b/refbox/translations/th-TH/refbox.ftl
@@ -145,6 +145,7 @@ half-time-lenght = ความยาวพักครึ่ง
 length-of-half-time-period = ความยาวของช่วงพักครึ่งเวลา
 nom-break = พักตามกำหนด
 game-block = บล็อกเกม
+game-block-full = บล็อกเกม:
 game-block-help = เวลาจากการเริ่มต้นของเกมหนึ่งถึงการเริ่มต้นของเกมถัดไป
 game-block-too-short = สั้นเกินไปสำหรับเกมรวมกับช่วงพักขั้นต่ำ
 game-block-tight = ตึง — การพักทีมอาจทำให้เกมเกินช่วงเวลาของตน

--- a/refbox/translations/tl-PH/refbox.ftl
+++ b/refbox/translations/tl-PH/refbox.ftl
@@ -145,6 +145,7 @@ half-time-lenght = HABA NG PAHINGA
 length-of-half-time-period = Ang haba ng panahon ng pahinga
 nom-break = NOMINAL NA PAHINGA
 game-block = BLOKE NG LARO
+game-block-full = BLOKE NG LARO:
 game-block-help = Oras mula sa simula ng isang laro hanggang sa simula ng susunod
 game-block-too-short = Masyadong maikli para sa laro kasama ang pinakamaliit na pahinga
 game-block-tight = Masikip — ang mga timeout ng koponan ay maaaring itulak ang mga laro lampas sa kanilang slot

--- a/refbox/translations/tr-TR/refbox.ftl
+++ b/refbox/translations/tr-TR/refbox.ftl
@@ -145,6 +145,7 @@ half-time-lenght = DEVRE ARASI SÜRESİ
 length-of-half-time-period = Devre arası süresinin uzunluğu
 nom-break = NOMİNAL ARA
 game-block = OYUN BLOĞU
+game-block-full = OYUN BLOĞU:
 game-block-help = Bir oyunun başlangıcından bir sonraki oyunun başlangıcına kadar geçen süre
 game-block-too-short = Oyunu ve minimum arayı sığdırmak için çok kısa
 game-block-tight = Dar — takım molaları oyunları zamanlamasının dışına itebilir

--- a/refbox/translations/zh-CN/refbox.ftl
+++ b/refbox/translations/zh-CN/refbox.ftl
@@ -145,6 +145,7 @@ half-time-lenght = 中场时长
 length-of-half-time-period = 中场休息阶段的时长
 nom-break = 名义休息
 game-block = 赛程块
+game-block-full = 赛程块：
 game-block-help = 从一场比赛开始到下一场比赛开始所经过的时间
 game-block-too-short = 时间太短，无法容纳比赛加上最短休息
 game-block-tight = 紧张 — 队伍暂停可能导致比赛超出其时段


### PR DESCRIPTION
## What changed
1. The Game Block button on the Game Parameters page now reads **"GAME BLOCK:"** with a trailing colon, matching every other parameter button on that page. Translated in all 15 languages.
2. The green **APPLY** button on that page is now disabled whenever the Game Block is **red** (too short to fit the game plus the minimum break), and re-enables once the Game Block is widened. A **yellow** ("tight") Game Block still allows Apply.

## Why
The missing colon was a visual inconsistency with every other button on the page. Separately, APPLY previously let an operator commit an invalid (too-short) Game Block from the main page, even though the Game Block editor's own Done button already blocked the too-short state — this closes that gap so an invalid slot can't be applied.

## Scope
`refbox` only.
- Code: `refbox/src/app/view_builders/configuration.rs` (Game Parameters page builder only — the shared footer used by other config pages is untouched).
- Translations: one new string `game-block-full` added to all 15 `refbox/translations/<locale>/refbox.ftl` files. The existing `game-block` string (used on the editor-screen title and help page) is unchanged.
- No changes to `uwh-common`, the game state machine, the wire format, or any other crate.

## How to verify
On the Game Parameters page with **USING UWHPORTAL = NO**:
1. Confirm the Game Block button reads **"GAME BLOCK:"** (with a colon), like "HALF LENGTH:" etc.
2. Set the Game Block too short so it turns **red** — confirm the green APPLY button greys out and can't be pressed.
3. Widen the Game Block until it is no longer red — confirm APPLY becomes pressable again.
4. Set a **yellow** ("tight") Game Block — confirm APPLY is still pressable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
