### PR TITLE
fix(refbox): rename audio button to REFRESH OUTPUT (single line, centered)

### DIFF
--- a/refbox/translations/de-DE/refbox.ftl
+++ b/refbox/translations/de-DE/refbox.ftl
@@ -110,8 +110,7 @@ sound-enabled = TON
 whistle-volume = PFEIFEN-
     LAUTSTÄRKE:
 manage-remotes = FERNBEDIENUNGEN VERWALTEN
-update-audio-output = AUDIOAUSGANG
-    AKTUALISIEREN
+update-audio-output = AUSGANG AKTUALISIEREN
 whistle-enabled = PFEIFE
     AKTIVIERT:
 above-water-volume = LAUTSTÄRKE

--- a/refbox/translations/en-US/refbox.ftl
+++ b/refbox/translations/en-US/refbox.ftl
@@ -109,8 +109,7 @@ sound-enabled = SOUND
 whistle-volume = WHISTLE
     VOLUME:
 manage-remotes = MANAGE REMOTES
-update-audio-output = UPDATE AUDIO
-    OUTPUT
+update-audio-output = REFRESH OUTPUT
 whistle-enabled = WHISTLE 
     ENABLED:
 above-water-volume = ABOVE WATER

--- a/refbox/translations/es/refbox.ftl
+++ b/refbox/translations/es/refbox.ftl
@@ -110,8 +110,7 @@ sound-enabled = SONIDO
 whistle-volume = VOLUMEN
     DEL SILBATO:
 manage-remotes = GESTIONAR REMOTOS
-update-audio-output = ACTUALIZAR
-    SALIDA DE AUDIO
+update-audio-output = ACTUALIZAR SALIDA
 whistle-enabled = SILBATO
     HABILITADO:
 above-water-volume = VOLUMEN

--- a/refbox/translations/fr/refbox.ftl
+++ b/refbox/translations/fr/refbox.ftl
@@ -108,8 +108,7 @@ sound-enabled = SON
 whistle-volume = VOLUME DU
     SIFFLET:
 manage-remotes = GÉRER LES TÉLÉCOMMANDES
-update-audio-output = ACTUALISER
-    SORTIE AUDIO
+update-audio-output = ACTUALISER SORTIE
 whistle-enabled = SIFFLET
     ACTIVÉ:
 above-water-volume = VOLUME

--- a/refbox/translations/id-ID/refbox.ftl
+++ b/refbox/translations/id-ID/refbox.ftl
@@ -110,8 +110,7 @@ sound-enabled = SUARA
 whistle-volume = VOLUME
     PELUIT:
 manage-remotes = KELOLA REMOTE
-update-audio-output = PERBARUI
-    OUTPUT AUDIO
+update-audio-output = PERBARUI OUTPUT
 whistle-enabled = PELUIT
     DIAKTIFKAN:
 above-water-volume = VOLUME

--- a/refbox/translations/it-IT/refbox.ftl
+++ b/refbox/translations/it-IT/refbox.ftl
@@ -110,8 +110,7 @@ sound-enabled = AUDIO
 whistle-volume = VOLUME
     FISCHIO:
 manage-remotes = GESTISCI TELECOMANDI
-update-audio-output = AGGIORNA
-    USCITA AUDIO
+update-audio-output = AGGIORNA USCITA
 whistle-enabled = FISCHIO
     ATTIVATO:
 above-water-volume = VOLUME

--- a/refbox/translations/ja-JP/refbox.ftl
+++ b/refbox/translations/ja-JP/refbox.ftl
@@ -110,8 +110,7 @@ sound-enabled = サウンド
 whistle-volume = 笛
     音量:
 manage-remotes = リモコン管理
-update-audio-output = オーディオ出力を
-    更新
+update-audio-output = 出力を更新
 whistle-enabled = 笛
     有効:
 above-water-volume = 水上

--- a/refbox/translations/ko-KR/refbox.ftl
+++ b/refbox/translations/ko-KR/refbox.ftl
@@ -112,8 +112,7 @@ sound-enabled = 소리
 whistle-volume = 호루라기
     음량:
 manage-remotes = 리모컨 관리
-update-audio-output = 오디오 출력
-    업데이트
+update-audio-output = 출력 새로고침
 whistle-enabled = 호루라기
     사용:
 above-water-volume = 수상

--- a/refbox/translations/ms-MY/refbox.ftl
+++ b/refbox/translations/ms-MY/refbox.ftl
@@ -110,8 +110,7 @@ sound-enabled = BUNYI
 whistle-volume = KELANTANGAN
     WISEL:
 manage-remotes = URUS KAWALAN JAUH
