### PR TITLE
fix(refbox): decouple portal score and stats uploads (stats best-effort)

### DIFF
--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -2638,8 +2638,12 @@ impl RefBoxApp {
                         discard_armed: false,
                     };
                     trace!("AppState changed to {:?}", self.app_state);
+                } else if self.portal_manager.is_stats_pending(&id) {
+                    // Stats-pending row: fire one stats attempt. No
+                    // background loop, no escalation.
+                    self.portal_manager.request_stats_retry(&id);
                 } else {
-                    // Young pending row tapped — force an immediate retry.
+                    // Young score-pending row tapped — force an immediate retry.
                     if let Err(e) = self.portal_manager.force_immediate_retry(&id) {
                         error!("force_immediate_retry failed: {e}");
                     }

--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -2605,6 +2605,9 @@ impl RefBoxApp {
                     PortalEvent::ItemResolved(id) => {
                         self.portal_manager.on_item_resolved(id);
                     }
+                    PortalEvent::ScoreSentStatsPending(id) => {
+                        self.portal_manager.on_score_sent_stats_pending(id);
+                    }
                     PortalEvent::HealthChanged | PortalEvent::ItemUpdated => {
                         self.portal_manager.ui_tick();
                     }

--- a/refbox/src/app/view_builders/portal_detail.rs
+++ b/refbox/src/app/view_builders/portal_detail.rs
@@ -49,9 +49,12 @@ pub(in super::super) fn build_portal_detail_page<'a>(
     // RETRY ALL is actionable only when there is at least one unsent
     // game (a stuck/red or pending/yellow row). Recent-success and
     // token-expired rows don't count.
-    let has_unsent = rows
-        .iter()
-        .any(|r| matches!(r, DetailRow::Stuck { .. } | DetailRow::Pending { .. }));
+    let has_unsent = rows.iter().any(|r| {
+        matches!(
+            r,
+            DetailRow::Stuck { .. } | DetailRow::Pending { .. } | DetailRow::StatsPending { .. }
+        )
+    });
 
     let row_buttons: CollectArrayResult<_, PORTAL_DETAIL_LIST_LEN> = rows
         .into_iter()
@@ -169,6 +172,16 @@ fn render_row<'a>(r: DetailRow) -> Element<'a, Message> {
                 .height(Length::Fixed(MIN_BUTTON_SIZE))
                 .into()
         }
+        DetailRow::StatsPending { id, game_number } => button(row_text_centered(fl!(
+            "portal-row-stats-pending",
+            game = game_number
+        )))
+        .on_press(Message::PortalRowTapped(id))
+        .style(yellow_button)
+        .padding(PADDING)
+        .width(Length::Fill)
+        .height(Length::Fixed(MIN_BUTTON_SIZE))
+        .into(),
         DetailRow::RecentSuccess {
             game_number,
             submitted_mins_ago,

--- a/refbox/src/portal_manager/health.rs
+++ b/refbox/src/portal_manager/health.rs
@@ -69,6 +69,11 @@ pub enum PortalCommand {
     /// after every queue mutation so the task knows which items to
     /// attempt on its next tick.
     QueueUpdated(QueueFile),
+    /// One-shot request to (re)post the stats for a single stats-pending
+    /// item. Triggered by the operator tapping the item's row or RETRY
+    /// ALL. The task attempts stats exactly once and never schedules a
+    /// follow-up — stats-pending items are not on the auto-retry cadence.
+    RetryStats(QueuedItem),
 }
 
 pub struct BackgroundTaskHandle {
@@ -171,6 +176,19 @@ async fn run_task(
                     None => break,
                     Some(PortalCommand::QueueUpdated(new_queue)) => {
                         queue_snapshot = new_queue;
+                    }
+                    Some(PortalCommand::RetryStats(item)) => {
+                        match io.post_stats(&item).await {
+                            Ok(()) => {
+                                let _ = event_tx
+                                    .send(PortalEvent::ItemResolved(item.id.clone()))
+                                    .await;
+                            }
+                            Err(_) => {
+                                // Stays stats-pending; no escalation, no loop.
+                                let _ = event_tx.send(PortalEvent::ItemUpdated).await;
+                            }
+                        }
                     }
                 }
             }
@@ -588,6 +606,103 @@ mod tests {
             stats_count.load(std::sync::atomic::Ordering::SeqCst),
             0,
             "the auto-retry loop must not auto-attempt stats for a stats-pending item"
+        );
+        drop(handle);
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn retry_stats_command_posts_stats_once_and_resolves_on_success() {
+        let scores_count = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let stats_count = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let io = FakeIo {
+            verify_results: Mutex::new(vec![Ok(())]),
+            verify_count: Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            scores_results: Mutex::new(vec![]),
+            scores_count: scores_count.clone(),
+            stats_results: Mutex::new(vec![Ok(())]),
+            stats_count: stats_count.clone(),
+        };
+        let mut handle = spawn(io);
+
+        let mut item = mk_queue_item(0);
+        item.score_sent = true;
+        let expected_id = item.id.clone();
+        handle
+            .command_tx
+            .send(PortalCommand::RetryStats(item))
+            .await
+            .unwrap();
+
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+
+        assert_eq!(
+            stats_count.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "RetryStats must post stats exactly once"
+        );
+        assert_eq!(
+            scores_count.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "RetryStats must never re-post the score"
+        );
+        let events = drain_events(&mut handle.event_rx);
+        assert!(
+            events.iter().any(|ev| matches!(
+                ev, PortalEvent::ItemResolved(id) if id == &expected_id
+            )),
+            "successful RetryStats must resolve the item, got {events:?}"
+        );
+        drop(handle);
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn retry_stats_command_emits_item_updated_on_failure() {
+        let scores_count = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let stats_count = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let io = FakeIo {
+            verify_results: Mutex::new(vec![Ok(())]),
+            verify_count: Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            scores_results: Mutex::new(vec![]),
+            scores_count: scores_count.clone(),
+            stats_results: Mutex::new(vec![Err(PortalCallError::Failed("forced".into()))]),
+            stats_count: stats_count.clone(),
+        };
+        let mut handle = spawn(io);
+
+        let mut item = mk_queue_item(0);
+        item.score_sent = true;
+        handle
+            .command_tx
+            .send(PortalCommand::RetryStats(item))
+            .await
+            .unwrap();
+
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+
+        assert_eq!(
+            stats_count.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "RetryStats must post stats exactly once even on failure"
+        );
+        assert_eq!(
+            scores_count.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "RetryStats must never re-post the score"
+        );
+        let events = drain_events(&mut handle.event_rx);
+        assert!(
+            events
+                .iter()
+                .any(|ev| matches!(ev, PortalEvent::ItemUpdated)),
+            "failed RetryStats must emit ItemUpdated, got {events:?}"
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|ev| matches!(ev, PortalEvent::ItemResolved(_))),
+            "failed RetryStats must NOT emit ItemResolved, got {events:?}"
         );
         drop(handle);
     }

--- a/refbox/src/portal_manager/health.rs
+++ b/refbox/src/portal_manager/health.rs
@@ -135,7 +135,8 @@ async fn run_task(
                 // Tick: try each eligible queued item, then health-check if due.
                 let now = OffsetDateTime::now_utc();
                 for item in &queue_snapshot.items {
-                    if is_item_retry_eligible(item, now)
+                    if !item.score_sent
+                        && is_item_retry_eligible(item, now)
                         && attempt_item(&io, item, &event_tx).await
                     {
                         last_success = Some(TokioInstant::now());
@@ -179,16 +180,17 @@ async fn run_task(
 
 /// Attempt to submit a single queued item (scores + stats). The portal
 /// API collapses all non-success outcomes (409 conflict, 401 token
-/// expired, 5xx, network) into a single error, so we treat any `Err`
-/// identically: leave the item on the queue for the next retry tick,
-/// and emit `ItemUpdated` so the UI can refresh the row. Only a full
-/// success (both scores and stats posted) emits `ItemResolved`.
+/// expired, 5xx, network) into a single error. Three outcomes:
 ///
-/// Returns `true` iff both portal calls succeeded. The caller uses this
-/// to decide whether to stamp `last_success`; advancing `last_success`
-/// on a failed attempt would suppress the cadence-driven
-/// `verify_token` health check and leave the indicator stuck at Green
-/// during a silent portal outage.
+/// - **Score fails** → emits `ItemUpdated`, returns `false`. The item
+///   remains fully on the queue; `last_success` is not advanced so the
+///   cadence-driven `verify_token` health check is not suppressed.
+/// - **Score succeeds, stats fail** → emits `ScoreSentStatsPending`,
+///   returns `true`. The portal is reachable (score posted), so we
+///   advance `last_success` to suppress an unnecessary `verify_token`.
+///   The main thread flips the item to `score_sent = true` so it exits
+///   the auto-retry loop and the yellow/red indicator.
+/// - **Both succeed** → emits `ItemResolved`, returns `true`.
 async fn attempt_item(
     io: &impl PortalTaskIo,
     item: &QueuedItem,
@@ -207,8 +209,14 @@ async fn attempt_item(
             true
         }
         Err(_) => {
-            let _ = event_tx.send(PortalEvent::ItemUpdated).await;
-            false
+            // Score is up but stats failed (e.g. an event that does not
+            // require unique cap numbers rejects all stats). Mark the
+            // item stats-pending; the portal is reachable, so return
+            // `true` to suppress the cadence `verify_token`.
+            let _ = event_tx
+                .send(PortalEvent::ScoreSentStatsPending(item.id.clone()))
+                .await;
+            true
         }
     }
 }
@@ -487,6 +495,101 @@ mod tests {
         );
 
         drop(handle.command_tx);
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn score_ok_stats_fail_emits_score_sent_stats_pending() {
+        let scores_count = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let stats_count = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let io = FakeIo {
+            verify_results: Mutex::new(vec![Ok(())]),
+            verify_count: Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            scores_results: Mutex::new(vec![Ok(())]),
+            scores_count: scores_count.clone(),
+            stats_results: Mutex::new(vec![Err(PortalCallError::Failed("no unique caps".into()))]),
+            stats_count: stats_count.clone(),
+        };
+        let mut handle = spawn(io);
+
+        let queue = queue_with_one_eligible_item();
+        let expected_id = queue.items[0].id.clone();
+        handle
+            .command_tx
+            .send(PortalCommand::QueueUpdated(queue))
+            .await
+            .unwrap();
+
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_secs(3)).await;
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_millis(500)).await;
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+
+        assert_eq!(scores_count.load(std::sync::atomic::Ordering::SeqCst), 1);
+        assert_eq!(stats_count.load(std::sync::atomic::Ordering::SeqCst), 1);
+
+        let events = drain_events(&mut handle.event_rx);
+        assert!(
+            events.iter().any(|ev| matches!(
+                ev,
+                PortalEvent::ScoreSentStatsPending(id) if id == &expected_id
+            )),
+            "expected ScoreSentStatsPending for {expected_id:?}, got {events:?}"
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|ev| matches!(ev, PortalEvent::ItemResolved(_))),
+            "score-ok/stats-fail must NOT resolve the item"
+        );
+        drop(handle);
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn stats_pending_item_is_not_auto_attempted_by_loop() {
+        let scores_count = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let stats_count = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let io = FakeIo {
+            verify_results: Mutex::new(vec![Ok(())]),
+            verify_count: Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            scores_results: Mutex::new(vec![Ok(())]),
+            scores_count: scores_count.clone(),
+            stats_results: Mutex::new(vec![Ok(())]),
+            stats_count: stats_count.clone(),
+        };
+        let handle = spawn(io);
+
+        // A single item already in the stats-pending state.
+        let mut item = mk_queue_item(0);
+        item.score_sent = true;
+        let queue = QueueFile {
+            version: QueueFile::CURRENT_VERSION,
+            items: vec![item],
+        };
+        handle
+            .command_tx
+            .send(PortalCommand::QueueUpdated(queue))
+            .await
+            .unwrap();
+
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_secs(3)).await;
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_millis(500)).await;
+        tokio::task::yield_now().await;
+
+        assert_eq!(
+            scores_count.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "the auto-retry loop must not re-post scores for a stats-pending item"
+        );
+        assert_eq!(
+            stats_count.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "the auto-retry loop must not auto-attempt stats for a stats-pending item"
+        );
+        drop(handle);
     }
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]

--- a/refbox/src/portal_manager/health.rs
+++ b/refbox/src/portal_manager/health.rs
@@ -231,6 +231,7 @@ mod tests {
             attempts,
             last_attempt_at: None,
             force: false,
+            score_sent: false,
         }
     }
 

