### PR TITLE
feat(refbox): add RETRY ALL button for bulk portal resend

### DIFF
--- a/refbox/src/app/message.rs
+++ b/refbox/src/app/message.rs
@@ -107,6 +107,12 @@ pub enum Message {
     /// re-login returns the operator to the portal detail page.
     PortalGoToLogin,
     RequestPortalRefresh,
+    /// Emitted when the operator taps RETRY ALL on the portal detail
+    /// page. `update()` calls `PortalManager::retry_all`, which resets
+    /// every queued game (including stuck ones) so the background task
+    /// re-attempts them all on its next tick. A plain resend — never a
+    /// force-overwrite.
+    PortalRetryAll,
     ShowWarnings,
     ShowParameterHelp,
     CloseParameterHelp,
@@ -325,6 +331,7 @@ impl Message {
             | Self::PortalDiscardTapped(_)
             | Self::PortalGoToLogin
             | Self::RequestPortalRefresh
+            | Self::PortalRetryAll
             | Self::ShowWarnings
             | Self::ShowParameterHelp
             | Self::CloseParameterHelp
@@ -421,6 +428,7 @@ impl PartialEq for Message {
             | (Self::PortalUiTick, Self::PortalUiTick)
             | (Self::PortalGoToLogin, Self::PortalGoToLogin)
             | (Self::RequestPortalRefresh, Self::RequestPortalRefresh)
+            | (Self::PortalRetryAll, Self::PortalRetryAll)
             | (Self::ShowWarnings, Self::ShowWarnings)
             | (Self::ShowParameterHelp, Self::ShowParameterHelp)
             | (Self::CloseParameterHelp, Self::CloseParameterHelp)
@@ -647,6 +655,7 @@ impl PartialEq for Message {
             | (Self::PortalDiscardTapped(_), _)
             | (Self::PortalGoToLogin, _)
             | (Self::RequestPortalRefresh, _)
+            | (Self::PortalRetryAll, _)
             | (Self::ShowWarnings, _)
             | (Self::ShowParameterHelp, _)
             | (Self::CloseParameterHelp, _)

--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -2661,6 +2661,12 @@ impl RefBoxApp {
                 trace!("AppState changed to {:?}", self.app_state);
                 Task::none()
             }
+            Message::PortalRetryAll => {
+                if let Err(e) = self.portal_manager.retry_all() {
+                    error!("retry_all failed: {e}");
+                }
+                Task::none()
+            }
             Message::PortalDiscardTapped(id) => {
                 // Snapshot the current attention-page state before any
                 // mutation so we don't fight the borrow checker when

--- a/refbox/src/app/view_builders/portal_detail.rs
+++ b/refbox/src/app/view_builders/portal_detail.rs
@@ -46,6 +46,13 @@ pub(in super::super) fn build_portal_detail_page<'a>(
 
     let num_items = rows.len();
 
+    // RETRY ALL is actionable only when there is at least one unsent
+    // game (a stuck/red or pending/yellow row). Recent-success and
+    // token-expired rows don't count.
+    let has_unsent = rows
+        .iter()
+        .any(|r| matches!(r, DetailRow::Stuck { .. } | DetailRow::Pending { .. }));
+
     let row_buttons: CollectArrayResult<_, PORTAL_DETAIL_LIST_LEN> = rows
         .into_iter()
         .skip(scroll_index)
@@ -77,6 +84,12 @@ pub(in super::super) fn build_portal_detail_page<'a>(
         .on_press(Message::ClosePortalDetailPage)
         .style(red_button);
 
+    // Blue safe-action button, anchored bottom-right opposite BACK.
+    // Grayed (no on_press) when there is nothing unsent to retry.
+    let retry_all = make_button(fl!("portal-retry-all"))
+        .on_press_maybe(has_unsent.then_some(Message::PortalRetryAll))
+        .style(blue_button);
+
     column![
         make_game_time_button(
             snapshot,
@@ -88,7 +101,7 @@ pub(in super::super) fn build_portal_detail_page<'a>(
             None,
         ),
         list,
-        row![back, horizontal_space(), horizontal_space(),]
+        row![back, horizontal_space(), retry_all,]
             .spacing(SPACING)
             .width(Length::Fill),
     ]

--- a/refbox/src/portal_manager/mod.rs
+++ b/refbox/src/portal_manager/mod.rs
@@ -544,8 +544,9 @@ impl PortalManager {
     /// `force` is deliberately left untouched: RETRY ALL is a plain
     /// resend, never an overwrite. A game the portal genuinely rejects
     /// (a conflict) simply re-fails and re-surfaces as stuck for the
-    /// operator to Force or Discard individually. See the design doc
-    /// (2026-06-25-retry-all-portal-queue) and ADR 011.
+    /// operator to Force or Discard individually. See ADR 011
+    /// (portal-health-indicator) for why a failed submit cannot be told
+    /// apart from a conflict.
     ///
     /// No-op-safe on an empty queue. Persistence is best-effort, matching
     /// `token_refreshed`/`force_submit`: the in-memory reset stands even

--- a/refbox/src/portal_manager/mod.rs
+++ b/refbox/src/portal_manager/mod.rs
@@ -535,6 +535,34 @@ impl PortalManager {
         Ok(())
     }
 
+    /// Operator tapped RETRY ALL on the portal detail page. Resets every
+    /// queued game so the background task re-attempts all of them on its
+    /// next tick: clears each item's attempt counter and last-attempt
+    /// timestamp, and resets `queued_at` to now so any item past the
+    /// 30-minute stuck threshold returns to the auto-retry pool.
+    ///
+    /// `force` is deliberately left untouched: RETRY ALL is a plain
+    /// resend, never an overwrite. A game the portal genuinely rejects
+    /// (a conflict) simply re-fails and re-surfaces as stuck for the
+    /// operator to Force or Discard individually. See the design doc
+    /// (2026-06-25-retry-all-portal-queue) and ADR 011.
+    ///
+    /// No-op-safe on an empty queue. Persistence is best-effort, matching
+    /// `token_refreshed`/`force_submit`: the in-memory reset stands even
+    /// if the disk write fails (the error propagates for logging).
+    pub fn retry_all(&mut self) -> std::io::Result<()> {
+        let now = OffsetDateTime::now_utc();
+        for item in &mut self.queue.items {
+            item.attempts = 0;
+            item.last_attempt_at = None;
+            item.queued_at = now;
+        }
+        queue::save(&self.config_dir, &self.queue)?;
+        self.recompute_indicator();
+        self.push_queue_snapshot();
+        Ok(())
+    }
+
     /// Operator tapped a young (yellow) pending row on the detail page.
     /// Clears `last_attempt_at` on the target item AND pushes a fresh
     /// queue snapshot to the background task, so the task sees the
@@ -812,6 +840,45 @@ mod tests {
         assert!(m.queue.items[0].force);
         assert_eq!(m.queue.items[0].attempts, 0);
         assert!(m.queue.items[0].last_attempt_at.is_none());
+    }
+
+    #[tokio::test]
+    async fn retry_all_unsticks_and_resets_every_item_without_forcing() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (mut m, _rx) = PortalManager::new(tmp.path(), NullIo).unwrap();
+
+        // One stuck game (queued 31 min ago) and one young pending game.
+        m.enqueue_game_end("event".into(), "G_STUCK".into(), 0, 0, "{}".into())
+            .unwrap();
+        m.enqueue_game_end("event".into(), "G_YOUNG".into(), 1, 0, "{}".into())
+            .unwrap();
+
+        // Age the first past the 30-min stuck threshold and give both
+        // some prior attempt history.
+        let old = OffsetDateTime::now_utc() - TimeDuration::minutes(31);
+        m.queue.items[0].queued_at = old;
+        m.queue.items[0].attempts = 5;
+        m.queue.items[0].last_attempt_at = Some(old);
+        m.queue.items[1].attempts = 2;
+        m.queue.items[1].last_attempt_at = Some(OffsetDateTime::now_utc());
+
+        // Precondition: the first item is currently stuck.
+        assert!(is_item_stuck(&m.queue.items[0], OffsetDateTime::now_utc()));
+
+        m.retry_all().unwrap();
+
+        let now = OffsetDateTime::now_utc();
+        for item in &m.queue.items {
+            // Reset to a fresh, immediately-retriable state...
+            assert_eq!(item.attempts, 0);
+            assert!(item.last_attempt_at.is_none());
+            // ...and no longer stuck (queued_at moved to ~now), which
+            // together with last_attempt_at == None means the background
+            // task will pick it up on its next tick.
+            assert!(!is_item_stuck(item, now));
+            // Safe resend: force must never be set by retry_all.
+            assert!(!item.force);
+        }
     }
 
     #[tokio::test]

--- a/refbox/translations/de-DE/refbox.ftl
+++ b/refbox/translations/de-DE/refbox.ftl
@@ -419,6 +419,7 @@ false-start = Fehlstart
 
 # Portal Health Indicator
 portal-summary-title = { $portal } PORTAL STATUS
+portal-retry-all = ALLE WIEDERHOLEN
 portal-row-token-expired = Portal-Anmeldung abgelaufen — zum erneuten Anmelden tippen
 portal-row-stuck = Spiel { $game } Übermittlungsfehler, zum Beheben tippen
 portal-row-pending = Spiel { $game } Spielstand nicht gesendet, zum erneuten Versuch tippen

--- a/refbox/translations/en-US/refbox.ftl
+++ b/refbox/translations/en-US/refbox.ftl
@@ -455,6 +455,7 @@ false-start = False Start
 
 # Portal Health Indicator
 portal-summary-title = { $portal } PORTAL STATUS
+portal-retry-all = RETRY ALL
 portal-row-token-expired = Portal login expired — tap to re-login
 portal-row-stuck = Game { $game } Score send error, tap to fix
 portal-row-pending = Game { $game } Score not sent, tap to retry

--- a/refbox/translations/es/refbox.ftl
+++ b/refbox/translations/es/refbox.ftl
@@ -430,6 +430,7 @@ false-start = Saque nulo
 
 # Portal Health Indicator
 portal-summary-title = ESTADO DE { $portal } PORTAL
+portal-retry-all = REINTENTAR TODO
 portal-row-token-expired = Sesión del portal expirada — toca para iniciar sesión
 portal-row-stuck = Juego { $game } · Error al enviar resultado, toca para corregir
 portal-row-pending = Juego { $game } · Resultado no enviado, toca para reintentar

--- a/refbox/translations/fr/refbox.ftl
+++ b/refbox/translations/fr/refbox.ftl
@@ -421,6 +421,7 @@ false-start = Faux départs
 
 # Portal Health Indicator
 portal-summary-title = STATUT { $portal } PORTAL
+portal-retry-all = TOUT RÉESSAYER
 portal-row-token-expired = Session du portail expirée — touchez pour vous reconnecter
 portal-row-stuck = Match { $game } · Erreur d'envoi du résultat, touchez pour corriger
 portal-row-pending = Match { $game } · Résultat non envoyé, touchez pour réessayer

--- a/refbox/translations/id-ID/refbox.ftl
+++ b/refbox/translations/id-ID/refbox.ftl
@@ -419,6 +419,7 @@ false-start = Start Curang
 
 # Portal Health Indicator
 portal-summary-title = STATUS { $portal } PORTAL
+portal-retry-all = ULANGI SEMUA
 portal-row-token-expired = Login Portal kedaluwarsa — ketuk untuk login ulang
 portal-row-stuck = Pertandingan { $game } Galat kirim skor, ketuk untuk perbaiki
 portal-row-pending = Pertandingan { $game } Skor belum terkirim, ketuk untuk coba lagi

--- a/refbox/translations/it-IT/refbox.ftl
+++ b/refbox/translations/it-IT/refbox.ftl
@@ -419,6 +419,7 @@ false-start = Falsa Partenza
 
 # Portal Health Indicator
 portal-summary-title = STATO PORTALE { $portal }
+portal-retry-all = RIPROVA TUTTO
 portal-row-token-expired = Sessione Portale scaduta — tocca per accedere di nuovo
 portal-row-stuck = Partita { $game } Errore invio punteggio, tocca per correggere
 portal-row-pending = Partita { $game } Punteggio non inviato, tocca per riprovare

--- a/refbox/translations/ja-JP/refbox.ftl
+++ b/refbox/translations/ja-JP/refbox.ftl
@@ -419,6 +419,7 @@ false-start = 不正スタート
 
 # Portal Health Indicator
 portal-summary-title = { $portal } PORTAL 状態
+portal-retry-all = すべて再試行
 portal-row-token-expired = ポータルのログインが期限切れです — タップして再ログイン
 portal-row-stuck = 試合 { $game } のスコア送信エラー、タップして修正
 portal-row-pending = 試合 { $game } のスコアが未送信、タップして再試行

--- a/refbox/translations/ko-KR/refbox.ftl
+++ b/refbox/translations/ko-KR/refbox.ftl
@@ -421,6 +421,7 @@ false-start = 부정 출발
 
 # Portal Health Indicator
 portal-summary-title = { $portal } PORTAL 상태
+portal-retry-all = 모두 재시도
 portal-row-token-expired = Portal 로그인 만료됨 — 탭하여 다시 로그인
 portal-row-stuck = 경기 { $game } 점수 전송 오류, 탭하여 수정
 portal-row-pending = 경기 { $game } 점수 전송 안 됨, 탭하여 재시도

--- a/refbox/translations/ms-MY/refbox.ftl
+++ b/refbox/translations/ms-MY/refbox.ftl
@@ -419,6 +419,7 @@ false-start = Permulaan Palsu
 
 # Portal Health Indicator
 portal-summary-title = STATUS PORTAL { $portal }
+portal-retry-all = CUBA SEMULA SEMUA
 portal-row-token-expired = Log masuk portal tamat tempoh — ketik untuk log masuk semula
 portal-row-stuck = Perlawanan { $game } Ralat hantar markah, ketik untuk perbaiki
 portal-row-pending = Perlawanan { $game } Markah belum dihantar, ketik untuk cuba semula

--- a/refbox/translations/nl-NL/refbox.ftl
+++ b/refbox/translations/nl-NL/refbox.ftl
@@ -419,6 +419,7 @@ false-start = Vals Vertrek
 
 # Portal Health Indicator
 portal-summary-title = { $portal } PORTAALSTATUS
+portal-retry-all = ALLES OPNIEUW
 portal-row-token-expired = Portaal-login verlopen — tik om opnieuw in te loggen
 portal-row-stuck = Wedstrijd { $game } Fout bij verzenden score, tik om te herstellen
 portal-row-pending = Wedstrijd { $game } Score niet verzonden, tik om opnieuw te proberen

--- a/refbox/translations/pt-PT/refbox.ftl
+++ b/refbox/translations/pt-PT/refbox.ftl
@@ -419,6 +419,7 @@ false-start = Saída Falsa
 
 # Portal Health Indicator
 portal-summary-title = ESTADO DO PORTAL { $portal }
+portal-retry-all = REPETIR TUDO
 portal-row-token-expired = Sessão do portal expirou — toque para iniciar sessão novamente
 portal-row-stuck = Jogo { $game } Erro no envio do resultado, toque para corrigir
 portal-row-pending = Jogo { $game } Resultado não enviado, toque para tentar novamente

--- a/refbox/translations/th-TH/refbox.ftl
+++ b/refbox/translations/th-TH/refbox.ftl
@@ -418,6 +418,7 @@ false-start = การออกตัวผิด
 
 # Portal Health Indicator
 portal-summary-title = สถานะ { $portal } PORTAL
+portal-retry-all = ลองใหม่ทั้งหมด
 portal-row-token-expired = การเข้าสู่ระบบพอร์ทัลหมดอายุ — แตะเพื่อเข้าสู่ระบบใหม่
 portal-row-stuck = เกม { $game } ส่งคะแนนผิดพลาด แตะเพื่อแก้ไข
 portal-row-pending = เกม { $game } ยังไม่ส่งคะแนน แตะเพื่อลองอีกครั้ง

--- a/refbox/translations/tl-PH/refbox.ftl
+++ b/refbox/translations/tl-PH/refbox.ftl
@@ -419,6 +419,7 @@ false-start = Maling Simula
 
 # Portal Health Indicator
 portal-summary-title = STATUS NG { $portal } PORTAL
+portal-retry-all = ULITIN LAHAT
 portal-row-token-expired = Nag-expire ang Portal login — pindutin para mag-login muli
 portal-row-stuck = Laro { $game } Error sa pagpapadala ng puntos, pindutin para ayusin
 portal-row-pending = Laro { $game } Hindi naipadala ang puntos, pindutin para subukan muli

--- a/refbox/translations/tr-TR/refbox.ftl
+++ b/refbox/translations/tr-TR/refbox.ftl
@@ -419,6 +419,7 @@ false-start = Hatalı Başlangıç
 
 # Portal Health Indicator
 portal-summary-title = { $portal } PORTAL DURUMU
+portal-retry-all = TÜMÜNÜ TEKRAR DENE
 portal-row-token-expired = Portal oturumu sona erdi — yeniden giriş için dokunun
 portal-row-stuck = Oyun { $game } Skor gönderme hatası, düzeltmek için dokunun
 portal-row-pending = Oyun { $game } Skor gönderilmedi, tekrar denemek için dokunun

--- a/refbox/translations/zh-CN/refbox.ftl
+++ b/refbox/translations/zh-CN/refbox.ftl
@@ -418,6 +418,7 @@ false-start = 抢跑
 
 # Portal Health Indicator
 portal-summary-title = { $portal } PORTAL 状态
+portal-retry-all = 全部重试
 portal-row-token-expired = Portal 登录已过期 — 点击重新登录
 portal-row-stuck = 比赛 { $game } 比分发送错误，点击修复
 portal-row-pending = 比赛 { $game } 比分未发送，点击重试


### PR DESCRIPTION
## What changed

Adds a blue **RETRY ALL** button to the portal status screen, in the bottom-right corner opposite the red BACK button. One tap re-sends **every** game result that is still waiting to reach the portal — including ones that have been waiting long enough to turn red ("stuck"). 

It is a **safe resend**: it never overwrites a result already on the portal. A game the portal rejects because a result already exists simply re-fails and stays flagged for you to handle individually (Force/Discard). The button is greyed out when there is nothing waiting to send, and there is no confirmation tap (it cannot overwrite or delete anything).

## Why

After a connection outage, several finished games can pile up in the send queue. Any game that has been waiting more than 30 minutes stops auto-retrying and is marked "stuck" — and today each stuck game must be tapped and force-sent individually. RETRY ALL clears the whole backlog in a single tap: it revives every stuck game and restarts its send, so the operator no longer has to nurse them one at a time.

## Scope

Changes are limited to the `refbox` crate:
- `app/message.rs` — new `PortalRetryAll` message
- `portal_manager/mod.rs` — new `retry_all()` (resets each queued game's retry timers, un-sticks it; never sets the force/overwrite flag)
- `app/mod.rs` — handles the new message
- `app/view_builders/portal_detail.rs` — the blue footer button (greyed when nothing is unsent)
- `translations/*/refbox.ftl` — the "RETRY ALL" label in all 15 languages

No changes to `uwh-common`, the wire format, or the game clock/state machine.

## How to verify

1. On the portal status screen with one or more unsent games (yellow "not sent" or red "stuck"), the blue **RETRY ALL** button is active in the bottom-right.
2. Tap it → all waiting games restart their send immediately; a stuck (red) game returns to yellow and retries (attempt counter resets to 0).
3. With no unsent games, the button is greyed and does nothing.
4. A game the portal already has is **not** overwritten — it stays flagged for individual Force/Discard (safe-resend behaviour).

**Already validated live against the dev portal:** a genuinely stuck (red) game was revived to yellow with a single tap of RETRY ALL, and the log confirmed fresh send attempts firing immediately afterward.

**Automated checks:** `just check` is green (fmt, clippy `-D warnings`, tests, audit). New unit test: `retry_all_unsticks_and_resets_every_item_without_forcing` (asserts every queued game is reset and un-stuck, and that the force/overwrite flag is never set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
