### PR TITLE
feat(refbox): rename Done to Apply, gray until changed

### DIFF
--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -4456,7 +4456,13 @@ impl RefBoxApp {
                 indices
             ),
             AppState::KeypadPage(page, player_num) =>
-                build_keypad_page(data, page, player_num, self.config.track_fouls_and_warnings),
+                build_keypad_page(
+                    data,
+                    page,
+                    player_num,
+                    self.config.track_fouls_and_warnings,
+                    self.edited_settings.as_ref().map(|e| e.game_number.clone()),
+                ),
             AppState::GameDetailsPage(is_refreshing) => build_game_info_page(
                 data,
                 &self.config.game,

--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -4433,8 +4433,13 @@ impl RefBoxApp {
             AppState::ScoreEdit {
                 scores,
                 is_confirmation,
-            } =>
-                build_score_edit_view(data, scores, is_confirmation, self.snapshot.conf_pause_time),
+            } => build_score_edit_view(
+                data,
+                scores,
+                is_confirmation,
+                self.snapshot.conf_pause_time,
+                self.snapshot.scores,
+            ),
             AppState::PenaltyOverview(indices) => build_penalty_overview_page(
                 data,
                 self.pen_edit.get_printable_lists(Instant::now()).unwrap(),

--- a/refbox/src/app/view_builders/configuration.rs
+++ b/refbox/src/app/view_builders/configuration.rs
@@ -1444,6 +1444,24 @@ fn make_remote_config_page<'a>(
     .into()
 }
 
+/// Returns true when the parameter editor's buffer differs from the value shown
+/// when it opened. Length is compared on whole seconds — the precision the mm:ss
+/// editor displays — so zeroing and rebuilding to the same displayed value counts
+/// as "no change" (mirrors `time_edit_has_changes` from PR #1218). For the Half
+/// Length editor, flipping the 2 Halves / 1 Period choice is also a change, since
+/// Apply commits `single_half` for that parameter; for all other parameters the
+/// `single_half` flag is not committed and is ignored here.
+fn param_edit_has_changes(
+    length: Duration,
+    old_length: Duration,
+    param: LengthParameter,
+    single_half: bool,
+    old_single_half: bool,
+) -> bool {
+    length.as_secs() != old_length.as_secs()
+        || (matches!(param, LengthParameter::Half) && single_half != old_single_half)
+}
+
 pub(in super::super) fn build_game_parameter_editor<'a>(
     data: ViewData<'_, '_>,
     param: LengthParameter,
@@ -1596,6 +1614,24 @@ pub(in super::super) fn build_game_parameter_editor<'a>(
         col = col.push(note);
     }
 
+    // The original value shown when the editor opened, re-derived from the seed
+    // config (the in-progress edited config, or the saved config) — the same
+    // source `EditParameter` used to populate the editor. Apply is enabled only
+    // when the operator has actually changed something, and (for Game Block) the
+    // pending value is not too short.
+    let old_length = match param {
+        LengthParameter::Half => config.half_play_duration,
+        LengthParameter::HalfTime => config.half_time_duration,
+        LengthParameter::GameBlock => config.game_block,
+        LengthParameter::MinimumBetweenGame => config.minimum_break,
+        LengthParameter::PreOvertime => config.pre_overtime_break,
+        LengthParameter::OvertimeHalf => config.ot_half_play_duration,
+        LengthParameter::OvertimeHalfTime => config.ot_half_time_duration,
+        LengthParameter::PreSuddenDeath => config.pre_sudden_death_duration,
+    };
+    let apply_enabled = !matches!(game_block_validity, Some(GameBlockValidity::TooShort))
+        && param_edit_has_changes(length, old_length, param, single_half, config.single_half);
+
     col.push(vertical_space())
         .push(
             row![
@@ -1604,12 +1640,11 @@ pub(in super::super) fn build_game_parameter_editor<'a>(
                     .width(Length::Fill)
                     .on_press(Message::ParameterEditComplete { canceled: true }),
                 horizontal_space(),
-                make_button(fl!("done"))
+                make_button(fl!("apply"))
                     .style(green_button)
                     .width(Length::Fill)
                     .on_press_maybe(
-                        (!matches!(game_block_validity, Some(GameBlockValidity::TooShort)))
-                            .then_some(Message::ParameterEditComplete { canceled: false }),
+                        apply_enabled.then_some(Message::ParameterEditComplete { canceled: false }),
                     ),
             ]
             .spacing(SPACING),
@@ -2143,6 +2178,68 @@ mod tests {
             standings_order: None,
             final_results_order: None,
         }
+    }
+
+    #[test]
+    fn param_edit_no_change_is_false() {
+        let d = Duration::from_secs(900);
+        assert!(!param_edit_has_changes(
+            d,
+            d,
+            LengthParameter::Half,
+            false,
+            false
+        ));
+    }
+
+    #[test]
+    fn param_edit_length_change_is_true() {
+        assert!(param_edit_has_changes(
+            Duration::from_secs(901),
+            Duration::from_secs(900),
+            LengthParameter::HalfTime,
+            false,
+            false
+        ));
+    }
+
+    #[test]
+    fn param_edit_single_half_toggle_on_half_is_true() {
+        let d = Duration::from_secs(900);
+        assert!(param_edit_has_changes(
+            d,
+            d,
+            LengthParameter::Half,
+            true,
+            false
+        ));
+    }
+
+    #[test]
+    fn param_edit_single_half_ignored_off_half() {
+        // single_half differs but the parameter is not Half, so it is not
+        // committed and must not count as a change.
+        let d = Duration::from_secs(900);
+        assert!(!param_edit_has_changes(
+            d,
+            d,
+            LengthParameter::GameBlock,
+            true,
+            false
+        ));
+    }
+
+    #[test]
+    fn param_edit_sub_second_matches_displayed_whole_seconds() {
+        // Original 900.6s displays as "15:00" (900 whole seconds); rebuilding to
+        // an exact 900.0s lands on the same displayed value, so it is not a change.
+        assert!(!param_edit_has_changes(
+            Duration::from_secs(900),
+            Duration::from_millis(900_600),
+            LengthParameter::HalfTime,
+            false,
+            false
+        ));
     }
 
     #[test]