--- a/refbox/src/portal_manager/mod.rs
+++ b/refbox/src/portal_manager/mod.rs
@@ -367,8 +367,8 @@ impl PortalManager {
         self.queue.items.iter().any(|it| is_item_stuck(it, now))
     }
 
-    fn has_any_queue_items(&self) -> bool {
-        !self.queue.items.is_empty()
+    fn has_score_pending_items(&self) -> bool {
+        self.queue.items.iter().any(|it| !it.score_sent)
     }
 
     fn needs_attention(&self) -> bool {
@@ -378,7 +378,7 @@ impl PortalManager {
     fn recompute_indicator(&mut self) {
         let health = if self.needs_attention() {
             HealthState::Red
-        } else if self.check_in_flight || self.has_any_queue_items() {
+        } else if self.check_in_flight || self.has_score_pending_items() {
             HealthState::Yellow
         } else {
             HealthState::Green
@@ -935,6 +935,23 @@ mod tests {
         // non-persistent default) rather than any user-supplied path.
         let (manager, _rx) = PortalManager::new_degraded();
         assert_eq!(manager.config_dir, std::env::temp_dir());
+    }
+
+    #[tokio::test]
+    async fn queue_with_only_stats_pending_item_is_green() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (mut m, _rx) = PortalManager::new(tmp.path(), NullIo).unwrap();
+        m.enqueue_game_end("e".into(), "G1".into(), 3, 2, "{}".into())
+            .unwrap();
+        // Mark it stats-pending and age it well past the stuck threshold.
+        m.queue.items[0].score_sent = true;
+        m.queue.items[0].queued_at = OffsetDateTime::now_utc() - TimeDuration::minutes(120);
+        m.recompute_indicator();
+        assert_eq!(
+            m.indicator_state().health,
+            HealthState::Green,
+            "a queue holding only stats-pending items must keep the dot green"
+        );
     }
 
     #[tokio::test]

--- a/refbox/src/portal_manager/mod.rs
+++ b/refbox/src/portal_manager/mod.rs
@@ -240,6 +240,11 @@ pub enum PortalEvent {
     HealthChanged,
     ItemResolved(ItemId),
     ItemUpdated,
+    /// The score posted successfully but the stats upload failed. The
+    /// main thread flips the item to stats-pending (`score_sent = true`)
+    /// so the auto-retry loop, the stuck escalation, and the indicator
+    /// all stop treating it as outstanding. Carries the item id.
+    ScoreSentStatsPending(ItemId),
     /// Result of the latest periodic `verify_token` probe.
     /// `true` = portal accepted the token, `false` = rejected. The
     /// main-thread handler maps this onto `token_known_problem` so the
@@ -621,6 +626,27 @@ impl PortalManager {
         self.recompute_indicator();
         self.push_queue_snapshot();
         Ok(())
+    }
+
+    /// Background task reported a score-OK / stats-fail outcome: the score
+    /// is up but the stats upload was rejected. Flip the item to
+    /// stats-pending so it leaves the auto-retry loop and the yellow/red
+    /// indicator, persist, and push a fresh snapshot so the background
+    /// task stops attempting it. Idempotent: a duplicate event (or an
+    /// unknown id) is a silent no-op.
+    pub fn on_score_sent_stats_pending(&mut self, id: ItemId) {
+        let Some(item) = self.find_mut(&id) else {
+            return;
+        };
+        if item.score_sent {
+            return; // Already stats-pending; nothing to do.
+        }
+        item.score_sent = true;
+        if let Err(e) = queue::save(&self.config_dir, &self.queue) {
+            log::warn!("portal queue save after score-sent/stats-pending failed: {e}");
+        }
+        self.recompute_indicator();
+        self.push_queue_snapshot();
     }
 
     /// Called from the UI thread after the background task reports that
@@ -1236,6 +1262,31 @@ mod tests {
             reloaded.items[0].last_attempt_at.is_none(),
             "on-disk queue must show last_attempt_at cleared"
         );
+    }
+
+    #[tokio::test]
+    async fn on_score_sent_stats_pending_marks_item_and_stays_green() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (mut m, _rx) = PortalManager::new(tmp.path(), NullIo).unwrap();
+        m.enqueue_game_end("e".into(), "G1".into(), 3, 2, "{}".into())
+            .unwrap();
+        let id = m.queue.items[0].id.clone();
+        assert_eq!(m.indicator_state().health, HealthState::Yellow);
+
+        m.on_score_sent_stats_pending(id);
+
+        assert!(
+            m.queue.items[0].score_sent,
+            "item must be marked stats-pending"
+        );
+        assert_eq!(
+            m.indicator_state().health,
+            HealthState::Green,
+            "once the score is sent the dot must be green even though stats are outstanding"
+        );
+        // Persisted: a restart must reload it as stats-pending.
+        let reloaded = queue::load_or_empty(tmp.path()).unwrap();
+        assert!(reloaded.items[0].score_sent);
     }
 
     #[test]

--- a/refbox/src/portal_manager/mod.rs
+++ b/refbox/src/portal_manager/mod.rs
@@ -595,6 +595,9 @@ impl PortalManager {
     /// if the disk write fails (the error propagates for logging).
     pub fn retry_all(&mut self) -> std::io::Result<()> {
         let now = OffsetDateTime::now_utc();
+        // Reset every item; touching a stats-pending item's attempt/queued_at
+        // fields is harmless (they are unused while score_sent == true) and
+        // keeps this a single pass.
         for item in &mut self.queue.items {
             item.attempts = 0;
             item.last_attempt_at = None;
@@ -1420,6 +1423,7 @@ mod tests {
         m.enqueue_game_end("e".into(), "G_SCORE".into(), 2, 1, "{}".into())
             .unwrap();
         m.queue.items[1].attempts = 3;
+        m.queue.items[1].last_attempt_at = Some(OffsetDateTime::now_utc());
 
         m.retry_all().unwrap();
 
@@ -1428,10 +1432,16 @@ mod tests {
             m.queue.items[0].score_sent,
             "retry_all must not clear score_sent"
         );
-        assert!(!m.queue.items[0].force);
+        assert!(
+            !m.queue.items[0].force,
+            "retry_all must not set force on the stats-pending item"
+        );
         // Score-pending item is reset for immediate auto-retry.
         assert_eq!(m.queue.items[1].attempts, 0);
         assert!(m.queue.items[1].last_attempt_at.is_none());
-        assert!(!m.queue.items[1].force);
+        assert!(
+            !m.queue.items[1].force,
+            "retry_all must not set force on the score-pending item"
+        );
     }
 }

--- a/refbox/src/portal_manager/mod.rs
+++ b/refbox/src/portal_manager/mod.rs
@@ -597,6 +597,13 @@ impl PortalManager {
         queue::save(&self.config_dir, &self.queue)?;
         self.recompute_indicator();
         self.push_queue_snapshot();
+        // Stats-pending games are not on the auto-retry cadence; give
+        // each a single fresh stats attempt so RETRY ALL sweeps them too.
+        for item in &self.queue.items {
+            if item.score_sent {
+                self.send_stats_retry(item);
+            }
+        }
         Ok(())
     }
 
@@ -1348,5 +1355,31 @@ mod tests {
             !is_item_stuck(&it, OffsetDateTime::now_utc()),
             "a stats-pending item must never be classified as stuck"
         );
+    }
+
+    #[tokio::test]
+    async fn retry_all_preserves_score_sent_and_resets_score_pending() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (mut m, _rx) = PortalManager::new(tmp.path(), NullIo).unwrap();
+        // One stats-pending game and one score-pending game.
+        m.enqueue_game_end("e".into(), "G_STATS".into(), 1, 0, "{}".into())
+            .unwrap();
+        m.queue.items[0].score_sent = true;
+        m.enqueue_game_end("e".into(), "G_SCORE".into(), 2, 1, "{}".into())
+            .unwrap();
+        m.queue.items[1].attempts = 3;
+
+        m.retry_all().unwrap();
+
+        // Stats-pending item keeps score_sent and is not forced.
+        assert!(
+            m.queue.items[0].score_sent,
+            "retry_all must not clear score_sent"
+        );
+        assert!(!m.queue.items[0].force);
+        // Score-pending item is reset for immediate auto-retry.
+        assert_eq!(m.queue.items[1].attempts, 0);
+        assert!(m.queue.items[1].last_attempt_at.is_none());
+        assert!(!m.queue.items[1].force);
     }
 }

--- a/refbox/src/portal_manager/mod.rs
+++ b/refbox/src/portal_manager/mod.rs
@@ -508,6 +508,7 @@ impl PortalManager {
             attempts: 0,
             last_attempt_at: None,
             force: false,
+            score_sent: false,
         };
         self.queue.items.push(item);
         queue::save(&self.config_dir, &self.queue)?;
@@ -747,6 +748,7 @@ mod tests {
             attempts: 0,
             last_attempt_at: None,
             force: false,
+            score_sent: false,
         }
     }
 

--- a/refbox/src/portal_manager/mod.rs
+++ b/refbox/src/portal_manager/mod.rs
@@ -478,6 +478,34 @@ impl PortalManager {
         (m, rx)
     }
 
+    /// Send a one-shot `RetryStats` command to the background task for
+    /// the given item. The command carries a clone of the item, so the
+    /// task can attempt it without holding the UI lock. Spawned like
+    /// `push_queue_snapshot` because `update()` is synchronous.
+    fn send_stats_retry(&self, item: &QueuedItem) {
+        let tx = self.command_tx.clone();
+        let item = item.clone();
+        tokio::spawn(async move {
+            let _ = tx.send(health::PortalCommand::RetryStats(item)).await;
+        });
+    }
+
+    /// Operator asked to retry the stats for one stats-pending item
+    /// (tapped its row). Sends exactly one `RetryStats`. No-op if the id
+    /// is not in the queue.
+    pub fn request_stats_retry(&self, id: &ItemId) {
+        if let Some(item) = self.find(id) {
+            self.send_stats_retry(item);
+        }
+    }
+
+    /// True iff the queued item exists and its score has been sent but
+    /// stats are still outstanding (stats-pending). False for score-
+    /// pending items and for unknown ids.
+    pub fn is_stats_pending(&self, id: &ItemId) -> bool {
+        self.find(id).is_some_and(|it| it.score_sent)
+    }
+
     /// Send the current queue snapshot to the background task. Called
     /// after every queue mutation so the task's view stays fresh.
     fn push_queue_snapshot(&self) {
@@ -1287,6 +1315,28 @@ mod tests {
         // Persisted: a restart must reload it as stats-pending.
         let reloaded = queue::load_or_empty(tmp.path()).unwrap();
         assert!(reloaded.items[0].score_sent);
+    }
+
+    #[tokio::test]
+    async fn is_stats_pending_reflects_score_sent_flag() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (mut m, _rx) = PortalManager::new(tmp.path(), NullIo).unwrap();
+        m.enqueue_game_end("e".into(), "G1".into(), 0, 0, "{}".into())
+            .unwrap();
+        let id = m.queue.items[0].id.clone();
+        assert!(!m.is_stats_pending(&id), "fresh item is score-pending");
+
+        m.queue.items[0].score_sent = true;
+        assert!(m.is_stats_pending(&id), "score_sent item is stats-pending");
+
+        let unknown = ItemId {
+            event_id: "e".into(),
+            game_number: "GX".into(),
+        };
+        assert!(
+            !m.is_stats_pending(&unknown),
+            "unknown id must be false, not panic"
+        );
     }
 
     #[test]

--- a/refbox/src/portal_manager/mod.rs
+++ b/refbox/src/portal_manager/mod.rs
@@ -278,6 +278,12 @@ pub enum DetailRow {
         game_number: String,
         attempts: u32,
     },
+    /// A game whose score is sent but whose stats upload is still
+    /// outstanding (stats-pending). Rendered yellow like `Pending`, but
+    /// it never escalates and is not auto-retried — tapping fires one
+    /// stats attempt. No attempt counter: the row is one-shot, so a
+    /// counter would wrongly imply background retrying.
+    StatsPending { id: ItemId, game_number: String },
     /// A recently-completed submission, shown as an informational
     /// green strip. Not tappable.
     RecentSuccess {
@@ -767,11 +773,19 @@ impl PortalManager {
             }
         }
         for it in &items {
-            if !is_item_stuck(it, now) {
+            if !it.score_sent && !is_item_stuck(it, now) {
                 out.push(DetailRow::Pending {
                     id: it.id.clone(),
                     game_number: it.id.game_number.clone(),
                     attempts: it.attempts,
+                });
+            }
+        }
+        for it in &items {
+            if it.score_sent {
+                out.push(DetailRow::StatsPending {
+                    id: it.id.clone(),
+                    game_number: it.id.game_number.clone(),
                 });
             }
         }
@@ -1355,6 +1369,44 @@ mod tests {
             !is_item_stuck(&it, OffsetDateTime::now_utc()),
             "a stats-pending item must never be classified as stuck"
         );
+    }
+
+    #[tokio::test]
+    async fn detail_rows_places_stats_pending_after_pending_before_recent() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (mut m, _rx) = PortalManager::new(tmp.path(), NullIo).unwrap();
+
+        // A score-pending (young) game and a stats-pending game.
+        m.enqueue_game_end("e".into(), "G_SCORE".into(), 0, 0, "{}".into())
+            .unwrap();
+        m.queue.items[0].queued_at = OffsetDateTime::now_utc() - TimeDuration::minutes(2);
+        m.enqueue_game_end("e".into(), "G_STATS".into(), 1, 0, "{}".into())
+            .unwrap();
+        m.queue.items[1].score_sent = true;
+
+        // And one recent success.
+        m.enqueue_game_end("e".into(), "G_DONE".into(), 2, 1, "{}".into())
+            .unwrap();
+        let done_id = m.queue.items[2].id.clone();
+        m.on_item_resolved(done_id);
+
+        let rows = m.detail_rows();
+        assert!(
+            matches!(&rows[0], DetailRow::Pending { game_number, .. } if game_number == "G_SCORE"),
+            "row0 should be the score-pending game, got {:?}",
+            rows[0]
+        );
+        assert!(
+            matches!(&rows[1], DetailRow::StatsPending { game_number, .. } if game_number == "G_STATS"),
+            "row1 should be the stats-pending game, got {:?}",
+            rows[1]
+        );
+        assert!(
+            matches!(&rows[2], DetailRow::RecentSuccess { game_number, .. } if game_number == "G_DONE"),
+            "row2 should be the recent success, got {:?}",
+            rows[2]
+        );
+        assert_eq!(rows.len(), 3);
     }
 
     #[tokio::test]

