### PR TITLE
feat(refbox): use Apply instead of Done on language pickers

### DIFF
--- a/refbox/src/app/languages.rs
+++ b/refbox/src/app/languages.rs
@@ -98,23 +98,23 @@ impl Language {
         }
     }
 
-    pub fn done_text(self) -> &'static str {
+    pub fn apply_text(self) -> &'static str {
         match self {
-            Self::English => "DONE",
-            Self::French => "TERMINÉ",
-            Self::Spanish => "HECHO",
-            Self::Mandarin => "完成",
-            Self::Korean => "완료",
-            Self::Italian => "FATTO",
-            Self::German => "FERTIG",
-            Self::Tagalog => "TAPOS",
-            Self::Indonesian => "SELESAI",
-            Self::Dutch => "KLAAR",
-            Self::Japanese => "完了",
-            Self::Malay => "SELESAI",
-            Self::Portuguese => "CONCLUÍDO",
-            Self::Thai => "เสร็จสิ้น",
-            Self::Turkish => "TAMAM",
+            Self::English => "APPLY",
+            Self::French => "APPLIQUER",
+            Self::Spanish => "APLICAR",
+            Self::Mandarin => "应用",
+            Self::Korean => "적용",
+            Self::Italian => "APPLICA",
+            Self::German => "ANWENDEN",
+            Self::Tagalog => "ILAPAT",
+            Self::Indonesian => "TERAPKAN",
+            Self::Dutch => "TOEPASSEN",
+            Self::Japanese => "適用",
+            Self::Malay => "GUNA",
+            Self::Portuguese => "APLICAR",
+            Self::Thai => "ใช้",
+            Self::Turkish => "UYGULA",
         }
     }
 

--- a/refbox/src/app/view_builders/beep_test_settings.rs
+++ b/refbox/src/app/view_builders/beep_test_settings.rs
@@ -704,8 +704,8 @@ pub(in super::super) fn build_beep_test_language_picker<'a>(
             .into()
     };
 
-    // Cancel / Done(Restart) footer. The labels use the selected language's
-    // own translation of CANCEL / DONE / RESTART (so a user mid-switch can
+    // Cancel / Apply(Restart) footer. The labels use the selected language's
+    // own translation of CANCEL / APPLY / RESTART (so a user mid-switch can
     // read them) and the appropriate font for the selected script.
     let make_label = |content: &'static str, font: Option<iced_core::Font>| {
         let t = text(content)
@@ -733,7 +733,7 @@ pub(in super::super) fn build_beep_test_language_picker<'a>(
             .on_press_maybe(confirm_msg)
             .into()
     } else {
-        button(make_label(selected.done_text(), selected_font))
+        button(make_label(selected.apply_text(), selected_font))
             .padding(PADDING)
             .height(Length::Fixed(MIN_BUTTON_SIZE))
             .style(green_button)

--- a/refbox/src/app/view_builders/configuration.rs
+++ b/refbox/src/app/view_builders/configuration.rs
@@ -1783,7 +1783,7 @@ fn make_language_select_page<'a>(
         style: iced_core::font::Style::Normal,
     };
 
-    // Font to apply to Cancel/Done/Restart text so they render in the target language's script
+    // Font to apply to Cancel/Apply/Restart text so they render in the target language's script
     // regardless of the app's current default font. Without an explicit Latin arm, Turkish text
     // like "İPTAL" or "BAŞLAT" renders as tofu when the app is currently in a CJK/Thai locale.
     let selected_font: Option<iced_core::Font> = match selected {
@@ -1982,7 +1982,7 @@ fn make_language_select_page<'a>(
                     .on_press_maybe(confirm_msg)
                     .into()
             } else {
-                button(make_label(selected.done_text(), selected_font))
+                button(make_label(selected.apply_text(), selected_font))
                     .padding(PADDING)
                     .height(Length::Fixed(MIN_BUTTON_SIZE))
                     .style(green_button)


### PR DESCRIPTION
## What changed
The save button on the refbox language-selection screens now reads **APPLY** instead of **DONE**. This applies to two places that share the same code:
- **Settings → Language**
- **Beep Test mode → language picker**

The label is shown in the currently-selected language's own script (e.g. APPLIQUER, APLICAR, 適用), and stays grayed-out until you actually pick a different language. The "RESTART TO APPLY" label (shown only when switching between Latin and CJK fonts) is unchanged.

## Why
The earlier Done→Apply rollout (PR #1241) standardized config screens on an "Apply" button that grays out until something changes. The language pickers were missed — they still said "Done". This brings them in line with the rest of the app.

## Scope
Limited to `refbox`:
- `refbox/src/app/languages.rs` — renamed `done_text()` → `apply_text()` and pointed its 15 values at the existing native "APPLY" strings.
- `refbox/src/app/view_builders/configuration.rs` — call site + comment.
- `refbox/src/app/view_builders/beep_test_settings.rs` — call site + comment.

No new translation keys were added — the 15 "APPLY" translations already exist and are reused from the earlier rollout. No behaviour change beyond the label (the gray-until-changed logic already existed).

## How to verify
1. Launch refbox → **Settings → Language**. The bottom-right footer button reads **APPLY** and is grayed out. Tap a different language → it becomes active. Tap it → the language applies.
2. Open **Beep Test mode → language picker**. Same **APPLY** label and behaviour.
3. `just check` passes (fmt, lint, tests, audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)