### PR TITLE
fix(refbox): make game-info button and page consistent

### DIFF
--- a/refbox/src/app/view_builders/game_info.rs
+++ b/refbox/src/app/view_builders/game_info.rs
@@ -238,6 +238,21 @@ fn details_strings(
         left_string += "\n";
     };
 
+    // Stop Clock in Last 2 Minutes — a normal game rule (not Portal-specific), shown directly
+    // above Team Timeouts. Reads "Unknown" when no schedule timing rule is available
+    // (e.g. when not using the Portal).
+    let stop_clock = if let Some(sched) = schedule {
+        if let Some(timing_rule) = sched.get_game_timing(game_number) {
+            bool_string(timing_rule.last_2_min_stop_time)
+        } else {
+            fl!("unknown")
+        }
+    } else {
+        fl!("unknown")
+    };
+    left_string += &fl!("stop-clock-last-2", stop_clock = stop_clock);
+    left_string += "\n";
+
     let team_timeouts_value = if config.num_team_timeouts_allowed == 0 {
         "0".to_string()
     } else if config.timeouts_counted_per_half {
@@ -261,19 +276,8 @@ fn details_strings(
     );
     left_string += "\n";
 
+    // Referees only exist when using the Portal — they render into the right column.
     if using_uwhportal {
-        let stop_clock = if let Some(sched) = schedule {
-            if let Some(timing_rule) = sched.get_game_timing(game_number) {
-                bool_string(timing_rule.last_2_min_stop_time)
-            } else {
-                fl!("unknown")
-            }
-        } else {
-            fl!("unknown")
-        };
-        left_string += &fl!("stop-clock-last-2", stop_clock = stop_clock);
-        left_string += "\n";
-
         let mut chief_ref = "-".to_string();
         let mut timer = "-".to_string();
         let mut water_ref_1 = "-".to_string();
@@ -316,4 +320,61 @@ fn details_strings(
     }
 
     (left_string, right_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn details_page_shows_stop_clock_even_outside_portal_mode() {
+        let config = GameConfig {
+            num_team_timeouts_allowed: 0,
+            ..Default::default()
+        };
+        let snapshot = GameSnapshot::default();
+
+        let (left, _right) = details_strings(&snapshot, &config, false, None, None);
+
+        let stop_clock_line = fl!("stop-clock-last-2", stop_clock = fl!("unknown"));
+        let team_timeouts_line = fl!("team-timeouts", value = "0");
+
+        let stop_idx = left
+            .find(&stop_clock_line)
+            .expect("page must show stop-clock even when not using the portal");
+        let to_idx = left
+            .find(&team_timeouts_line)
+            .expect("team-timeouts line should be present");
+        assert!(
+            stop_idx < to_idx,
+            "stop-clock should appear above team timeouts"
+        );
+    }
+
+    #[test]
+    fn details_page_keeps_referees_portal_only() {
+        let config = GameConfig::default();
+        let snapshot = GameSnapshot::default();
+
+        let ref_block = fl!(
+            "ref-list",
+            chief_ref = "-",
+            timer = "-",
+            water_ref_1 = "-",
+            water_ref_2 = "-",
+            water_ref_3 = "-"
+        );
+
+        let (_l, right_no_portal) = details_strings(&snapshot, &config, false, None, None);
+        assert!(
+            !right_no_portal.contains(&ref_block),
+            "referees must not show when not using the portal"
+        );
+
+        let (_l2, right_portal) = details_strings(&snapshot, &config, true, None, None);
+        assert!(
+            right_portal.contains(&ref_block),
+            "referees must show when using the portal"
+        );
+    }
 }

--- a/refbox/src/app/view_builders/shared_elements.rs
+++ b/refbox/src/app/view_builders/shared_elements.rs
@@ -1072,16 +1072,9 @@ pub(super) fn config_string(
         )
     };
 
-    let team_timeouts_value = if config.num_team_timeouts_allowed == 0 {
-        "0".to_string()
-    } else if config.timeouts_counted_per_half {
-        format!("{}/{}", config.num_team_timeouts_allowed, fl!("half"))
-    } else {
-        format!("{}/{}", config.num_team_timeouts_allowed, fl!("game"))
-    };
-    result += "\n";
-    result += &fl!("team-timeouts", value = team_timeouts_value);
-
+    // Stop Clock in Last 2 Minutes — a normal game rule (not Portal-specific), shown directly
+    // above Team Timeouts. Reads "Unknown" when no schedule timing rule is available
+    // (e.g. when not using the Portal).
     let stop_clock = if let Some(sched) = schedule {
         if let Some(timing_rule) = sched.get_game_timing(&game_number) {
             bool_string(timing_rule.last_2_min_stop_time)
@@ -1093,47 +1086,60 @@ pub(super) fn config_string(
     };
     result += "\n";
     result += &fl!("stop-clock-last-2", stop_clock = stop_clock);
+
+    let team_timeouts_value = if config.num_team_timeouts_allowed == 0 {
+        "0".to_string()
+    } else if config.timeouts_counted_per_half {
+        format!("{}/{}", config.num_team_timeouts_allowed, fl!("half"))
+    } else {
+        format!("{}/{}", config.num_team_timeouts_allowed, fl!("game"))
+    };
     result += "\n";
+    result += &fl!("team-timeouts", value = team_timeouts_value);
 
-    let mut chief_ref = "-".to_string();
-    let mut timer = "-".to_string();
-    let mut water_ref_1 = "-".to_string();
-    let mut water_ref_2 = "-".to_string();
-    let mut water_ref_3 = "-".to_string();
+    // Referees only exist when using the Portal — hide the whole block otherwise.
+    if using_uwhportal {
+        let mut chief_ref = "-".to_string();
+        let mut timer = "-".to_string();
+        let mut water_ref_1 = "-".to_string();
+        let mut water_ref_2 = "-".to_string();
+        let mut water_ref_3 = "-".to_string();
 
-    if let Some(games) = games {
-        if let Some(game) = games.get(&game_number) {
-            if let Some(refs) = &game.referee_assignments {
-                for ref_assignment in refs {
-                    if ref_assignment.user_id.is_some() {
-                        // Fall back to '-' for unassigned slots — language-neutral,
-                        // visually distinct from real names.
-                        let display = ref_assignment
-                            .display_name
-                            .clone()
-                            .unwrap_or_else(|| "-".to_string());
-                        match ref_assignment.role.as_str() {
-                            "Chief" => chief_ref = display,
-                            "TimeOrScoreKeeper" => timer = display,
-                            "Water1" => water_ref_1 = display,
-                            "Water2" => water_ref_2 = display,
-                            "Water3" => water_ref_3 = display,
-                            _ => {}
+        if let Some(games) = games {
+            if let Some(game) = games.get(&game_number) {
+                if let Some(refs) = &game.referee_assignments {
+                    for ref_assignment in refs {
+                        if ref_assignment.user_id.is_some() {
+                            // Fall back to '-' for unassigned slots — language-neutral,
+                            // visually distinct from real names.
+                            let display = ref_assignment
+                                .display_name
+                                .clone()
+                                .unwrap_or_else(|| "-".to_string());
+                            match ref_assignment.role.as_str() {
+                                "Chief" => chief_ref = display,
+                                "TimeOrScoreKeeper" => timer = display,
+                                "Water1" => water_ref_1 = display,
+                                "Water2" => water_ref_2 = display,
+                                "Water3" => water_ref_3 = display,
+                                _ => {}
+                            }
                         }
                     }
                 }
             }
         }
-    }
 
-    result += &fl!(
-        "ref-list",
-        chief_ref = chief_ref,
-        timer = timer,
-        water_ref_1 = water_ref_1,
-        water_ref_2 = water_ref_2,
-        water_ref_3 = water_ref_3
-    );
+        result += "\n";
+        result += &fl!(
+            "ref-list",
+            chief_ref = chief_ref,
+            timer = timer,
+            water_ref_1 = water_ref_1,
+            water_ref_2 = water_ref_2,
+            water_ref_3 = water_ref_3
+        );
+    }
 
     result
 }
@@ -1451,5 +1457,58 @@ mod tests {
     fn crosses_portal_rugby_to_hockey_is_true() {
         assert!(crosses_portal(Mode::Rugby, Mode::Hockey6V6));
         assert!(crosses_portal(Mode::Rugby, Mode::Hockey3V3));
+    }
+
+    #[test]
+    fn config_string_hides_referees_outside_portal_mode() {
+        let config = GameConfig::default();
+        let snapshot = GameSnapshot::default();
+
+        // The referee block exactly as config_string renders it with no assignments.
+        let ref_block = fl!(
+            "ref-list",
+            chief_ref = "-",
+            timer = "-",
+            water_ref_1 = "-",
+            water_ref_2 = "-",
+            water_ref_3 = "-"
+        );
+
+        let out_no_portal = config_string(&snapshot, &config, false, None, None);
+        assert!(
+            !out_no_portal.contains(&ref_block),
+            "referees must not show when not using the portal"
+        );
+
+        let out_portal = config_string(&snapshot, &config, true, None, None);
+        assert!(
+            out_portal.contains(&ref_block),
+            "referees must show when using the portal"
+        );
+    }
+
+    #[test]
+    fn config_string_shows_stop_clock_above_team_timeouts() {
+        let config = GameConfig {
+            num_team_timeouts_allowed: 0,
+            ..Default::default()
+        };
+        let snapshot = GameSnapshot::default();
+
+        let out = config_string(&snapshot, &config, false, None, None);
+
+        let stop_clock_line = fl!("stop-clock-last-2", stop_clock = fl!("unknown"));
+        let team_timeouts_line = fl!("team-timeouts", value = "0");
+
+        let stop_idx = out
+            .find(&stop_clock_line)
+            .expect("stop-clock line should always be present");
+        let to_idx = out
+            .find(&team_timeouts_line)
+            .expect("team-timeouts line should be present");
+        assert!(
+            stop_idx < to_idx,
+            "stop-clock should appear above team timeouts"
+        );
     }
 }


### PR DESCRIPTION
## What changed
- On the **main-screen Game Info button**, the referee lines (Chief Ref, Timer, Water Refs) now appear **only when using the Portal**. Out of Portal Mode they are hidden — no more stray "Chief Ref: -".
- On **both** the Game Info button and the **Game Information page**, "Stop Clock in Last 2 Minutes" now sits **directly above** "Team Timeouts".
- The **Game Information page** now **always shows** "Stop Clock in Last 2 Minutes" (previously it was hidden when not using the Portal). Out of Portal Mode it reads "Unknown", matching the button.

No translation text changed and no game logic changed — only the order and the show/hide conditions of two existing lines in each of the two display builders.

## Why
The two screens disagreed: the button showed referees (and a stray "Chief Ref: -") even with no Portal connected, while the page hid "Stop Clock in Last 2 Minutes" entirely when off-Portal. Referees only exist via the Portal, and "Stop Clock in Last 2 Minutes" is a normal game rule that should always be visible. This makes both screens follow one consistent rule: referees are Portal-only; everything else (including Stop Clock) is always shown.

## Scope
Changes are limited to `refbox/src/app/view_builders/` — `shared_elements.rs` (the `config_string` builder for the button) and `game_info.rs` (the `details_strings` builder for the page). No changes to `uwh-common`, no wire-format changes, no new dependencies, no translation edits.

## How to verify
Run the app **not connected to the Portal**:
- **Main-screen Game Info panel:** no referee lines; "Stop Clock in Last 2 Minutes" appears directly above "Team Timeouts".
- **Game Information page** (tap the centre panel): "Stop Clock in Last 2 Minutes" is shown (reads "Unknown"), directly above "Team Timeouts"; still no referee lines.

When connected to the Portal, both screens show the referee lines and the real Yes/No Stop Clock value, in the same positions.

Automated coverage: 4 new unit tests in `shared_elements.rs` and `game_info.rs` assert referees are hidden off-Portal (and shown on-Portal) and that Stop Clock renders above Team Timeouts on both surfaces. `just check` passes (fmt, clippy `-D warnings`, full test suite, audit).