--- a/refbox/src/portal_manager/mod.rs
+++ b/refbox/src/portal_manager/mod.rs
@@ -296,7 +296,9 @@ struct RecentSuccess {
 pub const STUCK_THRESHOLD: TimeDuration = TimeDuration::minutes(30);
 
 pub fn is_item_stuck(item: &QueuedItem, now: OffsetDateTime) -> bool {
-    (now - item.queued_at) >= STUCK_THRESHOLD
+    // Stats-pending items (score already accepted) never go stuck: a
+    // missing stat must not nag the operator or escalate to red.
+    !item.score_sent && (now - item.queued_at) >= STUCK_THRESHOLD
 }
 
 pub struct PortalManager {
@@ -1216,6 +1218,17 @@ mod tests {
         assert!(
             reloaded.items[0].last_attempt_at.is_none(),
             "on-disk queue must show last_attempt_at cleared"
+        );
+    }
+
+    #[test]
+    fn stats_pending_item_is_never_stuck_even_when_old() {
+        let mut it = mk_young_item();
+        it.score_sent = true;
+        it.queued_at = OffsetDateTime::now_utc() - TimeDuration::minutes(120);
+        assert!(
+            !is_item_stuck(&it, OffsetDateTime::now_utc()),
+            "a stats-pending item must never be classified as stuck"
         );
     }
 }

--- a/refbox/src/portal_manager/queue.rs
+++ b/refbox/src/portal_manager/queue.rs
@@ -57,6 +57,16 @@ pub struct QueuedItem {
     /// via the FORCE THIS GAME RESULT button on the attention action
     /// page (see Task 15).
     pub force: bool,
+    /// Whether the portal has already accepted this game's **score**.
+    /// `false` = score-pending (the normal queued state: auto-retried,
+    /// can go stuck/red). `true` = stats-pending (score is up, only the
+    /// stats upload is outstanding) — excluded from the auto-retry loop,
+    /// the stuck escalation, and the yellow/red indicator; re-sent only
+    /// by a one-shot `RetryStats` command. `#[serde(default)]` so old
+    /// `portal_queue.json` files (written before this field existed)
+    /// load as score-pending.
+    #[serde(default)]
+    pub score_sent: bool,
 }
 
 const QUEUE_FILE_NAME: &str = "portal_queue.json";
@@ -153,6 +163,7 @@ mod tests {
                 attempts: 2,
                 last_attempt_at: Some(datetime!(2026-04-19 14:23:15 UTC)),
                 force: false,
+                score_sent: false,
             }],
         };
         let s = serde_json::to_string_pretty(&q).unwrap();
