### PR TITLE
fix(refbox): grey out game-info REFRESH when the portal token is expired

### DIFF
--- a/refbox/src/app/view_builders/game_info.rs
+++ b/refbox/src/app/view_builders/game_info.rs
@@ -26,6 +26,13 @@ pub(in super::super) fn build_game_info_page<'a>(
         ..
     } = data;
 
+    // A refresh re-fetches the schedule from the portal, which can only
+    // fail while the saved login token is expired — so grey the button out
+    // in that one case and leave the operator to re-login via the
+    // connection indicator. A Red caused merely by a stuck submission
+    // leaves `token_expired` false and keeps refresh usable.
+    let token_expired = portal_indicator.is_some_and(|s| s.token_expired);
+
     let middle_item: Element<_> = if using_uwhportal {
         if is_refreshing {
             make_button(fl!("refreshing"))
@@ -36,7 +43,7 @@ pub(in super::super) fn build_game_info_page<'a>(
             make_button(fl!("refresh"))
                 .style(blue_button)
                 .width(Length::Fill)
-                .on_press(Message::RequestPortalRefresh)
+                .on_press_maybe((!token_expired).then_some(Message::RequestPortalRefresh))
                 .into()
         }
     } else {

--- a/refbox/src/portal_manager/mod.rs
+++ b/refbox/src/portal_manager/mod.rs
@@ -216,12 +216,19 @@ pub enum HealthState {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PortalIndicatorState {
     pub health: HealthState,
+    /// True when the saved login token is known to be expired/rejected.
+    /// This is the specific Red cause that makes a schedule refresh
+    /// pointless (it can only fail until the operator re-logs-in), so
+    /// the game-info REFRESH button greys out on it. A Red caused only
+    /// by a stuck queue item leaves this `false`.
+    pub token_expired: bool,
 }
 
 impl Default for PortalIndicatorState {
     fn default() -> Self {
         Self {
             health: HealthState::Green,
+            token_expired: false,
         }
     }
 }
@@ -382,7 +389,10 @@ impl PortalManager {
             HealthState::Green
         };
 
-        self.indicator_state = PortalIndicatorState { health };
+        self.indicator_state = PortalIndicatorState {
+            health,
+            token_expired: self.token_known_problem,
+        };
     }
 
     fn find_mut(&mut self, id: &ItemId) -> Option<&mut QueuedItem> {
@@ -757,6 +767,31 @@ mod tests {
     fn token_known_problem_is_red() {
         let m = PortalManager::new_for_test(QueueFile::empty(), false, true);
         assert_eq!(m.indicator_state().health, HealthState::Red);
+    }
+
+    #[test]
+    fn token_known_problem_sets_token_expired() {
+        let m = PortalManager::new_for_test(QueueFile::empty(), false, true);
+        assert!(m.indicator_state().token_expired);
+    }
+
+    #[test]
+    fn stuck_item_red_is_not_token_expired() {
+        // A Red caused solely by a stuck queue item must NOT report
+        // token_expired — a schedule refresh still works in that case.
+        let q = QueueFile {
+            version: 1,
+            items: vec![mk_stuck_item()],
+        };
+        let m = PortalManager::new_for_test(q, false, false);
+        assert_eq!(m.indicator_state().health, HealthState::Red);
+        assert!(!m.indicator_state().token_expired);
+    }
+
+    #[test]
+    fn healthy_connection_is_not_token_expired() {
+        let m = PortalManager::new_for_test(QueueFile::empty(), false, false);
+        assert!(!m.indicator_state().token_expired);
     }
 
     #[test]


### PR DESCRIPTION
## What changed
On the game info page, the blue REFRESH button now greys out (and can't be pressed) in one
specific situation: when the saved UWH Portal login token has expired. In every other case —
a healthy connection, a check in progress, or even a "needs attention" state caused by a
stuck score submission — REFRESH stays blue and tappable, exactly as before. When it greys
out, the operator re-logs-in the same way as always: by tapping the coloured connection
indicator on the time banner.

## Why
REFRESH re-fetches the schedule from the portal. That request can only fail while the login
token is expired (the fix for that is re-logging in, not pressing REFRESH). Pressing a button
that can only fail is misleading, so the button is disabled in just that case. A "needs
attention" state caused by a stuck submission does not stop a schedule refresh from working,
so REFRESH stays usable then.

## Scope
Changes are limited to `refbox`: one boolean (`token_expired`) added to the connection-status
value in `refbox/src/portal_manager/mod.rs`, and the game-info REFRESH button in
`refbox/src/app/view_builders/game_info.rs` using the existing `on_press_maybe` disable
pattern. No game-clock / tournament-manager changes, no `uwh-common` changes, no new
translation strings (the label stays "REFRESH").

## How to verify
- `just check` passes (formatting, clippy incl. `--no-default-features`, full test suite, audit).
- New unit tests in `portal_manager`:
  - `token_known_problem_sets_token_expired` — an expired token reports `token_expired = true`.
  - `stuck_item_red_is_not_token_expired` — a Red caused only by a stuck submission reports
    `false`, so REFRESH stays usable.
  - `healthy_connection_is_not_token_expired` — a healthy connection reports `false`.
- In the running app: with a valid token, REFRESH on the game info page is blue/tappable;
  with an expired token (portal returns 401 on the token check) it appears greyed and does
  not respond to taps, while BACK and SETTINGS next to it stay normal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
