### PR TITLE
fix(refbox): keep portal link across restarts when the clock is unsynced

### DIFF
--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -1780,8 +1780,14 @@ impl RefBoxApp {
 
         // Restore a recent portal link so a relaunch (language change, self-update)
         // or a short shutdown comes back recognized instead of dormant. A stale or
-        // cross-portal note is ignored — and a stale one deleted — so a fresh power-on
-        // weeks later for a new event starts clean. See ADR 011/017 amendment.
+        // cross-portal note is simply not restored (the app starts dormant) but the
+        // note is NOT deleted here: a Raspberry Pi can boot with an uncorrected clock,
+        // and deleting on a momentarily-wrong clock would permanently lose a recent
+        // link and force the operator to re-supply the token on every restart. The
+        // note's real lifecycle lives in `persist_link_session` (rewritten on Apply /
+        // heartbeat, deleted when the portal is switched off or no event is linked).
+        // See ADR 011/017 amendment and
+        // docs/superpowers/specs/2026-06-25-portal-link-restore-resilience-design.md.
         match crate::portal_manager::link_session::load_or_none(&new.config_dir) {
             Ok(Some(note)) => {
                 if decide_restore(&note, time::OffsetDateTime::now_utc(), new.config.mode) {
@@ -1800,8 +1806,9 @@ impl RefBoxApp {
                     // event list and silently skip the game re-selection.
                     new.pending_restore_schedule = Some(note.event_id);
                 } else {
-                    info!("Portal link note present but stale/cross-portal; starting dormant");
-                    let _ = crate::portal_manager::link_session::delete(&new.config_dir);
+                    info!(
+                        "Portal link note present but stale/cross-portal; starting dormant (note kept)"
+                    );
                 }
             }
             Ok(None) => {}
@@ -5054,7 +5061,22 @@ fn decide_restore(
     current_mode: Mode,
 ) -> bool {
     use crate::portal_manager::link_session::{FRESHNESS_WINDOW, is_fresh};
-    is_fresh(note.last_active, now, FRESHNESS_WINDOW) && !crosses_portal(note.mode, current_mode)
+    // A link for a different portal (UWR vs UWH) is never restored, regardless
+    // of timing — that is a correctness guard, not a freshness question.
+    if crosses_portal(note.mode, current_mode) {
+        return false;
+    }
+    // A Raspberry Pi has no battery-backed clock, so it can boot with a time
+    // that has not yet been corrected by the network. If `now` reads *earlier*
+    // than when the link was last saved, the clock is plainly not trustworthy
+    // yet — and the link is therefore genuinely recent. Restore it rather than
+    // discard a fresh link on the strength of a bad clock. The token is
+    // re-verified against the portal after restore, so this is safe.
+    if now < note.last_active {
+        return true;
+    }
+    // Trustworthy clock: restore only while the link is within the window.
+    is_fresh(note.last_active, now, FRESHNESS_WINDOW)
 }
 
 #[cfg(test)]
@@ -5084,9 +5106,28 @@ mod restore_tests {
 
     #[test]
     fn stale_does_not_restore() {
+        // Trustworthy clock, link older than the 120h window → dormant.
         let now = time::OffsetDateTime::now_utc();
-        let n = note(now - time::Duration::hours(49), Mode::Hockey6V6);
+        let n = note(now - time::Duration::hours(121), Mode::Hockey6V6);
         assert!(!decide_restore(&n, now, Mode::Hockey6V6));
+    }
+
+    #[test]
+    fn clock_behind_save_restores() {
+        // Pi booted with an uncorrected clock: `now` reads earlier than the
+        // link was saved. The clock is untrustworthy and the link is genuinely
+        // recent, so it must restore (this is the bad-boot-clock fix).
+        let now = time::OffsetDateTime::now_utc();
+        let n = note(now + time::Duration::hours(3), Mode::Hockey6V6);
+        assert!(decide_restore(&n, now, Mode::Hockey6V6));
+    }
+
+    #[test]
+    fn clock_behind_save_does_not_override_cross_portal() {
+        // The cross-portal guard wins even when the clock looks untrustworthy.
+        let now = time::OffsetDateTime::now_utc();
+        let n = note(now + time::Duration::hours(3), Mode::Hockey6V6);
+        assert!(!decide_restore(&n, now, Mode::Rugby));
     }
 
     #[test]

--- a/refbox/src/portal_manager/link_session.rs
+++ b/refbox/src/portal_manager/link_session.rs
@@ -18,8 +18,12 @@ use time::macros::format_description;
 use crate::config::Mode;
 use uwh_common::uwhportal::schedule::{EventId, GameNumber};
 
-/// How recent the last session must be to auto-restore the link on startup.
-pub const FRESHNESS_WINDOW: time::Duration = time::Duration::hours(48);
+/// How recent the last session must be to auto-restore the link on startup,
+/// *when the boot clock is trustworthy*. A Raspberry Pi has no battery-backed
+/// clock and may boot with a time that has not yet been corrected by the
+/// network — `decide_restore` handles that clock-suspect case separately so a
+/// wrong boot clock never discards a recent link.
+pub const FRESHNESS_WINDOW: time::Duration = time::Duration::hours(120);
 
 const FILE_NAME: &str = "portal_link.json";
 const TMP_FILE_NAME: &str = "portal_link.json.tmp";
@@ -204,15 +208,15 @@ mod tests {
         assert!(is_fresh(t0, t0, FRESHNESS_WINDOW)); // 0h
         assert!(is_fresh(
             t0,
-            t0 + time::Duration::hours(47),
+            t0 + FRESHNESS_WINDOW - time::Duration::hours(1),
             FRESHNESS_WINDOW
-        ));
-        assert!(is_fresh(t0, t0 + FRESHNESS_WINDOW, FRESHNESS_WINDOW)); // exactly 48h
+        )); // just inside the window
+        assert!(is_fresh(t0, t0 + FRESHNESS_WINDOW, FRESHNESS_WINDOW)); // exactly the window
         assert!(!is_fresh(
             t0,
-            t0 + time::Duration::hours(48) + time::Duration::seconds(1),
+            t0 + FRESHNESS_WINDOW + time::Duration::seconds(1),
             FRESHNESS_WINDOW
-        ));
+        )); // just past the window
         // clock skew: "now" before last_active is treated as not fresh
         assert!(!is_fresh(
             t0,


### PR DESCRIPTION
## What changed
After a system restart, the refbox now comes back connected to the same UWH Portal
event/court/game it had before, instead of dropping the connection and making the operator
re-enter the portal token.

Specifically:
- The "how recent must the saved link be to auto-restore it" window is widened from 48 hours
  to 120 hours.
- If the machine boots with a clock that reads *earlier* than when the link was last saved
  (the tell-tale sign its clock hasn't been corrected by the network yet), the refbox now
  keeps and restores the link rather than throwing it away.
- The saved link is no longer deleted just because a startup freshness check failed. It is
  cleared only through normal use — turning the portal off, or applying a config with no
  event linked.

The portal token is still re-verified against the portal after the link is restored, so this
never bypasses real authentication: if the saved token has genuinely gone bad, the red
connection indicator still appears, exactly as today.

## Why
On a Raspberry Pi there is no battery-backed clock, so right after a reboot its time is wrong
until the network corrects it — and venue internet availability varies, so it may never be
corrected. The old startup logic compared the saved link against that wrong clock, decided it
was "too old," and deleted it. With no event linked, the refbox then displays a perfectly
valid token as invalid and prompts for re-entry. The result was operators having to re-supply
the token after every restart (reported on v0.4.4).

## Scope
Changes are limited to `refbox`: the portal link-restore startup logic
(`refbox/src/app/mod.rs` `decide_restore` + the startup restore block) and the freshness
window/tests in `refbox/src/portal_manager/link_session.rs`. No changes to the game clock /
tournament state machine, to `uwh-common`, or to the token storage / login flow.

## How to verify
- `just check` passes (formatting, clippy incl. `--no-default-features`, full test suite, audit).
- New/updated unit tests encode the behaviour:
  - `clock_behind_save_restores` — a boot clock earlier than the save time restores the link.
  - `clock_behind_save_does_not_override_cross_portal` — the UWR-vs-UWH guard still wins.
  - `stale_does_not_restore` — a correct clock with a >120h-old link comes up dormant.
  - `is_fresh_boundaries` — window boundary checks updated to 120h.
- Field check (not reproducible in CI, needs a Pi that boots with a wrong clock): after a
  restart, the refbox should come back on the same event without asking for the token again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