@@ -189,6 +200,7 @@ mod tests {
                     attempts: 0,
                     last_attempt_at: None,
                     force: false,
+                    score_sent: false,
                 }],
             };
             save(tmp.path(), &q).unwrap();
@@ -226,5 +238,53 @@ mod tests {
             assert!(tmp.path().join("portal_queue.json").exists());
             assert!(!tmp.path().join("portal_queue.json.tmp").exists());
         }
+    }
+
+    #[test]
+    fn score_sent_round_trips_true() {
+        let item = QueuedItem {
+            id: ItemId {
+                event_id: "e1".into(),
+                game_number: "G1".into(),
+            },
+            black_score: 1,
+            white_score: 0,
+            stats: "{}".into(),
+            queued_at: datetime!(2026-06-25 12:00:00 UTC),
+            attempts: 0,
+            last_attempt_at: None,
+            force: false,
+            score_sent: true,
+        };
+        let s = serde_json::to_string(&item).unwrap();
+        let back: QueuedItem = serde_json::from_str(&s).unwrap();
+        assert!(back.score_sent);
+        assert_eq!(item, back);
+    }
+
+    #[test]
+    fn missing_score_sent_field_defaults_to_false() {
+        // Simulate an old portal_queue.json written before this field existed.
+        let item = QueuedItem {
+            id: ItemId {
+                event_id: "e1".into(),
+                game_number: "G1".into(),
+            },
+            black_score: 0,
+            white_score: 0,
+            stats: "{}".into(),
+            queued_at: datetime!(2026-06-25 12:00:00 UTC),
+            attempts: 0,
+            last_attempt_at: None,
+            force: false,
+            score_sent: true,
+        };
+        let mut v = serde_json::to_value(&item).unwrap();
+        v.as_object_mut().unwrap().remove("score_sent");
+        let back: QueuedItem = serde_json::from_value(v).unwrap();
+        assert!(
+            !back.score_sent,
+            "an item with no score_sent field must load as score-pending (false)"
+        );
     }
 }

