### PR TITLE
refactor(refbox): top-pin time editors, move paused note below

### DIFF
--- a/refbox/src/app/view_builders/configuration.rs
+++ b/refbox/src/app/view_builders/configuration.rs
@@ -1590,10 +1590,7 @@ pub(in super::super) fn build_game_parameter_editor<'a>(
     .spacing(SPACING)
     .align_y(Vertical::Top);
 
-    col = col
-        .push(vertical_space())
-        .push(editor_row)
-        .push(vertical_space());
+    col = col.push(editor_row);
 
     if let Some(note) = validity_note {
         col = col.push(note);

--- a/refbox/src/app/view_builders/time_edit.rs
+++ b/refbox/src/app/view_builders/time_edit.rs
@@ -49,13 +49,11 @@ pub(in super::super) fn build_time_edit_view<'a>(
             portal_indicator,
             None
         ),
-        vertical_space(),
+        edit_row,
         text(fl!("Note-Game-time-is-paused"))
             .size(SMALL_TEXT)
             .width(Length::Fill)
             .align_x(Horizontal::Center),
-        vertical_space(),
-        edit_row,
         vertical_space(),
         row![
             make_button(fl!("cancel"))


### PR DESCRIPTION
## What changed
On the refbox time-setting editor screens, the editor box (the title plus the time with the ▲▼ and "=0" buttons) is now pinned near the top of the screen instead of floating in the vertical middle. This applies to:

- The game-parameter editors in Settings (Game Block, Half Time, Half Length, breaks, overtime, etc.).
- The game-clock edit screen.

On the game-clock edit screen, the "The time is paused while on this screen…" note has also moved to **below** the editor box, so it matches where notes sit on the other screens.

As a side benefit, the Game Block editor box no longer jumps up and down when its red "too short" / yellow "tight" warning note appears or disappears — the box is now anchored to the top and can't be pushed around by the note.

## Why
The editor screens were inconsistent: the editor box floated in the middle on the parameter editors and the game-clock screen, while the recently redesigned team-timeout edit screen already kept its controls pinned at the top. Anchoring all of them to the top gives one consistent layout, and it cleanly fixes the long-standing Game Block note-shift annoyance without needing to reserve fixed space for the note.

## Scope
Changes are limited to two view-builder files in the `refbox` crate:
- `refbox/src/app/view_builders/configuration.rs` (`build_game_parameter_editor`)
- `refbox/src/app/view_builders/time_edit.rs` (`build_time_edit_view`)

No state-machine, wire-format, shared-type, or styling changes. The team-timeout edit screen was intentionally left untouched (it was already top-anchored).

## How to verify
1. Open Settings and tap into a time setting (e.g. Half Time): the editor box sits near the top, not in the middle.
2. Open the Half Length editor: the editor box sits directly under the 2-HALVES / 1-PERIOD selector.
3. Open the Game Block editor and change the value so the red "too short" / yellow "tight" note appears and disappears: the editor box stays put (no vertical jump).
4. Open the game-clock edit screen: the editor box sits near the top, and the "time is paused" note appears below the editor.
5. On every screen, the CANCEL / DONE buttons stay pinned at the bottom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
