### PR TITLE
fix(refbox): capture entry snapshot on direct config-page entry

### DIFF
--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -1313,6 +1313,12 @@ impl RefBoxApp {
         self.edited_settings = Some(edited_settings);
 
         self.app_state = AppState::EditGameConfig(landing);
+        // Start change-watching for the landing page right away. Without this,
+        // entering the editor directly on a real page (e.g. the game-info
+        // shortcut into Game Options) leaves no page-entry snapshot, so
+        // page_has_changes always reports "no changes" and Apply never enables.
+        // No-op for Main/User landings (capture_snapshot_for early-returns).
+        self.capture_snapshot_for(landing);
         trace!("AppState changed to {:?}", self.app_state);
         task
     }


### PR DESCRIPTION
## What changed
Opening the **Game Options** config page via the quick shortcut (straight from the game-info
screen) now starts change-tracking immediately. Previously that shortcut skipped it, so the
APPLY button never became active no matter what you changed on the page.

## Why
This is the actual cause of "APPLY stays grey after switching USING UWHPORTAL to YES and
completing the event/court/game selection." Change-detection only started when you reached
Game Options by navigating through the settings menu; the direct shortcut left it un-started,
so the page always reported "no changes" and APPLY stayed disabled.

## Scope
One line in `refbox/src/app/mod.rs` — `enter_game_config` now captures the page-entry snapshot
for the landing page. No other behaviour changes; it is a no-op for the menu/User landing pages
(which have no APPLY button).

## How to verify
1. From the game-info screen, use the shortcut into Game Options.
2. Set USING UWHPORTAL to YES and pick the event, court, and game.
3. APPLY now turns active (it stayed grey before this fix).
4. Confirm the normal menu path (Settings -> Game Options) still enables APPLY on a change.

`cargo test -p refbox` passes (317 tests); formatting and lint clean. (The entry path itself
isn't unit-testable without a full fake-app harness, so this was verified by live walkthrough.)
