### PR TITLE
feat(refbox): require player number + infraction before saving entries

### DIFF
--- a/refbox/src/app/view_builders/keypad_pages/foul_add.rs
+++ b/refbox/src/app/view_builders/keypad_pages/foul_add.rs
@@ -17,6 +17,7 @@ pub(super) fn make_foul_add_page<'a>(
     color: Option<GameColor>,
     foul: Infraction,
     ret_to_overview: bool,
+    player_num: u32,
 ) -> Element<'a, Message> {
     let (black_style, white_style, equal_style): (StyleFn, StyleFn, StyleFn) = match color {
         Some(GameColor::Black) => (black_selected_button, white_button, blue_button),
@@ -53,11 +54,13 @@ pub(super) fn make_foul_add_page<'a>(
         make_button(fl!("done"))
             .style(green_button)
             .width(Length::Fill)
-            .on_press(Message::FoulEditComplete {
-                canceled: false,
-                deleted: false,
-                ret_to_overview,
-            }),
+            .on_press_maybe(foul_add_can_commit(foul, color, player_num).then_some(
+                Message::FoulEditComplete {
+                    canceled: false,
+                    deleted: false,
+                    ret_to_overview,
+                },
+            )),
     );
     column![
         row![
@@ -81,4 +84,51 @@ pub(super) fn make_foul_add_page<'a>(
         exit_row,
     ]
     .into()
+}
+
+/// Returns true when the foul entry has everything it needs to be saved: an
+/// infraction must always be selected, and an individual foul (Black/White)
+/// also needs a player number. An "equal" foul (`color == None`) has no player,
+/// so it needs only the infraction.
+fn foul_add_can_commit(infraction: Infraction, color: Option<GameColor>, player_num: u32) -> bool {
+    !matches!(infraction, Infraction::Unknown) && (color.is_none() || player_num > 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn foul_needs_infraction() {
+        // Equal foul, infraction unset → blocked.
+        assert!(!foul_add_can_commit(Infraction::Unknown, None, 0));
+    }
+
+    #[test]
+    fn foul_equal_with_infraction_ok_without_number() {
+        assert!(foul_add_can_commit(Infraction::StickInfringement, None, 0));
+    }
+
+    #[test]
+    fn foul_individual_needs_number() {
+        assert!(!foul_add_can_commit(
+            Infraction::StickInfringement,
+            Some(GameColor::Black),
+            0
+        ));
+        assert!(foul_add_can_commit(
+            Infraction::StickInfringement,
+            Some(GameColor::Black),
+            5
+        ));
+    }
+
+    #[test]
+    fn foul_individual_with_number_still_needs_infraction() {
+        assert!(!foul_add_can_commit(
+            Infraction::Unknown,
+            Some(GameColor::Black),
+            5
+        ));
+    }
 }

--- a/refbox/src/app/view_builders/keypad_pages/mod.rs
+++ b/refbox/src/app/view_builders/keypad_pages/mod.rs
@@ -242,8 +242,14 @@ pub(in super::super) fn build_keypad_page<'a>(
                     infraction,
                     team_warning,
                     ret_to_overview,
-                } =>
-                    make_warning_add_page(origin, color, infraction, team_warning, ret_to_overview),
+                } => make_warning_add_page(
+                    origin,
+                    color,
+                    infraction,
+                    team_warning,
+                    ret_to_overview,
+                    player_num,
+                ),
                 KeypadPage::PortalLogin(id, requested) => {
                     make_portal_login_page(id, requested, mode)
                 }

--- a/refbox/src/app/view_builders/keypad_pages/mod.rs
+++ b/refbox/src/app/view_builders/keypad_pages/mod.rs
@@ -223,6 +223,7 @@ pub(in super::super) fn build_keypad_page<'a>(
                         mode,
                         track_fouls_and_warnings,
                         foul,
+                        player_num,
                     )
                 }
                 KeypadPage::GameNumber =>

--- a/refbox/src/app/view_builders/keypad_pages/mod.rs
+++ b/refbox/src/app/view_builders/keypad_pages/mod.rs
@@ -235,7 +235,7 @@ pub(in super::super) fn build_keypad_page<'a>(
                     color,
                     infraction,
                     ret_to_overview,
-                } => make_foul_add_page(origin, color, infraction, ret_to_overview),
+                } => make_foul_add_page(origin, color, infraction, ret_to_overview, player_num),
                 KeypadPage::WarningAdd {
                     origin,
                     color,

--- a/refbox/src/app/view_builders/keypad_pages/penalty_edit.rs
+++ b/refbox/src/app/view_builders/keypad_pages/penalty_edit.rs
@@ -17,6 +17,7 @@ pub(super) fn make_penalty_edit_page<'a>(
     mode: Mode,
     track_fouls_and_warnings: bool,
     infraction: Infraction,
+    player_num: u32,
 ) -> Element<'a, Message> {
     let (black_style, white_style): (StyleFn, StyleFn) = match color {
         GameColor::Black => (black_selected_button, white_button),
@@ -105,10 +106,13 @@ pub(super) fn make_penalty_edit_page<'a>(
         make_smaller_button(fl!("done"))
             .style(green_button)
             .width(Length::Fill)
-            .on_press(Message::PenaltyEditComplete {
-                canceled: false,
-                deleted: false,
-            }),
+            .on_press_maybe(
+                penalty_edit_can_commit(infraction, track_fouls_and_warnings, player_num)
+                    .then_some(Message::PenaltyEditComplete {
+                        canceled: false,
+                        deleted: false,
+                    }),
+            ),
     );
 
     let green_label = fl!("penalty-kind", kind = green.fluent());