--- a/refbox/translations/de-DE/refbox.ftl
+++ b/refbox/translations/de-DE/refbox.ftl
@@ -423,6 +423,7 @@ portal-retry-all = ALLE WIEDERHOLEN
 portal-row-token-expired = Portal-Anmeldung abgelaufen — zum erneuten Anmelden tippen
 portal-row-stuck = Spiel { $game } Übermittlungsfehler, zum Beheben tippen
 portal-row-pending = Spiel { $game } Spielstand nicht gesendet, zum erneuten Versuch tippen
+portal-row-stats-pending = Spiel { $game } Statistik nicht gesendet, zum erneuten Versuch tippen
 portal-row-attempt-suffix = (Versuch { $attempts })
 portal-row-recent = Spiel { $game } · Übermittelt vor { $mins } Min
 portal-action-force-submit = Dieses Spielergebnis erneut senden

--- a/refbox/translations/en-US/refbox.ftl
+++ b/refbox/translations/en-US/refbox.ftl
@@ -459,6 +459,7 @@ portal-retry-all = RETRY ALL
 portal-row-token-expired = Portal login expired — tap to re-login
 portal-row-stuck = Game { $game } Score send error, tap to fix
 portal-row-pending = Game { $game } Score not sent, tap to retry
+portal-row-stats-pending = Game { $game } Stats not sent, tap to retry
 portal-row-attempt-suffix = (attempt { $attempts })
 portal-row-recent = Game { $game } · Submitted { $mins } min ago
 portal-action-force-submit = Retry this game result

