### PR TITLE
fix(refbox): match View Mode button value text size to other buttons

### DIFF
--- a/refbox/src/app/view_builders/configuration.rs
+++ b/refbox/src/app/view_builders/configuration.rs
@@ -475,7 +475,7 @@ fn make_user_config_page<'a>(
     let view_mode_button = make_value_button(
         fl!("view-mode"),
         view_mode_label,
-        (false, false),
+        (false, true),
         Some(Message::CycleDisplayMode),
     );
 


### PR DESCRIPTION
## What changed
On the **User Options** settings page, the **View Mode** button now shows its selected value — "Light", "Dark", or "High Contrast" — in the same larger text size used by every other settings button (for example the buttons on the App Options / Game Parameters page). Previously it was the only one of these buttons that showed its value in a smaller text size. Tapping the button still cycles through the display modes exactly as before — only the text size of the displayed value changed.

## Why
The View Mode button looked inconsistent with the rest of the settings buttons. Out of the 26 value-buttons in this part of the UI, View Mode was the single exception rendering its value in small text. This brings it in line with the house standard so all the settings buttons look uniform.

## Scope
A single one-line change in `refbox/src/app/view_builders/configuration.rs`. No behaviour, labels, layout, width, or other buttons were changed. No other crates touched.

## How to verify
1. Launch the refbox.
2. Open settings → **User Options**.
3. Look at the **View Mode** button: the mode value ("Light" / "Dark" / "High Contrast") should appear in the larger text size, matching the value text on the App Options page buttons.
4. Tap it to confirm it still cycles Light → Dark → High Contrast as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