@@ -157,4 +161,47 @@ pub(super) fn make_penalty_edit_page<'a>(
 
     content = content.push(exit_row);
     content.into()
+}
+
+/// Returns true when the penalty entry can be saved: a player number is always
+/// required (penalties are always individual). The infraction is required only
+/// when "track fouls & warnings" is on — that is exactly when the infraction
+/// picker is shown on this screen.
+fn penalty_edit_can_commit(
+    infraction: Infraction,
+    track_fouls_and_warnings: bool,
+    player_num: u32,
+) -> bool {
+    player_num > 0 && (!track_fouls_and_warnings || !matches!(infraction, Infraction::Unknown))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn penalty_needs_number() {
+        // Tracking off: only a number is required.
+        assert!(!penalty_edit_can_commit(Infraction::Unknown, false, 0));
+        assert!(penalty_edit_can_commit(Infraction::Unknown, false, 5));
+    }
+
+    #[test]
+    fn penalty_needs_infraction_when_tracking_on() {
+        assert!(!penalty_edit_can_commit(Infraction::Unknown, true, 5));
+        assert!(penalty_edit_can_commit(
+            Infraction::StickInfringement,
+            true,
+            5
+        ));
+    }
+
+    #[test]
+    fn penalty_tracking_on_still_needs_number() {
+        assert!(!penalty_edit_can_commit(
+            Infraction::StickInfringement,
+            true,
+            0
+        ));
+    }
 }

--- a/refbox/src/app/view_builders/keypad_pages/warning_add.rs
+++ b/refbox/src/app/view_builders/keypad_pages/warning_add.rs
@@ -17,6 +17,7 @@ pub(super) fn make_warning_add_page<'a>(
     foul: Infraction,
     team_warning: bool,
     ret_to_overview: bool,
+    player_num: u32,
 ) -> Element<'a, Message> {
     let (black_style, white_style): (StyleFn, StyleFn) = match color {
         GameColor::Black => (black_selected_button, white_button),
@@ -58,11 +59,15 @@ pub(super) fn make_warning_add_page<'a>(
         make_button(fl!("done"))
             .style(green_button)
             .width(Length::Fill)
-            .on_press(Message::WarningEditComplete {
-                canceled: false,
-                deleted: false,
-                ret_to_overview,
-            }),
+            .on_press_maybe(
+                warning_add_can_commit(foul, team_warning, player_num).then_some(
+                    Message::WarningEditComplete {
+                        canceled: false,
+                        deleted: false,
+                        ret_to_overview,
+                    },
+                ),
+            ),
     );
     column![
         row![
@@ -83,4 +88,49 @@ pub(super) fn make_warning_add_page<'a>(
         exit_row,
     ]
     .into()
+}
+
+/// Returns true when the warning entry can be saved: an infraction must always
+/// be selected, and an individual warning also needs a player number. A team
+/// warning (`team_warning == true`) has no player, so it needs only the infraction.
+fn warning_add_can_commit(infraction: Infraction, team_warning: bool, player_num: u32) -> bool {
+    !matches!(infraction, Infraction::Unknown) && (team_warning || player_num > 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn warning_needs_infraction() {
+        assert!(!warning_add_can_commit(Infraction::Unknown, true, 0));
+    }
+
+    #[test]
+    fn warning_team_with_infraction_ok_without_number() {
+        assert!(warning_add_can_commit(
+            Infraction::StickInfringement,
+            true,
+            0
+        ));
+    }
+
+    #[test]
+    fn warning_individual_needs_number() {
+        assert!(!warning_add_can_commit(
+            Infraction::StickInfringement,
+            false,
+            0
+        ));
+        assert!(warning_add_can_commit(
+            Infraction::StickInfringement,
+            false,
+            7
+        ));
+    }
+
+    #[test]
+    fn warning_individual_with_number_still_needs_infraction() {
+        assert!(!warning_add_can_commit(Infraction::Unknown, false, 7));
+    }
 }


### PR DESCRIPTION
## What changed

On the screens where you **add or edit a foul, warning, or penalty**, the green **"Done"** button now stays greyed-out (not pressable) until the entry has the information it needs:

- An **infraction** must be picked (the "?" replaced with a real type) — always for fouls and warnings, and for penalties too when the "track fouls & warnings" setting is on.
- A **player number** must be entered for any entry tied to a specific player. Team-wide entries don't need one: a foul marked **"="** (equal) and a **TEAM** warning are exempt. Penalties always need a number (they're always on a player).

The "Done" label itself is unchanged, and **Cancel / Delete always work**.

## Why

This stops an incomplete penalty / warning / foul — one with no player number, or with the infraction left as "?" — from being saved into the records by accident. It catches the problem right where the operator enters the details, instead of letting a blank entry reach the list.

## Scope

Changes are limited to the `refbox` crate's three add/edit screens (`foul_add.rs`, `warning_add.rs`, `penalty_edit.rs`) and the keypad screen that hosts them (`keypad_pages/mod.rs`). No game-clock, scoring, hardware, or shared-data changes; no new text.

## How to verify

- New **foul** (opens on "="): "Done" greys until you pick an infraction. Switch to Black/White → greys until you also enter a player number; back to "=" → enabled with just the infraction.
- New **warning** (opens individual): "Done" greys until both an infraction *and* a number; turn on **TEAM** → enabled with just the infraction.
- **Penalty** with "track fouls & warnings" on → greys until both a number *and* an infraction; with it off → greys until just a number.
- Cancel and Delete always work; editing a complete existing entry shows "Done" enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
