### PR TITLE
feat(refbox): restore portal link across restart

### DIFF
--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -171,6 +171,11 @@ pub struct RefBoxApp {
     /// One-shot: the game number to re-select once the schedule arrives during
     /// a startup link restore; cleared on first use. `None` in normal operation.
     pending_restore_game: Option<GameNumber>,
+    /// One-shot: the event whose schedule to fetch once the event list lands
+    /// during a startup link restore. Deferred (rather than fetched at startup)
+    /// so the schedule arrives after `self.events` is populated — `RecvSchedule`
+    /// requires the event to be present there. Cleared on first use.
+    pending_restore_schedule: Option<EventId>,
     sound: SoundController,
     sim_children: Vec<Child>,
     sim_spawn_config: crate::SimSpawnConfig,
@@ -1601,6 +1606,7 @@ impl RefBoxApp {
             current_event_id: None,
             current_court: None,
             pending_restore_game: None,
+            pending_restore_schedule: None,
             sound,
             sim_children,
             sim_spawn_config,
@@ -1629,7 +1635,6 @@ impl RefBoxApp {
         // or a short shutdown comes back recognized instead of dormant. A stale or
         // cross-portal note is ignored — and a stale one deleted — so a fresh power-on
         // weeks later for a new event starts clean. See ADR 011/017 amendment.
-        let mut restore_schedule_for: Option<EventId> = None;
         match crate::portal_manager::link_session::load_or_none(&new.config_dir) {
             Ok(Some(note)) => {
                 if decide_restore(&note, time::OffsetDateTime::now_utc(), new.config.mode) {
@@ -1643,7 +1648,10 @@ impl RefBoxApp {
                     new.current_court = note.court.clone();
                     new.pending_restore_game = note.game_number.clone();
                     new.set_current_event_id(Some(note.event_id.clone()));
-                    restore_schedule_for = Some(note.event_id);
+                    // Defer the schedule fetch to RecvEventList (after the event
+                    // list populates self.events) so it can't race ahead of the
+                    // event list and silently skip the game re-selection.
+                    new.pending_restore_schedule = Some(note.event_id);
                 } else {
                     info!("Portal link note present but stale/cross-portal; starting dormant");
                     let _ = crate::portal_manager::link_session::delete(&new.config_dir);
@@ -1664,11 +1672,6 @@ impl RefBoxApp {
         }];
         if new.using_uwhportal {
             startup_tasks.push(new.request_event_list());
-        }
-        // On a restored link, also fetch the schedule so the remembered game can
-        // be re-selected and its scheduled-start countdown re-established (Task 4).
-        if let Some(event_id) = restore_schedule_for {
-            startup_tasks.push(new.request_schedule(event_id));
         }
         // Arm a one-shot ~20s timer. If the app is still running when it fires,
         // startup was healthy and the update trial marker can be cleared so a
@@ -3676,6 +3679,23 @@ impl RefBoxApp {
                     tasks.push(self.request_teams_list(event.id.clone()));
                 }
                 self.events = Some(e_map);
+                // Startup link restore: now that the event list is populated,
+                // fetch the schedule for the restored event so RecvSchedule can
+                // re-select the remembered game and start its scheduled countdown.
+                if let Some(event_id) = self.pending_restore_schedule.take() {
+                    let in_list = self
+                        .events
+                        .as_ref()
+                        .is_some_and(|m| m.contains_key(&event_id));
+                    if in_list {
+                        tasks.push(self.request_schedule(event_id));
+                    } else {
+                        warn!(
+                            "Restore event {} not in fetched event list; not re-linking schedule",
+                            event_id.full()
+                        );
+                    }
+                }
                 Task::batch(tasks)
             }
             Message::RecvTeamsList(event_id, teams) => {

--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -168,6 +168,9 @@ pub struct RefBoxApp {
     schedule: Option<Schedule>,
     current_event_id: Option<EventId>,
     current_court: Option<String>,
+    /// One-shot: the game number to re-select once the schedule arrives during
+    /// a startup link restore; cleared on first use. `None` in normal operation.
+    pending_restore_game: Option<GameNumber>,
     sound: SoundController,
     sim_children: Vec<Child>,
     sim_spawn_config: crate::SimSpawnConfig,
@@ -1574,7 +1577,7 @@ impl RefBoxApp {
             default_app_state.clone()
         };
 
-        let new = Self {
+        let mut new = Self {
             pen_edit: ListEditor::new(tm.clone()),
             warn_edit: ListEditor::new(tm.clone()),
             foul_edit: ListEditor::new(tm.clone()),
@@ -1597,6 +1600,7 @@ impl RefBoxApp {
             schedule: None,
             current_event_id: None,
             current_court: None,
+            pending_restore_game: None,
             sound,
             sim_children,
             sim_spawn_config,
@@ -1621,8 +1625,37 @@ impl RefBoxApp {
             scramble_token_pending,
         };
 
+        // Restore a recent portal link so a relaunch (language change, self-update)
+        // or a short shutdown comes back recognized instead of dormant. A stale or
+        // cross-portal note is ignored — and a stale one deleted — so a fresh power-on
+        // weeks later for a new event starts clean. See ADR 011/017 amendment.
+        let mut restore_schedule_for: Option<EventId> = None;
+        match crate::portal_manager::link_session::load_or_none(&new.config_dir) {
+            Ok(Some(note)) => {
+                if decide_restore(&note, time::OffsetDateTime::now_utc(), new.config.mode) {
+                    info!(
+                        "Restoring portal link to {} (court {:?}, game {:?})",
+                        note.event_id.full(),
+                        note.court,
+                        note.game_number
+                    );
+                    new.using_uwhportal = true;
+                    new.current_court = note.court.clone();
+                    new.pending_restore_game = note.game_number.clone();
+                    new.set_current_event_id(Some(note.event_id.clone()));
+                    restore_schedule_for = Some(note.event_id);
+                } else {
+                    info!("Portal link note present but stale/cross-portal; starting dormant");
+                    let _ = crate::portal_manager::link_session::delete(&new.config_dir);
+                }
+            }
+            Ok(None) => {}
+            Err(e) => error!("Failed to read portal_link.json: {e}"),
+        }
+
         // Portal subsystem stays dormant until the operator turns Using-UWH-Portal
-        // ON: no event-list fetch fires at startup unless the runtime flag is true.
+        // ON (or a recent link was restored above): no event-list fetch fires at
+        // startup unless the runtime flag is true.
         // See ADR 017 (Portal Data Lifecycle) for the dormancy contract.
         let mut startup_tasks = vec![if fullscreen {
             window::get_latest().and_then(|w| window::change_mode(w, window::Mode::Fullscreen))
@@ -1631,6 +1664,11 @@ impl RefBoxApp {
         }];
         if new.using_uwhportal {
             startup_tasks.push(new.request_event_list());
+        }
+        // On a restored link, also fetch the schedule so the remembered game can
+        // be re-selected and its scheduled-start countdown re-established (Task 4).
+        if let Some(event_id) = restore_schedule_for {
+            startup_tasks.push(new.request_schedule(event_id));
         }
         // Arm a one-shot ~20s timer. If the app is still running when it fires,
         // startup was healthy and the update trial marker can be cleared so a
@@ -4831,6 +4869,59 @@ impl RefBoxApp {
             background_color: window_background(),
             text_color,
         }
+    }
+}
+
+/// Decide whether a remembered link note should be restored at startup:
+/// it must be fresh (within the freshness window) and belong to the same
+/// portal as the current mode (a UWH note is never restored into UWR).
+fn decide_restore(
+    note: &crate::portal_manager::link_session::LinkSessionFile,
+    now: time::OffsetDateTime,
+    current_mode: Mode,
+) -> bool {
+    use crate::portal_manager::link_session::{FRESHNESS_WINDOW, is_fresh};
+    is_fresh(note.last_active, now, FRESHNESS_WINDOW) && !crosses_portal(note.mode, current_mode)
+}
+
+#[cfg(test)]
+mod restore_tests {
+    use super::*;
+    use crate::portal_manager::link_session::LinkSessionFile;
+
+    fn note(last_active: time::OffsetDateTime, mode: Mode) -> LinkSessionFile {
+        LinkSessionFile {
+            version: LinkSessionFile::CURRENT_VERSION,
+            event_id: EventId::from_full("events/2113-A").unwrap(),
+            court: Some("1".into()),
+            game_number: Some("G1".into()),
+            mode,
+            last_active,
+        }
+    }
+
+    #[test]
+    fn fresh_same_portal_restores() {
+        let now = time::OffsetDateTime::now_utc();
+        let n = note(now - time::Duration::hours(20), Mode::Hockey6V6);
+        assert!(decide_restore(&n, now, Mode::Hockey6V6));
+        // 3v3 shares the UWH portal with 6v6 → still restore
+        assert!(decide_restore(&n, now, Mode::Hockey3V3));
+    }
+
+    #[test]
+    fn stale_does_not_restore() {
+        let now = time::OffsetDateTime::now_utc();
+        let n = note(now - time::Duration::hours(49), Mode::Hockey6V6);
+        assert!(!decide_restore(&n, now, Mode::Hockey6V6));
+    }
+
+    #[test]
+    fn cross_portal_does_not_restore() {
+        let now = time::OffsetDateTime::now_utc();
+        let n = note(now, Mode::Hockey6V6);
+        // Rugby uses the UWR portal → must NOT restore a UWH note
+        assert!(!decide_restore(&n, now, Mode::Rugby));
     }
 }
 

--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -3740,11 +3740,18 @@ impl RefBoxApp {
                                 if self.edited_settings.is_none() {
                                     let mut tm = self.tm.lock().unwrap();
                                     if tm.current_period() == GamePeriod::BetweenGames {
+                                        // On a startup link restore, re-select the
+                                        // remembered game; otherwise pick the default
+                                        // next game by number.
+                                        let restore_num = self.pending_restore_game.take();
+                                        let lookup_num = restore_num
+                                            .clone()
+                                            .unwrap_or_else(|| tm.next_game_number());
                                         if let (Some(game), Some(timing)) = self
                                             .schedule
                                             .as_ref()
                                             .unwrap()
-                                            .get_game_and_timing(&tm.next_game_number())
+                                            .get_game_and_timing(&lookup_num)
                                         {
                                             info!(
                                                 "Setting upcoming game info from received schedule: {game:?}"
@@ -3754,6 +3761,21 @@ impl RefBoxApp {
                                                 timing: Some(timing.clone()),
                                                 start_time: Some(game.start_time),
                                             });
+                                            if restore_num.is_some() {
+                                                // Start the live countdown to the
+                                                // scheduled start so a restored session
+                                                // is ready to go (same path the normal
+                                                // between-games transition uses).
+                                                let now = Instant::now();
+                                                // why this cannot panic: BetweenGames was
+                                                // just checked and next_game was just set.
+                                                tm.apply_next_game_start(now).unwrap();
+                                                let new_game_config = tm.config().clone();
+                                                let snapshot = tm.generate_snapshot(now).unwrap();
+                                                std::mem::drop(tm);
+                                                self.config.game = new_game_config;
+                                                return self.apply_snapshot(snapshot);
+                                            }
                                             if let AppState::GameDetailsPage(
                                                 ref mut is_refreshing,
                                             ) = self.app_state

--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -2462,6 +2462,13 @@ impl RefBoxApp {
                         self.portal_manager.on_token_status(valid);
                     }
                 }
+                // The background task fires verify_token on its cadence
+                // (~5 min when healthy). Use that heartbeat to refresh the link
+                // note's last-active timestamp (and current game number) so the
+                // 48h restore window tracks real usage, not just first link.
+                if self.using_uwhportal && self.current_event_id.is_some() {
+                    self.persist_link_session();
+                }
                 Task::none()
             }
             Message::PortalUiTick => {

--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -851,6 +851,41 @@ impl RefBoxApp {
         }
     }
 
+    /// Write or delete `portal_link.json` to reflect the current live link.
+    /// Linked (portal on + an event selected) → write a note stamped now so a
+    /// relaunch or short shutdown can re-establish the link. Not linked →
+    /// delete any existing note. Errors are logged, never fatal: a failed note
+    /// write only means a future restart won't auto-relink.
+    fn persist_link_session(&self) {
+        use crate::portal_manager::link_session::{self, LinkSessionFile};
+        if self.using_uwhportal {
+            if let Some(event_id) = self.current_event_id.clone() {
+                // The game the operator is on: the upcoming game between games,
+                // otherwise the current game number from the live snapshot.
+                let game_number = if self.snapshot.current_period == GamePeriod::BetweenGames {
+                    Some(self.snapshot.next_game_number.clone())
+                } else {
+                    Some(self.snapshot.game_number.clone())
+                };
+                let note = LinkSessionFile {
+                    version: LinkSessionFile::CURRENT_VERSION,
+                    event_id,
+                    court: self.current_court.clone(),
+                    game_number,
+                    mode: self.config.mode,
+                    last_active: time::OffsetDateTime::now_utc(),
+                };
+                if let Err(e) = link_session::save(&self.config_dir, &note) {
+                    error!("Failed to write portal_link.json: {e}");
+                }
+                return;
+            }
+        }
+        if let Err(e) = link_session::delete(&self.config_dir) {
+            error!("Failed to delete portal_link.json: {e}");
+        }
+    }
+
     fn apply_app_options(&mut self) -> Option<ConfirmationKind> {
         let edited = self.edited_settings.as_ref()?;
         // Snapshot the fields we need so the immutable borrow on
@@ -2550,6 +2585,10 @@ impl RefBoxApp {
                 }
                 self.page_entry_snapshot = None;
                 self.persist_config();
+                // Keep the link note in step with the committed portal fields
+                // (link/unlink, court, game) so a relaunch restores the right
+                // state — or deletes the note when the portal was switched off.
+                self.persist_link_session();
                 self.navigate_to_parent(page);
                 Task::none()
             }

--- a/refbox/src/portal_manager/link_session.rs
+++ b/refbox/src/portal_manager/link_session.rs
@@ -1,0 +1,223 @@
+//! On-disk persistence for the active portal link ("link session").
+//!
+//! Records which event/court/game this machine is linked to plus a
+//! "last active" timestamp, so a relaunch (language change, self-update)
+//! or a short shutdown can re-establish the link instead of starting
+//! dormant. See
+//! `docs/superpowers/specs/2026-06-22-portal-link-restore-across-restart-design.md`.
+//!
+//! Mirrors the atomic-write + tolerant-load pattern of `queue.rs`.
+
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use time::OffsetDateTime;
+use time::macros::format_description;
+
+use crate::config::Mode;
+use uwh_common::uwhportal::schedule::{EventId, GameNumber};
+
+/// How recent the last session must be to auto-restore the link on startup.
+pub const FRESHNESS_WINDOW: time::Duration = time::Duration::hours(48);
+
+const FILE_NAME: &str = "portal_link.json";
+const TMP_FILE_NAME: &str = "portal_link.json.tmp";
+
+/// The remembered live portal link, persisted next to `portal_queue.json`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LinkSessionFile {
+    pub version: u32,
+    pub event_id: EventId,
+    pub court: Option<String>,
+    pub game_number: Option<GameNumber>,
+    pub mode: Mode,
+    #[serde(with = "time::serde::rfc3339")]
+    pub last_active: OffsetDateTime,
+}
+
+impl LinkSessionFile {
+    pub const CURRENT_VERSION: u32 = 1;
+}
+
+fn file_path(dir: &Path) -> PathBuf {
+    dir.join(FILE_NAME)
+}
+
+fn tmp_path(dir: &Path) -> PathBuf {
+    dir.join(TMP_FILE_NAME)
+}
+
+/// Load the note. Missing → `None`. Present but unparseable or of an
+/// unknown version → rename to `portal_link.corrupt.<ts>.json`, log, and
+/// return `None`. Never blocks startup.
+pub fn load_or_none(dir: &Path) -> std::io::Result<Option<LinkSessionFile>> {
+    let path = file_path(dir);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let bytes = fs::read(&path)?;
+    match serde_json::from_slice::<LinkSessionFile>(&bytes) {
+        Ok(note) if note.version == LinkSessionFile::CURRENT_VERSION => Ok(Some(note)),
+        Ok(note) => {
+            log::error!(
+                "portal_link.json has unknown version {}; renaming and ignoring",
+                note.version
+            );
+            rename_corrupt(&path)?;
+            Ok(None)
+        }
+        Err(e) => {
+            log::error!("portal_link.json failed to parse ({e}); renaming and ignoring");
+            rename_corrupt(&path)?;
+            Ok(None)
+        }
+    }
+}
+
+fn rename_corrupt(path: &Path) -> std::io::Result<()> {
+    // Format: YYYYMMDDTHHMMSSZ, e.g. "20260622T142203Z".
+    let fmt = format_description!("[year][month][day]T[hour][minute][second]Z");
+    let ts = OffsetDateTime::now_utc()
+        .format(&fmt)
+        .unwrap_or_else(|_| "unknown-time".to_string());
+    let mut new_path = path.to_path_buf();
+    new_path.set_file_name(format!("portal_link.corrupt.{ts}.json"));
+    fs::rename(path, &new_path)
+}
+
+/// Atomically write the note: temp file → fsync → rename over target.
+pub fn save(dir: &Path, note: &LinkSessionFile) -> std::io::Result<()> {
+    let tmp = tmp_path(dir);
+    {
+        let mut f = fs::File::create(&tmp)?;
+        serde_json::to_writer(&f, note).map_err(std::io::Error::other)?;
+        f.flush()?;
+        f.sync_all()?;
+    }
+    fs::rename(&tmp, file_path(dir))?;
+    Ok(())
+}
+
+/// Remove the note. A missing file is treated as success.
+pub fn delete(dir: &Path) -> std::io::Result<()> {
+    match fs::remove_file(file_path(dir)) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
+/// True iff `now` is within `window` of `last_active` (and not before it).
+/// A `now` earlier than `last_active` (clock moved backwards) is not fresh.
+pub fn is_fresh(last_active: OffsetDateTime, now: OffsetDateTime, window: time::Duration) -> bool {
+    now >= last_active && (now - last_active) <= window
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+    use time::macros::datetime;
+
+    fn sample(now: OffsetDateTime) -> LinkSessionFile {
+        LinkSessionFile {
+            version: LinkSessionFile::CURRENT_VERSION,
+            event_id: EventId::from_full("events/2113-A").unwrap(),
+            court: Some("1".to_string()),
+            game_number: Some("G27".to_string()),
+            mode: Mode::Hockey6V6,
+            last_active: now,
+        }
+    }
+
+    #[test]
+    fn round_trips_via_serde() {
+        let note = sample(datetime!(2026-06-22 14:22:03 UTC));
+        let s = serde_json::to_string(&note).unwrap();
+        let back: LinkSessionFile = serde_json::from_str(&s).unwrap();
+        assert_eq!(note, back);
+    }
+
+    #[test]
+    fn load_none_when_file_missing() {
+        let tmp = TempDir::new().unwrap();
+        assert!(load_or_none(tmp.path()).unwrap().is_none());
+    }
+
+    #[test]
+    fn save_then_load_round_trip() {
+        let tmp = TempDir::new().unwrap();
+        let note = sample(OffsetDateTime::now_utc());
+        save(tmp.path(), &note).unwrap();
+        assert_eq!(load_or_none(tmp.path()).unwrap(), Some(note));
+    }
+
+    #[test]
+    fn delete_removes_file_and_is_ok_when_missing() {
+        let tmp = TempDir::new().unwrap();
+        save(tmp.path(), &sample(OffsetDateTime::now_utc())).unwrap();
+        delete(tmp.path()).unwrap();
+        assert!(load_or_none(tmp.path()).unwrap().is_none());
+        // second delete on an already-absent file is still Ok
+        delete(tmp.path()).unwrap();
+    }
+
+    #[test]
+    fn corrupt_file_is_renamed_and_none_returned() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("portal_link.json");
+        std::fs::write(&path, b"not json").unwrap();
+        assert!(load_or_none(tmp.path()).unwrap().is_none());
+        assert!(!path.exists());
+        let renamed = std::fs::read_dir(tmp.path()).unwrap().any(|e| {
+            e.unwrap()
+                .file_name()
+                .to_string_lossy()
+                .starts_with("portal_link.corrupt")
+        });
+        assert!(renamed, "expected a corrupt backup file");
+    }
+
+    #[test]
+    fn unknown_version_is_renamed_and_none_returned() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("portal_link.json");
+        let mut note = sample(OffsetDateTime::now_utc());
+        note.version = 999;
+        std::fs::write(&path, serde_json::to_string(&note).unwrap()).unwrap();
+        assert!(load_or_none(tmp.path()).unwrap().is_none());
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn atomic_write_leaves_no_tmp_file() {
+        let tmp = TempDir::new().unwrap();
+        save(tmp.path(), &sample(OffsetDateTime::now_utc())).unwrap();
+        assert!(tmp.path().join("portal_link.json").exists());
+        assert!(!tmp.path().join("portal_link.json.tmp").exists());
+    }
+
+    #[test]
+    fn is_fresh_boundaries() {
+        let t0 = datetime!(2026-06-22 08:00:00 UTC);
+        assert!(is_fresh(t0, t0, FRESHNESS_WINDOW)); // 0h
+        assert!(is_fresh(
+            t0,
+            t0 + time::Duration::hours(47),
+            FRESHNESS_WINDOW
+        ));
+        assert!(is_fresh(t0, t0 + FRESHNESS_WINDOW, FRESHNESS_WINDOW)); // exactly 48h
+        assert!(!is_fresh(
+            t0,
+            t0 + time::Duration::hours(48) + time::Duration::seconds(1),
+            FRESHNESS_WINDOW
+        ));
+        // clock skew: "now" before last_active is treated as not fresh
+        assert!(!is_fresh(
+            t0,
+            t0 - time::Duration::hours(1),
+            FRESHNESS_WINDOW
+        ));
+    }
+}

--- a/refbox/src/portal_manager/mod.rs
+++ b/refbox/src/portal_manager/mod.rs
@@ -5,6 +5,7 @@
 //! and `docs/decisions/011-portal-health-indicator.md`.
 
 pub mod health;
+pub mod link_session;
 pub mod queue;
 
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
## What changed

The refbox now **remembers its live UWH Portal link** — which event, court, and game it's on — and automatically re-establishes it when the program relaunches.

Previously, changing the on-screen language between two different alphabets (e.g. Korean ↔ English) forces a full relaunch (the font can only be chosen at startup), and that relaunch dropped the live link: the operator was sent back through linking and could be re-prompted for a token, even though the saved token was still valid.

After this change, on startup the refbox reads a small `portal_link.json` note (kept next to the existing `portal_queue.json`). If the note is **less than 48 hours old** and for the **same sport's portal**, it re-links to that event/court/game and re-arms the live countdown to the game's scheduled start — with no token re-prompt. If the note is older than 48 hours (a new event weeks later) or for a different sport, it's ignored and the machine starts clean, so it never fixates on a finished event. The token itself is handled exactly as before. A live, in-progress game (running clock/scores) is intentionally **not** carried across a relaunch — this restores your *place in the schedule*, ready to start.

This also benefits the overnight-shutdown (within 48h) and self-update cases, not just language changes.

## Why

At a tournament, switching the display language — or an overnight power-cycle within the 48-hour window — shouldn't make the machine forget it's linked and demand a re-link / re-entered token. This keeps the machine "recognized" across those restarts while still starting clean for a genuinely new event later.

## Scope

Changes are limited to the `refbox` crate:
- `refbox/src/portal_manager/link_session.rs` (new) — the `portal_link.json` read/write/delete + freshness module, mirroring the atomic-write + tolerant-load pattern of `queue.rs`.
- `refbox/src/portal_manager/mod.rs` — one line to register the module.
- `refbox/src/app/mod.rs` — write/clear the note on link/unlink (and refresh it on the portal heartbeat); restore the link at startup behind a freshness + same-portal gate; re-select the remembered game and start its scheduled countdown when the schedule arrives.

No changes to `uwh-common`, the wire format, the wireless remote, the LED panel, or the overlay.

## How to verify

**Automated:** `just check` is green — formatting, linter, 345 tests (including 11 new ones for this feature: file read/write/corrupt-handling, the 48-hour freshness boundary, and the restore decision), and the security audit.

**Manual (done, against a real portal event):** linked to a live event with a court and game selected, then switched language Korean ↔ English several times. Every relaunch came back **already linked** to the same event and game, with the live countdown to the scheduled start showing and the portal indicator green — **no token re-prompt**. Confirmed in the logs each time:
```
Restoring portal link to events/2305-A (court Some("1"), game Some("1"))
  → Got event list → Got schedule → Setting between games time from uwhportal info
```
A cold start with no note begins dormant exactly as before (no regression to normal startup).

**Reviewer notes:**
- A brief (~2–3 s) default 15:00 break shows on relaunch before the scheduled countdown appears, while the event list + schedule are re-fetched from the portal — the same transient as a normal link; left as-is by design.
- This relaxes the "dormant-until-linked at startup" default (ADR 011 amendment 2026-04-23 / ADR 017) **only** for a fresh (≤ 48 h), same-portal note; a stale, absent, or cross-portal note preserves the dormant cold-start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
