### PR TITLE
feat(refbox): add UPDATE AUDIO OUTPUT button to re-adopt OS default speaker

### DIFF
--- a/refbox/src/app/message.rs
+++ b/refbox/src/app/message.rs
@@ -139,6 +139,11 @@ pub enum Message {
         canceled: bool,
     },
     RequestRemoteId,
+    // Constructed by the Sound-page button on non-Linux only; on Linux the Pi
+    // has a fixed dedicated speaker so the button is compiled out. The variant
+    // is kept ungated so the worker match and update() arm stay uniform.
+    #[cfg_attr(target_os = "linux", allow(dead_code))]
+    UpdateAudioOutput,
     GotRemoteId(RemoteId),
     DeleteRemote(usize),
     ConfirmationSelected(ConfirmationOption),
@@ -337,6 +342,7 @@ impl Message {
             | Self::SelectLanguage(_)
             | Self::LanguageSelectComplete { .. }
             | Self::RequestRemoteId
+            | Self::UpdateAudioOutput
             | Self::GotRemoteId(_)
             | Self::DeleteRemote(_)
             | Self::ConfirmationSelected(_)
@@ -421,6 +427,7 @@ impl PartialEq for Message {
             | (Self::EditGameConfig, Self::EditGameConfig)
             | (Self::ConfigEditComplete, Self::ConfigEditComplete)
             | (Self::RequestRemoteId, Self::RequestRemoteId)
+            | (Self::UpdateAudioOutput, Self::UpdateAudioOutput)
             | (Self::EndTimeout, Self::EndTimeout)
             | (Self::CancelTimeout, Self::CancelTimeout)
             | (Self::StopClock, Self::StopClock)
@@ -658,6 +665,7 @@ impl PartialEq for Message {
             | (Self::SelectLanguage(_), _)
             | (Self::LanguageSelectComplete { .. }, _)
             | (Self::RequestRemoteId, _)
+            | (Self::UpdateAudioOutput, _)
             | (Self::GotRemoteId(_), _)
             | (Self::DeleteRemote(_), _)
             | (Self::ConfirmationSelected(_), _)

--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -2325,6 +2325,10 @@ impl RefBoxApp {
                 trace!("AppState changed to {:?}", self.app_state);
                 Task::none()
             }
+            Message::UpdateAudioOutput => {
+                self.sound.reload_audio_output();
+                Task::none()
+            }
             Message::OpenNewDisplay => {
                 if self.has_led_panel {
                     // Defense in depth — the UI grays the button out when an

--- a/refbox/src/app/view_builders/configuration.rs
+++ b/refbox/src/app/view_builders/configuration.rs
@@ -1207,6 +1207,17 @@ fn make_sound_config_page<'a>(
 ) -> Element<'a, Message> {
     let EditableSettings { sound, .. } = settings;
 
+    // Re-adopt the OS default output device. Laptop-only: the Pi runs Linux
+    // with a fixed dedicated speaker, so the button is absent there and the
+    // bottom row keeps its existing empty spacer.
+    #[cfg(not(target_os = "linux"))]
+    let audio_output_slot: Element<'a, Message> = make_button(fl!("update-audio-output"))
+        .on_press(Message::UpdateAudioOutput)
+        .style(light_gray_button)
+        .into();
+    #[cfg(target_os = "linux")]
+    let audio_output_slot: Element<'a, Message> = horizontal_space().into();
+
     column![
         make_game_time_button(
             snapshot,
@@ -1317,7 +1328,7 @@ fn make_sound_config_page<'a>(
         .spacing(SPACING)
         .height(Length::Fill),
         row![
-            horizontal_space(),
+            audio_output_slot,
             horizontal_space(),
             make_value_button(
                 fl!("auto-sound-stop-play"),

--- a/refbox/src/sound_controller/button_handler/mod.rs
+++ b/refbox/src/sound_controller/button_handler/mod.rs
@@ -22,6 +22,7 @@ pub(super) enum SoundMessage {
     TriggerWhistle,
     StartManualBuzzer,
     StopManualBuzzer,
+    ReloadAudioOutput,
     #[cfg(target_os = "linux")]
     StartWiredBuzzer,
     #[cfg(target_os = "linux")]

--- a/refbox/src/sound_controller/mod.rs
+++ b/refbox/src/sound_controller/mod.rs
@@ -276,7 +276,6 @@ impl SoundEnds {
 }
 
 pub struct SoundController {
-    _context: Arc<AudioContext>,
     msg_tx: UnboundedSender<SoundMessage>,
     settings_tx: Sender<SoundSettings>,
     stop_tx: Sender<bool>,
@@ -322,9 +321,13 @@ impl SoundController {
 
         let mut _stop_rx = stop_rx.clone();
         let mut _settings_rx = settings_rx.clone();
-        let _context = context.clone();
 
         let handle = task::spawn(async move {
+            // Owned by the worker so the audio output device can be rebuilt in
+            // place when the operator presses "UPDATE AUDIO OUTPUT". A fresh
+            // AudioContext resolves the CURRENT system default output device.
+            let mut context = context;
+            let mut library = library;
             #[cfg_attr(not(target_os = "linux"), allow(unused_assignments))]
             let mut last_sound: Option<(SoundId, Sound)> = None;
             let mut sound_queue: VecDeque<SoundId> = VecDeque::new();
@@ -357,6 +360,31 @@ impl SoundController {
                                         if sound_queue.contains(&SoundId::ManualAlarm) {
                                             sound_queue.retain(|s| *s != SoundId::ManualAlarm);
                                         }
+                                    }
+                                    SoundMessage::ReloadAudioOutput => {
+                                        info!("Reloading audio output to current system default");
+                                        // Stop any sound playing on the OLD device first.
+                                        if let Some((sound_id, sound)) = last_sound.take() {
+                                            sound.stop().await;
+                                            sound_ends.cancel(&sound_id);
+                                        }
+                                        // A fresh context (default sink) re-resolves
+                                        // the device the OS currently has as default.
+                                        let opts = AudioContextOptions {
+                                            sample_rate: Some(SAMPLE_RATE),
+                                            ..AudioContextOptions::default()
+                                        };
+                                        let new_context = AudioContext::new(opts);
+                                        debug!(
+                                            "Audio output reloaded with sink {:?}",
+                                            new_context.sink_id()
+                                        );
+                                        context = Arc::new(new_context);
+                                        library = SoundLibrary::new(&context);
+                                        // sound_queue holds only SoundId values; they are
+                                        // realized into Sound objects later by start_sound,
+                                        // which uses the new context — so the queue is
+                                        // intentionally left intact here, not drained.
                                     }
                                     #[cfg(target_os = "linux")]
                                     SoundMessage::StartWiredBuzzer => {
@@ -425,7 +453,7 @@ impl SoundController {
                                 trigger_flash().unwrap();
                             }
                             Sound::new(
-                                _context.clone(),
+                                context.clone(),
                                 volumes,
                                 library[settings.buzzer_sound].clone(),
                                 true,
@@ -436,7 +464,7 @@ impl SoundController {
                             info!("Playing whistle once");
                             let volumes = ChannelVolumes::new(&settings, true);
                             Sound::new(
-                                _context.clone(),
+                                context.clone(),
                                 volumes,
                                 library.whistle().clone(),
                                 false,
@@ -450,7 +478,7 @@ impl SoundController {
                                 trigger_flash().unwrap();
                             }
                             Sound::new(
-                                _context.clone(),
+                                context.clone(),
                                 volumes,
                                 library[settings.buzzer_sound].clone(),
                                 true,
@@ -465,7 +493,7 @@ impl SoundController {
                                 trigger_flash().unwrap();
                             }
                             Sound::new(
-                                _context.clone(),
+                                context.clone(),
                                 volumes,
                                 library[settings.buzzer_sound].clone(),
                                 true,
@@ -486,7 +514,7 @@ impl SoundController {
                                     trigger_flash().unwrap();
                                 }
                                 Sound::new(
-                                    _context.clone(),
+                                    context.clone(),
                                     volumes,
                                     library[buzzer_sound].clone(),
                                     true,
@@ -553,7 +581,6 @@ impl SoundController {
         };
 
         Self {
-            _context: context,
             msg_tx,
             settings_tx,
             stop_tx,
@@ -583,6 +610,12 @@ impl SoundController {
 
     pub fn trigger_buzzer(&self) {
         self.msg_tx.send(SoundMessage::TriggerBuzzer).unwrap()
+    }
+
+    pub fn reload_audio_output(&self) {
+        // The worker receiver lives for the app's lifetime; send only fails
+        // after shutdown, when there is nothing left to play through anyway.
+        self.msg_tx.send(SoundMessage::ReloadAudioOutput).unwrap()
     }
 
     /// Returns a future that resolves to the next detected remote id.

--- a/refbox/translations/de-DE/refbox.ftl
+++ b/refbox/translations/de-DE/refbox.ftl
@@ -110,6 +110,8 @@ sound-enabled = TON
 whistle-volume = PFEIFEN-
     LAUTSTÄRKE:
 manage-remotes = FERNBEDIENUNGEN VERWALTEN
+update-audio-output = AUDIOAUSGANG
+    AKTUALISIEREN
 whistle-enabled = PFEIFE
     AKTIVIERT:
 above-water-volume = LAUTSTÄRKE

--- a/refbox/translations/en-US/refbox.ftl
+++ b/refbox/translations/en-US/refbox.ftl
@@ -109,6 +109,8 @@ sound-enabled = SOUND
 whistle-volume = WHISTLE
     VOLUME:
 manage-remotes = MANAGE REMOTES
+update-audio-output = UPDATE AUDIO
+    OUTPUT
 whistle-enabled = WHISTLE 
     ENABLED:
 above-water-volume = ABOVE WATER

--- a/refbox/translations/es/refbox.ftl
+++ b/refbox/translations/es/refbox.ftl
@@ -110,6 +110,8 @@ sound-enabled = SONIDO
 whistle-volume = VOLUMEN
     DEL SILBATO:
 manage-remotes = GESTIONAR REMOTOS
+update-audio-output = ACTUALIZAR
+    SALIDA DE AUDIO
 whistle-enabled = SILBATO
     HABILITADO:
 above-water-volume = VOLUMEN

--- a/refbox/translations/fr/refbox.ftl
+++ b/refbox/translations/fr/refbox.ftl
@@ -108,6 +108,8 @@ sound-enabled = SON
 whistle-volume = VOLUME DU
     SIFFLET:
 manage-remotes = GÉRER LES TÉLÉCOMMANDES
+update-audio-output = ACTUALISER
+    SORTIE AUDIO
 whistle-enabled = SIFFLET
     ACTIVÉ:
 above-water-volume = VOLUME

--- a/refbox/translations/id-ID/refbox.ftl
+++ b/refbox/translations/id-ID/refbox.ftl
@@ -110,6 +110,8 @@ sound-enabled = SUARA
 whistle-volume = VOLUME
     PELUIT:
 manage-remotes = KELOLA REMOTE
+update-audio-output = PERBARUI
+    OUTPUT AUDIO
 whistle-enabled = PELUIT
     DIAKTIFKAN:
 above-water-volume = VOLUME

--- a/refbox/translations/it-IT/refbox.ftl
+++ b/refbox/translations/it-IT/refbox.ftl
@@ -110,6 +110,8 @@ sound-enabled = AUDIO
 whistle-volume = VOLUME
     FISCHIO:
 manage-remotes = GESTISCI TELECOMANDI
+update-audio-output = AGGIORNA
+    USCITA AUDIO
 whistle-enabled = FISCHIO
     ATTIVATO:
 above-water-volume = VOLUME

--- a/refbox/translations/ja-JP/refbox.ftl
+++ b/refbox/translations/ja-JP/refbox.ftl
@@ -110,6 +110,8 @@ sound-enabled = サウンド
 whistle-volume = 笛
     音量:
 manage-remotes = リモコン管理
+update-audio-output = オーディオ出力を
+    更新
 whistle-enabled = 笛
     有効:
 above-water-volume = 水上

--- a/refbox/translations/ko-KR/refbox.ftl
+++ b/refbox/translations/ko-KR/refbox.ftl
@@ -112,6 +112,8 @@ sound-enabled = 소리
 whistle-volume = 호루라기
     음량:
 manage-remotes = 리모컨 관리
+update-audio-output = 오디오 출력
+    업데이트
 whistle-enabled = 호루라기
     사용:
 above-water-volume = 수상

--- a/refbox/translations/ms-MY/refbox.ftl
+++ b/refbox/translations/ms-MY/refbox.ftl
@@ -110,6 +110,8 @@ sound-enabled = BUNYI
 whistle-volume = KELANTANGAN
     WISEL:
 manage-remotes = URUS KAWALAN JAUH
+update-audio-output = KEMAS KINI
+    OUTPUT AUDIO
 whistle-enabled = WISEL
     DIAKTIFKAN:
 above-water-volume = KELANTANGAN

--- a/refbox/translations/nl-NL/refbox.ftl
+++ b/refbox/translations/nl-NL/refbox.ftl
@@ -110,6 +110,8 @@ sound-enabled = GELUID
 whistle-volume = FLUIT-
     VOLUME:
 manage-remotes = AFSTANDSBEDIENINGEN BEHEREN
+update-audio-output = AUDIO-UITVOER
+    BIJWERKEN
 whistle-enabled = FLUIT
     INGESCHAKELD:
 above-water-volume = VOLUME

--- a/refbox/translations/pt-PT/refbox.ftl
+++ b/refbox/translations/pt-PT/refbox.ftl
@@ -110,6 +110,8 @@ sound-enabled = SOM
 whistle-volume = VOLUME DO
     APITO:
 manage-remotes = GERIR CONTROLOS REMOTOS
+update-audio-output = ATUALIZAR
+    SAÍDA DE ÁUDIO
 whistle-enabled = APITO
     ATIVADO:
 above-water-volume = VOLUME

--- a/refbox/translations/th-TH/refbox.ftl
+++ b/refbox/translations/th-TH/refbox.ftl
@@ -110,6 +110,8 @@ sound-enabled = เปิดใช้
 whistle-volume = ระดับเสียง
     นกหวีด:
 manage-remotes = จัดการรีโมต
+update-audio-output = อัปเดต
+    เอาต์พุตเสียง
 whistle-enabled = เปิดใช้
     นกหวีด:
 above-water-volume = ระดับเสียง

--- a/refbox/translations/tl-PH/refbox.ftl
+++ b/refbox/translations/tl-PH/refbox.ftl
@@ -110,6 +110,8 @@ sound-enabled = TUNOG
 whistle-volume = LAKAS NG
     SIPOL:
 manage-remotes = PAMAHALAAN ANG MGA REMOTE
+update-audio-output = I-UPDATE ANG
+    AUDIO OUTPUT
 whistle-enabled = SIPOL
     PINAGANA:
 above-water-volume = LAKAS SA

--- a/refbox/translations/tr-TR/refbox.ftl
+++ b/refbox/translations/tr-TR/refbox.ftl
@@ -110,6 +110,8 @@ sound-enabled = SES
 whistle-volume = DÜDÜK
     SESİ:
 manage-remotes = UZAKTAN KUMANDAYI YÖNETİN
+update-audio-output = SES ÇIKIŞINI
+    GÜNCELLE
 whistle-enabled = DÜDÜK
     AKTİF:
 above-water-volume = SU ÜSTÜ

--- a/refbox/translations/zh-CN/refbox.ftl
+++ b/refbox/translations/zh-CN/refbox.ftl
@@ -110,6 +110,8 @@ sound-enabled = 声音
 whistle-volume = 哨声
     音量：
 manage-remotes = 管理遥控器
+update-audio-output = 更新音频
+    输出
 whistle-enabled = 哨声
     启用：
 above-water-volume = 水上


### PR DESCRIPTION
## What changed

Adds a new **UPDATE AUDIO OUTPUT** button to the Sound Options page (just below "Whistle Volume"). Pressing it makes the refbox start playing its sounds through whatever speaker the computer currently has set as the default output — immediately, without restarting the app. The button appears on **Windows and Mac** laptops; it does **not** appear on the **Raspberry Pi**, whose speaker setup is fixed and left untouched.

## Why

The refbox chooses its audio output device once, when it starts up, and never follows a later change. So if you connect an external speaker (aux or Bluetooth) *after* the refbox is already running, its buzzers/whistles keep coming out of the laptop's built-in speakers — even though other apps (e.g. a web video) correctly switch to the external speaker. This button lets the operator point the refbox at the current default speaker on demand, with no restart. Targeted for the v0.4.4 release.

## Scope

Changes are limited to the `refbox` crate:
- `src/sound_controller/` — the sound worker now rebuilds its audio connection on request, which re-grabs the OS's current default output device.
- `src/app/message.rs` and `src/app/mod.rs` — the new button action and its handler.
- `src/app/view_builders/configuration.rs` — the button on the Sound page (Windows/Mac only; an empty spacer on the Pi).
- `translations/*/refbox.ftl` — one new label, added to all 15 languages.

No changes to shared types (`uwh-common`), the LED panel/overlay, the wireless remote, or any dependency.

## How to verify

On a **Windows (or Mac) laptop** — this cannot be tested on the Pi or the Linux dev machine, where the button is intentionally absent:

1. Start the refbox with sound playing through the built-in speakers.
2. Connect an external speaker (aux or Bluetooth) and set it as the Windows **default output** device (taskbar speaker icon).
3. On the Sound Options page, confirm **UPDATE AUDIO OUTPUT** appears just below "Whistle Volume", and press it.
4. Trigger a buzzer or whistle → it should now play through the **external** speaker, with no restart.
5. Optional: while a *held* manual alarm is sounding, press the button — the alarm resumes on the new speaker (by design), it does not go silent.

On the **Pi** build, confirm the button is **absent** and the Sound page is otherwise unchanged.

Automated checks: 333 tests pass and clippy is clean. The audio device-switch itself has no automated test — it needs a real speaker and is switched off on Linux/CI — which is why the manual laptop check above is required before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