--- a/refbox/src/app/view_builders/fouls.rs
+++ b/refbox/src/app/view_builders/fouls.rs
@@ -21,6 +21,15 @@ pub(in super::super) fn build_foul_overview_page<'a>(
         ..
     } = data;
 
+    let has_changes = any_pending_change(
+        warnings
+            .black
+            .iter()
+            .chain(warnings.equal.iter())
+            .chain(warnings.white.iter())
+            .map(|w| w.format_hint),
+    );
+
     column![
         make_game_time_button(
             snapshot,
@@ -64,10 +73,12 @@ pub(in super::super) fn build_foul_overview_page<'a>(
                     infraction: Infraction::Unknown,
                     ret_to_overview: true,
                 })),
-            make_button(fl!("done"))
+            make_button(fl!("apply"))
                 .style(green_button)
                 .width(Length::Fill)
-                .on_press(Message::FoulOverviewComplete { canceled: false }),
+                .on_press_maybe(
+                    has_changes.then_some(Message::FoulOverviewComplete { canceled: false }),
+                ),
         ]
         .spacing(SPACING),
     ]

--- a/refbox/src/app/view_builders/keypad_pages/game_number_edit.rs
+++ b/refbox/src/app/view_builders/keypad_pages/game_number_edit.rs
@@ -4,7 +4,10 @@ use iced::{
     widget::{column, row, vertical_space},
 };
 
-pub(super) fn make_game_number_edit_page<'a>() -> Element<'a, Message> {
+pub(super) fn make_game_number_edit_page<'a>(
+    value: u32,
+    original: Option<String>,
+) -> Element<'a, Message> {
     column![
         vertical_space(),
         row![
@@ -12,13 +15,50 @@ pub(super) fn make_game_number_edit_page<'a>() -> Element<'a, Message> {
                 .style(red_button)
                 .width(Length::Fill)
                 .on_press(Message::ParameterEditComplete { canceled: true }),
-            make_button(fl!("done"))
+            make_button(fl!("apply"))
                 .style(green_button)
                 .width(Length::Fill)
-                .on_press(Message::ParameterEditComplete { canceled: false }),
+                .on_press_maybe(
+                    game_number_has_changes(value, original.as_deref())
+                        .then_some(Message::ParameterEditComplete { canceled: false }),
+                ),
         ]
         .spacing(SPACING),
     ]
     .spacing(SPACING)
     .into()
+}
+
+/// Returns true when the typed game number differs from the one stored when the
+/// editor opened — i.e. when pressing Apply would actually change the stored
+/// value. `value.to_string()` is exactly what `ParameterEditComplete` writes
+/// back to the edited settings.
+fn game_number_has_changes(value: u32, original: Option<&str>) -> bool {
+    match original {
+        Some(o) => value.to_string() != o,
+        None => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn same_number_is_no_change() {
+        assert!(!game_number_has_changes(5, Some("5")));
+        assert!(!game_number_has_changes(12, Some("12")));
+    }
+
+    #[test]
+    fn different_number_is_change() {
+        assert!(game_number_has_changes(5, Some("6")));
+    }
+
+    #[test]
+    fn missing_original_enables_apply() {
+        // Defensive: the GameNumber keypad is only reached with edited settings
+        // present, but if the original is unknown, don't block committing.
+        assert!(game_number_has_changes(5, None));
+    }
 }

--- a/refbox/src/app/view_builders/keypad_pages/mod.rs
+++ b/refbox/src/app/view_builders/keypad_pages/mod.rs
@@ -40,6 +40,7 @@ pub(in super::super) fn build_keypad_page<'a>(
     page: KeypadPage,
     player_num: u32,
     track_fouls_and_warnings: bool,
+    original_game_number: Option<String>,
 ) -> Element<'a, Message> {
     let ViewData {
         snapshot,
@@ -224,7 +225,8 @@ pub(in super::super) fn build_keypad_page<'a>(
                         foul,
                     )
                 }