--- a/refbox/translations/es/refbox.ftl
+++ b/refbox/translations/es/refbox.ftl
@@ -434,6 +434,7 @@ portal-retry-all = REINTENTAR TODO
 portal-row-token-expired = Sesión del portal expirada — toca para iniciar sesión
 portal-row-stuck = Juego { $game } · Error al enviar resultado, toca para corregir
 portal-row-pending = Juego { $game } · Resultado no enviado, toca para reintentar
+portal-row-stats-pending = Juego { $game } · Estadísticas no enviadas, toca para reintentar
 portal-row-attempt-suffix = (intento { $attempts })
 portal-row-recent = Juego { $game } · Enviado hace { $mins } min
 portal-action-force-submit = Reintentar este resultado

--- a/refbox/translations/fr/refbox.ftl
+++ b/refbox/translations/fr/refbox.ftl
@@ -425,6 +425,7 @@ portal-retry-all = TOUT RÉESSAYER
 portal-row-token-expired = Session du portail expirée — touchez pour vous reconnecter
 portal-row-stuck = Match { $game } · Erreur d'envoi du résultat, touchez pour corriger
 portal-row-pending = Match { $game } · Résultat non envoyé, touchez pour réessayer
+portal-row-stats-pending = Match { $game } · Statistiques non envoyées, touchez pour réessayer
 portal-row-attempt-suffix = (tentative { $attempts })
 portal-row-recent = Match { $game } · Envoyé il y a { $mins } min
 portal-action-force-submit = Réessayer ce résultat

--- a/refbox/translations/id-ID/refbox.ftl
+++ b/refbox/translations/id-ID/refbox.ftl
@@ -423,6 +423,7 @@ portal-retry-all = ULANGI SEMUA
 portal-row-token-expired = Login Portal kedaluwarsa — ketuk untuk login ulang
 portal-row-stuck = Pertandingan { $game } Galat kirim skor, ketuk untuk perbaiki
 portal-row-pending = Pertandingan { $game } Skor belum terkirim, ketuk untuk coba lagi
