### PR TITLE
feat(refbox): relabel time-edit Done to Apply and disable when unchanged

### DIFF
--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -150,6 +150,9 @@ pub struct RefBoxApp {
     foul_edit: ListEditor<InfractionDetails, Option<Color>>,
     app_state: AppState,
     last_app_state: AppState,
+    // The game/timeout clock times captured when the time-edit screen was opened,
+    // used to gray out the Apply button when no change has been made.
+    time_edit_old: (Duration, Option<Duration>),
     last_message: Message,
     update_sender: UpdateSender,
     uwhportal_client: Option<Arc<Mutex<UwhPortalClient>>>,
@@ -1475,6 +1478,7 @@ impl RefBoxApp {
             snapshot,
             app_state: initial_app_state,
             last_app_state: default_app_state,
+            time_edit_old: (Duration::ZERO, None),
             last_message: Message::NoAction,
             update_sender,
             uwhportal_client,
@@ -1562,12 +1566,11 @@ impl RefBoxApp {
                 let mut tm = self.tm.lock().unwrap();
                 let was_running = tm.clock_is_running();
                 tm.stop_clock(now).unwrap();
+                let game_time = tm.game_clock_time(now).unwrap();
+                let timeout_time = tm.timeout_clock_time(now);
+                self.time_edit_old = (game_time, timeout_time);
                 self.last_app_state = self.app_state.clone();
-                self.app_state = AppState::TimeEdit(
-                    was_running,
-                    tm.game_clock_time(now).unwrap(),
-                    tm.timeout_clock_time(now),
-                );
+                self.app_state = AppState::TimeEdit(was_running, game_time, timeout_time);
                 trace!("AppState changed to {:?}", self.app_state);
                 Task::none()
             }
@@ -4420,8 +4423,13 @@ impl RefBoxApp {
                     behind_schedule,
                 )
             }
-            AppState::TimeEdit(_, time, timeout_time) =>
-                build_time_edit_view(data, time, timeout_time),
+            AppState::TimeEdit(_, time, timeout_time) => build_time_edit_view(
+                data,
+                time,
+                timeout_time,
+                self.time_edit_old.0,
+                self.time_edit_old.1,
+            ),
             AppState::ScoreEdit {
                 scores,
                 is_confirmation,

--- a/refbox/src/app/view_builders/time_edit.rs
+++ b/refbox/src/app/view_builders/time_edit.rs
@@ -10,6 +10,8 @@ pub(in super::super) fn build_time_edit_view<'a>(
     data: ViewData<'_, '_>,
     time: Duration,
     timeout_time: Option<Duration>,
+    old_time: Duration,
+    old_timeout_time: Option<Duration>,
 ) -> Element<'a, Message> {
     let ViewData {
         snapshot,
@@ -61,14 +63,106 @@ pub(in super::super) fn build_time_edit_view<'a>(
                 .width(Length::Fill)
                 .on_press(Message::TimeEditComplete { canceled: true }),
             horizontal_space(),
-            make_button(fl!("done"))
+            make_button(fl!("apply"))
                 .style(green_button)
                 .width(Length::Fill)
-                .on_press(Message::TimeEditComplete { canceled: false }),
+                .on_press_maybe(
+                    time_edit_has_changes(time, timeout_time, old_time, old_timeout_time)
+                        .then_some(Message::TimeEditComplete { canceled: false }),
+                ),
         ]
         .spacing(SPACING),
     ]
     .spacing(SPACING)
     .height(Length::Fill)
     .into()