-                KeypadPage::GameNumber => make_game_number_edit_page(),
+                KeypadPage::GameNumber =>
+                    make_game_number_edit_page(player_num, original_game_number),
                 KeypadPage::TeamTimeouts(_, _) => {
                     unreachable!("TeamTimeouts is handled by the early return above")
                 }

--- a/refbox/src/app/view_builders/penalties.rs
+++ b/refbox/src/app/view_builders/penalties.rs
@@ -28,6 +28,14 @@ pub(in super::super) fn build_penalty_overview_page<'a>(
         Mode::BeepTest => unreachable!("BeepTest mode does not edit penalties"),
     };
 
+    let has_changes = any_pending_change(
+        penalties
+            .black
+            .iter()
+            .chain(penalties.white.iter())
+            .map(|p| p.format_hint),
+    );
+
     column![
         make_game_time_button(
             snapshot,
@@ -68,10 +76,12 @@ pub(in super::super) fn build_penalty_overview_page<'a>(
                     default_pen_len,
                     Infraction::Unknown,
                 ))),
-            make_button(fl!("done"))
+            make_button(fl!("apply"))
                 .style(green_button)
                 .width(Length::Fill)
-                .on_press(Message::PenaltyOverviewComplete { canceled: false }),
+                .on_press_maybe(
+                    has_changes.then_some(Message::PenaltyOverviewComplete { canceled: false }),
+                ),
         ]
         .spacing(SPACING),
     ]

--- a/refbox/src/app/view_builders/score_edit.rs
+++ b/refbox/src/app/view_builders/score_edit.rs
@@ -11,6 +11,7 @@ pub(in super::super) fn build_score_edit_view<'a>(
     scores: BlackWhiteBundle<u8>,
     is_confirmation: bool,
     confirmation_time: Option<u32>,
+    old_scores: BlackWhiteBundle<u8>,
 ) -> Element<'a, Message> {
     let ViewData {
         snapshot,
@@ -122,6 +123,22 @@ pub(in super::super) fn build_score_edit_view<'a>(
         main_col = main_col.push(vertical_space());
     }
 
+    // Confirmation mode keeps "Done" and stays always-clickable (the operator
+    // must be able to commit the final score). Edit mode uses "Apply" and grays
+    // out until the scores actually differ from what was shown on open.
+    let confirm_btn = if is_confirmation {
+        make_button(fl!("done"))
+            .style(green_button)
+            .on_press(Message::ScoreEditComplete { canceled: false })
+    } else {
+        make_button(fl!("apply"))
+            .style(green_button)
+            .on_press_maybe(
+                score_edit_has_changes(scores, old_scores)
+                    .then_some(Message::ScoreEditComplete { canceled: false }),
+            )
+    };
+
     main_col
         .push(
             row![
@@ -140,11 +157,47 @@ pub(in super::super) fn build_score_edit_view<'a>(
                     .on_press_maybe(cancel_btn_msg)
                     .style(red_button),
                 horizontal_space(),
-                make_button(fl!("done"))
-                    .style(green_button)
-                    .on_press(Message::ScoreEditComplete { canceled: false }),
+                confirm_btn,
             ]
             .spacing(SPACING),
         )
         .into()
+}
+
+/// Returns true when the edited scores differ from the scores shown when the
+/// Score EDIT screen was opened (the tournament-manager scores, which are not
+/// changed until Apply). Only consulted in edit mode — never in confirmation,
+/// where the operator must always be able to commit the final score.
+fn score_edit_has_changes(scores: BlackWhiteBundle<u8>, old: BlackWhiteBundle<u8>) -> bool {
+    scores != old
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn score_no_change_is_false() {
+        let s = BlackWhiteBundle { black: 3, white: 5 };
+        assert!(!score_edit_has_changes(s, s));
+    }
+
+    #[test]
+    fn score_change_is_true() {
+        assert!(score_edit_has_changes(
+            BlackWhiteBundle { black: 4, white: 5 },
+            BlackWhiteBundle { black: 3, white: 5 }
+        ));
+    }
+
+    #[test]
+    fn score_round_trip_is_false() {
+        // +1 then -1 returns to the original bundle.
+        let original = BlackWhiteBundle { black: 2, white: 2 };
+        let after = BlackWhiteBundle {
+            black: original.black + 1 - 1,
+            white: original.white,
+        };
+        assert!(!score_edit_has_changes(after, original));
+    }
 }