+portal-row-stats-pending = Pertandingan { $game } Statistik belum terkirim, ketuk untuk coba lagi
 portal-row-attempt-suffix = (percobaan { $attempts })
 portal-row-recent = Pertandingan { $game } · Dikirim { $mins } mnt lalu
 portal-action-force-submit = Coba lagi kirim hasil pertandingan ini

--- a/refbox/translations/it-IT/refbox.ftl
+++ b/refbox/translations/it-IT/refbox.ftl
@@ -423,6 +423,7 @@ portal-retry-all = RIPROVA TUTTO
 portal-row-token-expired = Sessione Portale scaduta — tocca per accedere di nuovo
 portal-row-stuck = Partita { $game } Errore invio punteggio, tocca per correggere
 portal-row-pending = Partita { $game } Punteggio non inviato, tocca per riprovare
+portal-row-stats-pending = Partita { $game } Statistiche non inviate, tocca per riprovare
 portal-row-attempt-suffix = (tentativo { $attempts })
 portal-row-recent = Partita { $game } · Inviato { $mins } min fa
 portal-action-force-submit = Riprova questo risultato

--- a/refbox/translations/ja-JP/refbox.ftl
+++ b/refbox/translations/ja-JP/refbox.ftl
@@ -423,6 +423,7 @@ portal-retry-all = すべて再試行
 portal-row-token-expired = ポータルのログインが期限切れです — タップして再ログイン
 portal-row-stuck = 試合 { $game } のスコア送信エラー、タップして修正
 portal-row-pending = 試合 { $game } のスコアが未送信、タップして再試行
+portal-row-stats-pending = 試合 { $game } の統計が未送信、タップして再試行
 portal-row-recent = 試合 { $game } · { $mins } 分前に送信済み
 portal-row-attempt-suffix = (試行 { $attempts })
 portal-action-force-submit = この試合結果を再送信

--- a/refbox/translations/ko-KR/refbox.ftl
+++ b/refbox/translations/ko-KR/refbox.ftl
@@ -425,6 +425,7 @@ portal-retry-all = 모두 재시도
 portal-row-token-expired = Portal 로그인 만료됨 — 탭하여 다시 로그인
 portal-row-stuck = 경기 { $game } 점수 전송 오류, 탭하여 수정
 portal-row-pending = 경기 { $game } 점수 전송 안 됨, 탭하여 재시도
+portal-row-stats-pending = 경기 { $game } 통계 전송 안 됨, 탭하여 재시도
 portal-row-attempt-suffix = (시도 { $attempts }회)
 portal-row-recent = 경기 { $game } · { $mins }분 전 전송됨
 portal-action-force-submit = 이 경기 결과 재시도

--- a/refbox/translations/ms-MY/refbox.ftl
+++ b/refbox/translations/ms-MY/refbox.ftl
@@ -423,6 +423,7 @@ portal-retry-all = CUBA SEMULA SEMUA
 portal-row-token-expired = Log masuk portal tamat tempoh — ketik untuk log masuk semula
 portal-row-stuck = Perlawanan { $game } Ralat hantar markah, ketik untuk perbaiki
 portal-row-pending = Perlawanan { $game } Markah belum dihantar, ketik untuk cuba semula
+portal-row-stats-pending = Perlawanan { $game } Statistik belum dihantar, ketik untuk cuba semula
 portal-row-attempt-suffix = (percubaan { $attempts })
 portal-row-recent = Perlawanan { $game } · Dihantar { $mins } min lalu
 portal-action-force-submit = Cuba semula keputusan perlawanan ini

--- a/refbox/translations/nl-NL/refbox.ftl
+++ b/refbox/translations/nl-NL/refbox.ftl
@@ -423,6 +423,7 @@ portal-retry-all = ALLES OPNIEUW
 portal-row-token-expired = Portaal-login verlopen — tik om opnieuw in te loggen
 portal-row-stuck = Wedstrijd { $game } Fout bij verzenden score, tik om te herstellen
 portal-row-pending = Wedstrijd { $game } Score niet verzonden, tik om opnieuw te proberen
+portal-row-stats-pending = Wedstrijd { $game } Statistieken niet verzonden, tik om opnieuw te proberen
 portal-row-recent = Wedstrijd { $game } · Verzonden { $mins } min geleden
 portal-row-attempt-suffix = (poging { $attempts })
 portal-action-force-submit = Deze wedstrijduitslag opnieuw proberen

--- a/refbox/translations/pt-PT/refbox.ftl
+++ b/refbox/translations/pt-PT/refbox.ftl
@@ -423,6 +423,7 @@ portal-retry-all = REPETIR TUDO
 portal-row-token-expired = Sessão do portal expirou — toque para iniciar sessão novamente
 portal-row-stuck = Jogo { $game } Erro no envio do resultado, toque para corrigir
 portal-row-pending = Jogo { $game } Resultado não enviado, toque para tentar novamente
+portal-row-stats-pending = Jogo { $game } Estatísticas não enviadas, toque para tentar novamente
 portal-row-recent = Jogo { $game } · Enviado há { $mins } min
 portal-row-attempt-suffix = (tentativa { $attempts })
 portal-action-force-submit = Tentar novamente este resultado

--- a/refbox/translations/th-TH/refbox.ftl
+++ b/refbox/translations/th-TH/refbox.ftl
@@ -422,6 +422,7 @@ portal-retry-all = ลองใหม่ทั้งหมด
 portal-row-token-expired = การเข้าสู่ระบบพอร์ทัลหมดอายุ — แตะเพื่อเข้าสู่ระบบใหม่
 portal-row-stuck = เกม { $game } ส่งคะแนนผิดพลาด แตะเพื่อแก้ไข
 portal-row-pending = เกม { $game } ยังไม่ส่งคะแนน แตะเพื่อลองอีกครั้ง
