### PR TITLE
fix(refbox): open game-parameters page from portal-login-expired notice

### DIFF
--- a/refbox/src/app/message.rs
+++ b/refbox/src/app/message.rs
@@ -101,11 +101,6 @@ pub enum Message {
     /// attention action page. First tap arms the discard; second tap
     /// for the same item confirms and removes it from the queue.
     PortalDiscardTapped(ItemId),
-    /// Emitted when the operator taps GO TO LOGIN on the token-expired
-    /// action page. `update()` navigates to the existing portal login
-    /// keypad and sets `portal_login_return_to_detail` so a successful
-    /// re-login returns the operator to the portal detail page.
-    PortalGoToLogin,
     RequestPortalRefresh,
     ShowWarnings,
     ShowParameterHelp,
@@ -323,7 +318,6 @@ impl Message {
             | Self::PortalRowTapped(_)
             | Self::PortalForceSubmit(_)
             | Self::PortalDiscardTapped(_)
-            | Self::PortalGoToLogin
             | Self::RequestPortalRefresh
             | Self::ShowWarnings
             | Self::ShowParameterHelp
@@ -419,7 +413,6 @@ impl PartialEq for Message {
             | (Self::ClosePortalDetailPage, Self::ClosePortalDetailPage)
             | (Self::ClosePortalAttentionAction, Self::ClosePortalAttentionAction)
             | (Self::PortalUiTick, Self::PortalUiTick)
-            | (Self::PortalGoToLogin, Self::PortalGoToLogin)
             | (Self::RequestPortalRefresh, Self::RequestPortalRefresh)
             | (Self::ShowWarnings, Self::ShowWarnings)
             | (Self::ShowParameterHelp, Self::ShowParameterHelp)
@@ -645,7 +638,6 @@ impl PartialEq for Message {
             | (Self::PortalRowTapped(_), _)
             | (Self::PortalForceSubmit(_), _)
             | (Self::PortalDiscardTapped(_), _)
-            | (Self::PortalGoToLogin, _)
             | (Self::RequestPortalRefresh, _)
             | (Self::ShowWarnings, _)
             | (Self::ShowParameterHelp, _)

--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -211,15 +211,6 @@ pub struct RefBoxApp {
     /// stream task without needing a `&mut` on `self` (which iced's
     /// `subscription(&self)` entry point cannot provide).
     portal_event_rx: Arc<Mutex<Option<mpsc::Receiver<PortalEvent>>>>,
-    /// Set when the operator initiates portal re-login from the
-    /// token-expired action page so a successful login returns them to
-    /// the portal detail page instead of the default edit-config
-    /// landing. Consumed (cleared) when the success handler reads it.
-    /// Re-armed each time `PortalGoToLogin` fires, so an aborted login
-    /// leaves the flag stale but harmless: the next successful login
-    /// (from anywhere) would route to the detail page, which matches
-    /// the operator's most recent intent.
-    portal_login_return_to_detail: bool,
     /// Directory holding the persisted config + portal retry queue. Also
     /// where the self-update trial marker is written (next to the config).
     config_dir: std::path::PathBuf,
@@ -1778,7 +1769,6 @@ impl RefBoxApp {
             timeout_revive_token: 0,
             portal_manager,
             portal_event_rx,
-            portal_login_return_to_detail: false,
             config_dir,
             install_path,
             restart_argv,
@@ -2690,35 +2680,6 @@ impl RefBoxApp {
                         trace!("AppState changed to {:?}", self.app_state);
                     }
                 }
-                Task::none()
-            }
-            Message::PortalGoToLogin => {
-                // Navigate to the existing portal login keypad, arming
-                // the return-to-detail flag so a successful re-login
-                // lands back on the detail page (mirroring the
-                // `UwhPortalLinkFailed` GoBack handler, which reuses
-                // the same client id-lookup pattern).
-                let portal_id = match self.uwhportal_client.as_ref() {
-                    Some(client) => {
-                        // why this cannot panic: the guard is held only
-                        // for a synchronous `id()` call and dropped
-                        // immediately.
-                        client.lock().unwrap().id()
-                    }
-                    None => {
-                        // No portal client configured — there is
-                        // nothing to log into. Fall back to the detail
-                        // page so the operator is not stranded on an
-                        // empty login screen.
-                        warn!("PortalGoToLogin with no portal client configured");
-                        self.app_state = AppState::PortalDetailPage { scroll_index: 0 };
-                        trace!("AppState changed to {:?}", self.app_state);
-                        return Task::none();
-                    }
-                };
-                self.portal_login_return_to_detail = true;
-                self.app_state = AppState::KeypadPage(KeypadPage::PortalLogin(portal_id, false), 0);
-                trace!("AppState changed to {:?}", self.app_state);
                 Task::none()
             }
             Message::RequestPortalRefresh => {
@@ -4031,18 +3992,9 @@ impl RefBoxApp {
                             task = self.request_schedule(event_id.clone())
                         }
 
-                        // If the re-login was initiated from the
-                        // token-expired action page, return to the
-                        // portal detail page (where the operator left
-                        // off); otherwise land on the default
-                        // edit-config Game page. The flag is consumed
-                        // here so it does not leak into later logins.
-                        if self.portal_login_return_to_detail {
-                            self.portal_login_return_to_detail = false;
-                            AppState::PortalDetailPage { scroll_index: 0 }
-                        } else {
-                            AppState::EditGameConfig(ConfigPage::Game)
-                        }
+                        // A successful re-login lands on the edit-config
+                        // Game page (the portal parameters page).
+                        AppState::EditGameConfig(ConfigPage::Game)
                     }
                     r @ PortalTokenResponse::NoPendingLink
                     | r @ PortalTokenResponse::InvalidCode => {

--- a/refbox/src/app/view_builders/portal_detail.rs
+++ b/refbox/src/app/view_builders/portal_detail.rs
@@ -116,7 +116,7 @@ fn row_text_centered<'a>(label: String) -> Element<'a, Message> {
 fn render_row<'a>(r: DetailRow) -> Element<'a, Message> {
     match r {
         DetailRow::TokenExpired => button(row_text_centered(fl!("portal-row-token-expired")))
-            .on_press(Message::PortalGoToLogin)
+            .on_press(Message::EditGameConfigPage(ConfigPage::Game))
             .style(red_button)
             .padding(PADDING)
             .width(Length::Fill)


### PR DESCRIPTION
## What changed
When the **"Portal login expired — tap to re-login"** notice appears in the portal queue, tapping it now opens the **game-parameters page** (the page showing "USING UWHPORTAL: YES", Event, the Token button, Court, and Game) instead of dropping the operator straight onto the number-pad token-entry screen. From that page the operator re-validates the token with the full event/court context in front of them.

The old number-pad shortcut and a now-unreachable behaviour that used to bounce the operator back to the queue after a successful re-login have been removed. A successful re-login now lands on the game-parameters page — which was already the default for every other login path, so the experience is more consistent.

## Why
The previous behaviour took the operator straight to a bare number keypad with no surrounding context. Landing on the game-parameters page first is clearer. Making that the destination left the old keypad shortcut and its "return to queue" helper flag as dead code, which the project's `-D warnings` checks reject, so those were removed as part of the change.

## Scope
Limited to `refbox`:
- `refbox/src/app/view_builders/portal_detail.rs` — the notice's tap target
- `refbox/src/app/message.rs` — removal of the orphaned `PortalGoToLogin` message
- `refbox/src/app/mod.rs` — removal of the orphaned handler and `portal_login_return_to_detail` flag, and simplification of the post-login destination

(3 files, +4 / −60.)

## How to verify
- **Automated:** `just check` — formatting, linter (strict, both default and `--no-default-features`), and the full test suite (348 refbox tests) all pass.
- **On-screen:** the notice only appears when a portal token has actually expired. When it is present, tap it and confirm it opens the game-parameters page (USING UWHPORTAL: YES / Event / Token / Court / Game) rather than the number keypad. The same destination can be reached normally via Game Options to confirm the page renders correctly regardless of token state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)