--- a/refbox/src/app/view_builders/shared_elements.rs
+++ b/refbox/src/app/view_builders/shared_elements.rs
@@ -1432,10 +1432,34 @@ pub fn inf_short_name(inf: Infraction) -> String {
     }
 }
 
+/// Returns true when any of the given format hints represents a pending change
+/// (anything other than `NoChange`). Used to gray the Apply button on the
+/// penalty / warning / foul overview pages until a row is added, edited, or
+/// deleted.
+pub(super) fn any_pending_change(hints: impl IntoIterator<Item = FormatHint>) -> bool {
+    hints.into_iter().any(|h| h != FormatHint::NoChange)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::config::Mode;
+
+    #[test]
+    fn any_pending_change_detects_edits() {
+        let empty: [FormatHint; 0] = [];
+        assert!(!any_pending_change(empty));
+        assert!(!any_pending_change([
+            FormatHint::NoChange,
+            FormatHint::NoChange
+        ]));
+        assert!(any_pending_change([
+            FormatHint::NoChange,
+            FormatHint::Edited
+        ]));
+        assert!(any_pending_change([FormatHint::New]));
+        assert!(any_pending_change([FormatHint::Deleted]));
+    }
 
     #[test]
     fn crosses_portal_within_hockey_is_false() {

--- a/refbox/src/app/view_builders/warnings.rs
+++ b/refbox/src/app/view_builders/warnings.rs
@@ -21,6 +21,14 @@ pub(in super::super) fn build_warning_overview_page<'a>(
         ..
     } = data;
 
+    let has_changes = any_pending_change(
+        warnings
+            .black
+            .iter()
+            .chain(warnings.white.iter())
+            .map(|w| w.format_hint),
+    );
+
     column![
         make_game_time_button(
             snapshot,
@@ -60,10 +68,12 @@ pub(in super::super) fn build_warning_overview_page<'a>(
                     team_warning: false,
                     ret_to_overview: true,
                 })),
-            make_button(fl!("done"))
+            make_button(fl!("apply"))
                 .style(green_button)
                 .width(Length::Fill)
-                .on_press(Message::WarningOverviewComplete { canceled: false }),
+                .on_press_maybe(
+                    has_changes.then_some(Message::WarningOverviewComplete { canceled: false }),
+                ),
         ]
         .spacing(SPACING),
     ]


### PR DESCRIPTION
## What changed

On four kinds of screen, the green button now reads **"Apply"** instead of "Done", and it stays **greyed-out (not pressable) until you've actually made a change** — so "Apply" lights up only when there's something to save:

- The **parameter time editors** (e.g. Half Length, Half-Time, Game Block).
- The manual **Score EDIT** screen.
- The **Game Number** editor.
- The **Penalties / Warnings / Fouls overview** lists.

Reverting a change back to where it started greys the button again. On the Half Length editor, switching **2 Halves / 1 Period** also counts as a change.

The end-of-game **final-score confirmation** screen is deliberately left as **"Done"** and always pressable, so you can always confirm a score.

## Why

This matches the behaviour the time editor and the Settings pages already use, so the whole app is consistent. It also makes the button a clear signal: if it's lit, you have an unsaved change; if it's greyed, nothing has changed — which prevents accidental "saves" that do nothing.

## Scope

Changes are limited to the `refbox` crate's screen-drawing code (`refbox/src/app/view_builders/` and the matching display wiring in `refbox/src/app/mod.rs`). No game-clock, scoring, hardware, or shared-data changes. It reuses the existing "Apply" wording already translated in every language — no new text was added.

## How to verify

- **Parameter editor** (Settings → Game → e.g. Half Length): "Apply" is greyed on open; change the time → it lights up; set it back → it greys again. Switching 2 Halves / 1 Period also lights it up.
- **Game Number** (Settings → Game → Game Number): greyed until you type a different number.
- **Score EDIT** (main screen → EDIT scores): greyed until you change a score; +1 then −1 back to the original greys it again.
- **Final-score confirmation** (end-of-game score screen): still reads **"Done"** and is always pressable.
- **Penalties / Warnings / Fouls overviews**: "Apply" greyed with nothing pending; add / edit / delete an entry → it lights up. Cancel and the blue "New" button behave exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