-update-audio-output = KEMAS KINI
-    OUTPUT AUDIO
+update-audio-output = SEGARKAN OUTPUT
 whistle-enabled = WISEL
     DIAKTIFKAN:
 above-water-volume = KELANTANGAN

--- a/refbox/translations/nl-NL/refbox.ftl
+++ b/refbox/translations/nl-NL/refbox.ftl
@@ -110,8 +110,7 @@ sound-enabled = GELUID
 whistle-volume = FLUIT-
     VOLUME:
 manage-remotes = AFSTANDSBEDIENINGEN BEHEREN
-update-audio-output = AUDIO-UITVOER
-    BIJWERKEN
+update-audio-output = UITVOER VERNIEUWEN
 whistle-enabled = FLUIT
     INGESCHAKELD:
 above-water-volume = VOLUME

--- a/refbox/translations/pt-PT/refbox.ftl
+++ b/refbox/translations/pt-PT/refbox.ftl
@@ -110,8 +110,7 @@ sound-enabled = SOM
 whistle-volume = VOLUME DO
     APITO:
 manage-remotes = GERIR CONTROLOS REMOTOS
-update-audio-output = ATUALIZAR
-    SAÍDA DE ÁUDIO
+update-audio-output = ATUALIZAR SAÍDA
 whistle-enabled = APITO
     ATIVADO:
 above-water-volume = VOLUME

--- a/refbox/translations/th-TH/refbox.ftl
+++ b/refbox/translations/th-TH/refbox.ftl
@@ -110,8 +110,7 @@ sound-enabled = เปิดใช้
 whistle-volume = ระดับเสียง
     นกหวีด:
 manage-remotes = จัดการรีโมต
-update-audio-output = อัปเดต
-    เอาต์พุตเสียง
+update-audio-output = รีเฟรชเอาต์พุต
 whistle-enabled = เปิดใช้
     นกหวีด:
 above-water-volume = ระดับเสียง

--- a/refbox/translations/tl-PH/refbox.ftl
+++ b/refbox/translations/tl-PH/refbox.ftl
@@ -110,8 +110,7 @@ sound-enabled = TUNOG
 whistle-volume = LAKAS NG
     SIPOL:
 manage-remotes = PAMAHALAAN ANG MGA REMOTE
-update-audio-output = I-UPDATE ANG
-    AUDIO OUTPUT
+update-audio-output = I-REFRESH OUTPUT
 whistle-enabled = SIPOL
     PINAGANA:
 above-water-volume = LAKAS SA

--- a/refbox/translations/tr-TR/refbox.ftl
+++ b/refbox/translations/tr-TR/refbox.ftl
@@ -110,8 +110,7 @@ sound-enabled = SES
 whistle-volume = DÜDÜK
     SESİ:
 manage-remotes = UZAKTAN KUMANDAYI YÖNETİN
-update-audio-output = SES ÇIKIŞINI
-    GÜNCELLE
+update-audio-output = ÇIKIŞI YENİLE
 whistle-enabled = DÜDÜK
     AKTİF:
 above-water-volume = SU ÜSTÜ

--- a/refbox/translations/zh-CN/refbox.ftl
+++ b/refbox/translations/zh-CN/refbox.ftl
@@ -110,8 +110,7 @@ sound-enabled = 声音
 whistle-volume = 哨声
     音量：
 manage-remotes = 管理遥控器
-update-audio-output = 更新音频
-    输出
+update-audio-output = 刷新输出
 whistle-enabled = 哨声
     启用：
 above-water-volume = 水上


### PR DESCRIPTION
## What changed

Renames the Sound-page audio button label from **UPDATE AUDIO OUTPUT** to **REFRESH OUTPUT**, in all 15 languages. The shorter label fits on a single line, so it now sits **centered** in the button (the old two-line "UPDATE AUDIO / OUTPUT" left-aligned its second line).

## Why

Cleaner, clearer wording, and a centered label that matches the look of the other Sound-page buttons.

## Scope

Translation value only — the 15 `refbox/translations/*/refbox.ftl` files. No behavior change and no code logic change: the button still re-adopts the operating system's current default output device. The internal key (`update-audio-output`) and Rust identifiers are unchanged.

## How to verify

On a Windows/Mac build, the Sound-page button reads **REFRESH OUTPUT**, centered, and pressing it behaves exactly as before (re-adopts the current default speaker). Absent on the Pi, as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