+portal-row-stats-pending = เกม { $game } ยังไม่ส่งสถิติ แตะเพื่อลองอีกครั้ง
 portal-row-attempt-suffix = (ครั้งที่ { $attempts })
 portal-row-recent = เกม { $game } · ส่งเมื่อ { $mins } นาทีที่แล้ว
 portal-action-force-submit = ลองส่งผลเกมอีกครั้ง

--- a/refbox/translations/tl-PH/refbox.ftl
+++ b/refbox/translations/tl-PH/refbox.ftl
@@ -423,6 +423,7 @@ portal-retry-all = ULITIN LAHAT
 portal-row-token-expired = Nag-expire ang Portal login — pindutin para mag-login muli
 portal-row-stuck = Laro { $game } Error sa pagpapadala ng puntos, pindutin para ayusin
 portal-row-pending = Laro { $game } Hindi naipadala ang puntos, pindutin para subukan muli
+portal-row-stats-pending = Laro { $game } Hindi naipadala ang estadistika, pindutin para subukan muli
 portal-row-recent = Laro { $game } · Naipadala { $mins } min na ang nakalipas
 portal-row-attempt-suffix = (pagsubok { $attempts })
 portal-action-force-submit = Subukang muli ang resulta ng larong ito

--- a/refbox/translations/tr-TR/refbox.ftl
+++ b/refbox/translations/tr-TR/refbox.ftl
@@ -423,6 +423,7 @@ portal-retry-all = TÜMÜNÜ TEKRAR DENE
 portal-row-token-expired = Portal oturumu sona erdi — yeniden giriş için dokunun
 portal-row-stuck = Oyun { $game } Skor gönderme hatası, düzeltmek için dokunun
 portal-row-pending = Oyun { $game } Skor gönderilmedi, tekrar denemek için dokunun
+portal-row-stats-pending = Oyun { $game } İstatistikler gönderilmedi, tekrar denemek için dokunun
 portal-row-recent = Oyun { $game } · { $mins } dk önce gönderildi
 portal-row-attempt-suffix = (deneme { $attempts })
 portal-action-force-submit = Bu oyun sonucunu tekrar dene

--- a/refbox/translations/zh-CN/refbox.ftl
+++ b/refbox/translations/zh-CN/refbox.ftl
@@ -422,6 +422,7 @@ portal-retry-all = 全部重试
 portal-row-token-expired = Portal 登录已过期 — 点击重新登录
 portal-row-stuck = 比赛 { $game } 比分发送错误，点击修复
 portal-row-pending = 比赛 { $game } 比分未发送，点击重试
+portal-row-stats-pending = 比赛 { $game } 统计未发送，点击重试
 portal-row-attempt-suffix = （尝试 { $attempts } 次）
 portal-row-recent = 比赛 { $game } · { $mins } 分钟前已提交
 portal-action-force-submit = 重试此比赛结果


### PR DESCRIPTION
## What changed

When a game ends, the refbox sends two things to the UWH Portal separately: the **score** and the **player stats**. Until now, the refbox only treated a game as "done" when *both* uploads succeeded. On events that don't track stats, the portal rejects every stats upload — so those games never finished: they nagged yellow, turned red after 30 minutes, and re-sent the score over and over.

This change splits the two uploads and lets the **score** decide a game's status:

- **Score fails** → unchanged from today (the row goes yellow, turns red "stuck" after 30 minutes, the portal dot reflects it, and the background keeps retrying automatically).
- **Score succeeds but stats fail** → the game is treated as essentially sent. The portal **dot stays green**, and the game appears in the status list as one tappable yellow line: **"Game N Stats not sent, tap to retry."** It is **not** retried in the background and never turns red — it just waits. It is re-sent only when the operator taps that line or taps **RETRY ALL** (one fresh attempt each time).
- **Both succeed** → the game drops into the green "recently sent" list, as before.

In plain terms: a missing **score** still nags you; a missing **stat** now sits quietly as a "tap to retry" line without alarming you or looping in the background.

## Why

We confirmed (live, against dev event `1825-C`) that events the portal considers as *not requiring unique cap numbers* reject every stats upload with `400 "This event does not require unique cap numbers."`, while the score posts fine. Because the refbox required stats to succeed too, such a game could never finish — it stayed stuck forever and kept re-posting the score. The web refbox already treats stats as optional and completes the game on the score alone; this brings the Rust refbox in line, but with a richer model: the game stays visible and re-sendable rather than silently dropped.

## Scope

`refbox` crate only. No changes to `uwh-common`, the wire format, the portal client, or any `Cargo.toml`. Existing saved queues load unchanged (a new per-game flag defaults to "score not sent", so old `portal_queue.json` files behave exactly as before — no file-version bump).

Files: `refbox/src/portal_manager/{queue,health,mod}.rs`, `refbox/src/app/mod.rs`, `refbox/src/app/view_builders/portal_detail.rs`, and the new `portal-row-stats-pending` label in all 15 locales.

## How to verify

Automated: `just check` is green (rustfmt, clippy `-D warnings`, all tests incl. 361 in refbox, audit). New tests cover the score-OK/stats-fail transition, the indicator staying green, the one-shot retry (success and failure paths), the auto-retry loop skipping stats-pending games, the detail-row ordering, and backward-compatible loading of old queue files.

On-screen (recommended before merging, against a dev portal event that rejects stats, e.g. `1825-C`):
1. Finish a game on that event. **Expected:** the portal dot stays **green**, and the status list shows **"Game N Stats not sent, tap to retry"** — it does *not* go yellow/red, does *not* escalate after 30 minutes, and the background does *not* keep re-posting.
2. Tap that row, or tap **RETRY ALL**. **Expected:** exactly one fresh stats attempt; on this event it fails again and the row stays "Stats not sent" (no looping). On an event that *does* accept stats, the attempt succeeds and the game moves to "recently sent".
3. Make a **score** fail instead. **Expected:** unchanged behavior — yellow → red at 30 minutes, dot reflects it, background auto-retries.
4. Restart the app with a stats-pending game saved. **Expected:** it reloads as stats-pending (green dot, "Stats not sent" row) and is still retriable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
