### PR TITLE
refactor(refbox): rearrange sounds options page layout

### DIFF
--- a/refbox/src/app/view_builders/configuration.rs
+++ b/refbox/src/app/view_builders/configuration.rs
@@ -1206,11 +1206,11 @@ fn make_sound_config_page<'a>(
                 )),
             ),
             make_value_button(
-                fl!("whistle-volume"),
-                sound.whistle_vol.to_string(),
+                fl!("buzzer-sound"),
+                sound.buzzer_sound.to_string().to_uppercase(),
                 (false, true),
-                if sound.sound_enabled && sound.whistle_enabled {
-                    Some(Message::CycleParameter(CyclingParameter::AlertVolume))
+                if sound.sound_enabled {
+                    Some(Message::CycleParameter(CyclingParameter::BuzzerSound))
                 } else {
                     None
                 },
@@ -1245,27 +1245,27 @@ fn make_sound_config_page<'a>(
                 },
             ),
             make_value_button(
-                fl!("auto-sound-start-play"),
-                bool_string(sound.auto_sound_start_play),
+                fl!("alarm-button"),
+                bool_string(sound.manual_alarm_enabled),
                 (false, true),
                 if sound.sound_enabled {
                     Some(Message::ToggleBoolParameter(
-                        BoolGameParameter::AutoSoundStartPlay,
+                        BoolGameParameter::ManualAlarmEnabled,
                     ))
                 } else {
                     None
                 },
-            )
+            ),
         ]
         .spacing(SPACING)
         .height(Length::Fill),
         row![
             make_value_button(
-                fl!("buzzer-sound"),
-                sound.buzzer_sound.to_string().to_uppercase(),
+                fl!("whistle-volume"),
+                sound.whistle_vol.to_string(),
                 (false, true),
-                if sound.sound_enabled {
-                    Some(Message::CycleParameter(CyclingParameter::BuzzerSound))
+                if sound.sound_enabled && sound.whistle_enabled {
+                    Some(Message::CycleParameter(CyclingParameter::AlertVolume))
                 } else {
                     None
                 },
@@ -1281,6 +1281,24 @@ fn make_sound_config_page<'a>(
                 },
             ),
             make_value_button(
+                fl!("auto-sound-start-play"),
+                bool_string(sound.auto_sound_start_play),
+                (false, true),
+                if sound.sound_enabled {
+                    Some(Message::ToggleBoolParameter(
+                        BoolGameParameter::AutoSoundStartPlay,
+                    ))
+                } else {
+                    None
+                },
+            ),
+        ]
+        .spacing(SPACING)
+        .height(Length::Fill),
+        row![
+            horizontal_space(),
+            horizontal_space(),
+            make_value_button(
                 fl!("auto-sound-stop-play"),
                 bool_string(sound.auto_sound_stop_play),
                 (false, true),
@@ -1291,25 +1309,7 @@ fn make_sound_config_page<'a>(
                 } else {
                     None
                 },
-            )
-        ]
-        .spacing(SPACING)
-        .height(Length::Fill),
-        row![
-            make_value_button(
-                fl!("alarm-button"),
-                bool_string(sound.manual_alarm_enabled),
-                (false, true),
-                if sound.sound_enabled {
-                    Some(Message::ToggleBoolParameter(
-                        BoolGameParameter::ManualAlarmEnabled,
-                    ))
-                } else {
-                    None
-                },
             ),
-            horizontal_space(),
-            horizontal_space(),
         ]
         .spacing(SPACING)
         .height(Length::Fill),


### PR DESCRIPTION
## What changed
The controls on the **Sounds** settings page are rearranged into a new three-column grid:

| | Left | Middle | Right |
|---|---|---|---|
| Row 1 | Sound Enabled | Buzzer Sound | Manage Remotes |
| Row 2 | Whistle Enabled | Above Water Volume | Alarm Button |
| Row 3 | Whistle Volume | Underwater Volume | Auto Sound Start Play |
| Row 4 | *(empty)* | *(empty)* | Auto Sound Stop Play |
| Footer | Cancel | | Apply |

Nothing about how any control *works* changes — same labels, same toggle/cycle actions, same enable/disable behaviour (everything greys out when Sound is disabled, except Sound Enabled and Manage Remotes). Only the on-screen positions move.

## Why
To match the requested layout for the Sounds options page.

## Scope
Limited to `refbox` — a single function, `make_sound_config_page` in `refbox/src/app/view_builders/configuration.rs`. No other crate, page, config field, message, or translation key is touched.

## How to verify
1. Launch the refbox and open **Settings → Sounds**.
2. Confirm the grid matches the table above.
3. Toggle **Sound Enabled** off and confirm the other controls grey out as before (Sound Enabled and Manage Remotes stay active).
4. Confirm Whistle Volume only becomes active when both Sound Enabled and Whistle Enabled are on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
