### PR TITLE
feat(refbox): log a note on self-update and revert

### DIFF
--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -2829,6 +2829,18 @@ impl RefBoxApp {
                         let _ = crate::updater::marker::clear_trial(&self.config_dir);
                         match crate::updater::swap::revert(&install, &backup) {
                             Ok(()) => {
+                                // Record the rollback before the tracked backup
+                                // version is cleared. The running binary is the
+                                // version being reverted *from*; `update_backup_version`
+                                // is the one being restored *to*.
+                                if let (Some(from), Some(to)) = (
+                                    crate::updater::version::Version::parse(env!(
+                                        "CARGO_PKG_VERSION"
+                                    )),
+                                    self.update_backup_version,
+                                ) {
+                                    info!("Reverted update: v{from} -> v{to}; restarting to apply");
+                                }
                                 if let AppState::Updates {
                                     ref mut state,
                                     ref mut backup_available,
@@ -2888,8 +2900,17 @@ impl RefBoxApp {
             }
             Message::UpdaterHealthyCheck => {
                 // The app processed this message ~20s after launch, so it started
-                // healthily. Clear any update trial marker so a later boot is not
-                // mistaken for a failed trial. Idempotent / no-op if absent.
+                // healthily. A trial marker still present here means this is the
+                // first healthy run of a freshly self-installed binary, so record
+                // the version change before clearing the marker below. (`trying` is
+                // the version now running; `backup` is the one it replaced.)
+                if let Some((trying, backup)) =
+                    crate::updater::marker::trial_versions(&self.config_dir)
+                {
+                    info!("Self-update succeeded: now running v{trying} (updated from v{backup})");
+                }
+                // Clear any update trial marker so a later boot is not mistaken for
+                // a failed trial. Idempotent / no-op if absent.
                 if let Err(e) = crate::updater::marker::clear_trial(&self.config_dir) {
                     warn!("Failed to clear update trial marker: {e}");
                 }

--- a/refbox/src/updater/marker.rs
+++ b/refbox/src/updater/marker.rs
@@ -162,6 +162,16 @@ fn read_trial(dir: &Path) -> Option<(Version, Version, String)> {
     Some((trying, backup, phase))
 }
 
+/// Read the two versions recorded in the trial marker, if one is present.
+///
+/// Returns `(trying, backup)` — the version being trialled and the version it
+/// would revert to. Used to log a successful self-update once the freshly
+/// installed binary reaches a healthy state. Returns `None` when no marker is
+/// present or it is malformed.
+pub fn trial_versions(dir: &Path) -> Option<(Version, Version)> {
+    read_trial(dir).map(|(trying, backup, _phase)| (trying, backup))
+}
+
 /// Read marker files and decide what the application should do on startup.
 ///
 /// Two-phase trial logic:
@@ -343,5 +353,15 @@ mod tests {
             decide_on_startup(d.path()),
             StartupDecision::Normal
         ));
+    }
+
+    #[test]
+    fn trial_versions_reads_both_versions_when_present() {
+        let d = tempfile::tempdir().unwrap();
+        // No marker -> None.
+        assert_eq!(trial_versions(d.path()), None);
+        // After a trial is written, both versions are recoverable.
+        write_trial(d.path(), &v("0.4.4"), &v("0.4.3")).unwrap();
+        assert_eq!(trial_versions(d.path()), Some((v("0.4.4"), v("0.4.3"))));
     }
 }


### PR DESCRIPTION
## What changed

The refbox now writes a clear, timestamped note in its log file every time it changes version:

- **On a successful self-update** — written by the new version once it has started up and run healthily (~20 seconds after launch):
  `Self-update succeeded: now running v0.4.4 (updated from v0.4.3)`
- **When the operator presses Revert** to go back to the previous version:
  `Reverted update: v0.4.4 -> v0.4.3; restarting to apply`

These join the note that already existed for the failure case (automatic rollback when a new version won't start), so the log now records all three kinds of version change.

The success note is written by the *new* version, reading the small trial marker the outgoing version leaves behind. This means the very first jump — v0.4.3 → v0.4.4 — is captured (you'll see it the first time a box updates *into* the v0.4.4 that contains this change), and the note only appears once the new version has actually run healthily.

## Why

A clean update previously left almost no trace in the log — there was no way to confirm after the fact that a box had updated itself, or when. This makes every version change visible.

## Scope

Limited to the `refbox` crate, two files:
- `refbox/src/updater/marker.rs` — a small public `trial_versions` accessor to read the trialled and backup version numbers out of the existing marker file (+ a unit test).
- `refbox/src/app/mod.rs` — the two log lines, in the healthy-startup handler and the revert-confirm handler.

The update/revert mechanism itself is unchanged.

## How to verify

- **Automated:** `just check` passes — all refbox tests plus the new `trial_versions_reads_both_versions_when_present` test, with no formatting or linter issues.
- **On a real box (after this ships in v0.4.4):** when it self-updates to the next version, the log file (`refbox-log.txt`) will contain the `Self-update succeeded: …` line with a timestamp; pressing Revert will log the `Reverted update: …` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