+}
+
+/// Returns true when either the game or timeout clock differs from the values
+/// captured when the time-edit screen was opened.
+///
+/// The comparison is on whole seconds — the same precision shown on screen via
+/// `time_string` — so that zeroing the clock and rebuilding it back to the
+/// displayed value counts as "no change", even though the original may have
+/// carried a sub-second remainder that the display never showed.
+fn time_edit_has_changes(
+    time: Duration,
+    timeout_time: Option<Duration>,
+    old_time: Duration,
+    old_timeout_time: Option<Duration>,
+) -> bool {
+    time.as_secs() != old_time.as_secs()
+        || timeout_time.map(|d| d.as_secs()) != old_timeout_time.map(|d| d.as_secs())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::time_edit_has_changes;
+    use std::time::Duration;
+
+    #[test]
+    fn no_change_is_false() {
+        let t = Duration::from_secs(432);
+        assert!(!time_edit_has_changes(t, None, t, None));
+        assert!(!time_edit_has_changes(
+            t,
+            Some(Duration::from_secs(30)),
+            t,
+            Some(Duration::from_secs(30))
+        ));
+    }
+
+    #[test]
+    fn game_time_change_is_true() {
+        assert!(time_edit_has_changes(
+            Duration::from_secs(433),
+            None,
+            Duration::from_secs(432),
+            None
+        ));
+    }
+
+    #[test]
+    fn timeout_change_is_true() {
+        let t = Duration::from_secs(432);
+        // A timeout started during edit: original None, now Some.
+        assert!(time_edit_has_changes(
+            t,
+            Some(Duration::from_secs(60)),
+            t,
+            None
+        ));
+    }
+
+    #[test]
+    fn round_trip_back_to_original_is_false() {
+        // +1s then -1s returns to the exact original duration.
+        let original = Duration::from_secs(432);
+        let after_round_trip = original + Duration::from_secs(1) - Duration::from_secs(1);
+        assert!(!time_edit_has_changes(
+            after_round_trip,
+            None,
+            original,
+            None
+        ));
+    }
+
+    #[test]
+    fn zeroing_the_clock_is_a_change() {
+        // Pressing "= 0" drops the clock to (near) zero, which differs from the
+        // original displayed value, so Apply must be enabled to commit it.
+        let original = Duration::from_secs(897);
+        let zeroed = Duration::from_micros(1);
+        assert!(time_edit_has_changes(zeroed, None, original, None));
+    }
+
+    #[test]
+    fn sub_second_original_matches_displayed_whole_seconds() {
+        // Original is 432.6s but displays as "7:12" (432 whole seconds). Zeroing
+        // and rebuilding to an exact 432.0s lands on the same displayed value, so
+        // it must count as "no change".
+        let original = Duration::from_millis(432_600);
+        let rebuilt = Duration::from_secs(432);
+        assert!(!time_edit_has_changes(rebuilt, None, original, None));
+    }
 }


### PR DESCRIPTION
## What changed

On the time-edit screen (the screen with the GAME TIME +/- buttons), the green
**DONE** button is now labelled **APPLY**, and it stays **grayed-out until you
actually change the time**. As soon as the shown time differs from what it was
when you opened the screen, APPLY becomes pressable; adjust it back to the same
displayed value and it grays out again. To leave without making a change, use
CANCEL.

## Why

This brings the time-edit screen in line with the other settings screens, which
already use a Cancel / Apply pair. It also prevents accidentally "applying" when
nothing was actually changed.

## Scope

Changes are limited to the `refbox` crate:
- `refbox/src/app/mod.rs` — remembers the time(s) shown when the screen opens
- `refbox/src/app/view_builders/time_edit.rs` — the relabelled, conditionally
  enabled button, plus a small helper and its tests

No shared types, wire format, or other crates are touched. The "APPLY" text
reuses the existing translation key already shown on the settings pages, so no
new translations were needed.

## How to verify

1. Open the time-edit screen. The green button reads **APPLY** and is grayed-out;
   **CANCEL** is active.
2. Press **+** once → APPLY lights up. Press **−** to return to the original
   value → APPLY grays out again.
3. Press **= 0** → APPLY lights up (you can commit a zeroed clock). Build the time
   back up to the original displayed value → APPLY grays out again.
4. Make a real change and press **APPLY** → the new time is applied, exactly as
   the old DONE button did.

Note on precision: the comparison that grays the button looks at the *displayed*
whole seconds, but the time that actually gets stored keeps its full precision —
so entering the editor mid-second and pressing CANCEL preserves the exact
fractional time, just as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
