### PR TITLE
feat(refbox): show BACK instead of CANCEL on config/edit pages when nothing has changed

### DIFF
--- a/refbox/src/app/languages.rs
+++ b/refbox/src/app/languages.rs
@@ -98,6 +98,26 @@ impl Language {
         }
     }
 
+    pub fn back_text(self) -> &'static str {
+        match self {
+            Self::English => "BACK",
+            Self::French => "RETOUR",
+            Self::Spanish => "ATRÁS",
+            Self::Mandarin => "返回",
+            Self::Korean => "뒤로",
+            Self::Italian => "INDIETRO",
+            Self::German => "ZURÜCK",
+            Self::Tagalog => "BUMALIK",
+            Self::Indonesian => "KEMBALI",
+            Self::Dutch => "TERUG",
+            Self::Japanese => "戻る",
+            Self::Malay => "KEMBALI",
+            Self::Portuguese => "VOLTAR",
+            Self::Thai => "กลับ",
+            Self::Turkish => "GERİ",
+        }
+    }
+
     pub fn apply_text(self) -> &'static str {
         match self {
             Self::English => "APPLY",
@@ -135,6 +155,41 @@ impl Language {
             Self::Portuguese => "REINICIAR PARA APLICAR",
             Self::Thai => "รีสตาร์ทเพื่อใช้งาน",
             Self::Turkish => "UYGULAMAK İÇİN YENİDEN BAŞLAT",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn back_text_matches_known_values() {
+        assert_eq!(Language::English.back_text(), "BACK");
+        assert_eq!(Language::French.back_text(), "RETOUR");
+        assert_eq!(Language::German.back_text(), "ZURÜCK");
+        assert_eq!(Language::Japanese.back_text(), "戻る");
+        assert_eq!(Language::Mandarin.back_text(), "返回");
+        // Back must read differently from Cancel in every language.
+        for lang in [
+            Language::English,
+            Language::French,
+            Language::Spanish,
+            Language::Mandarin,
+            Language::Korean,
+            Language::Italian,
+            Language::German,
+            Language::Tagalog,
+            Language::Indonesian,
+            Language::Dutch,
+            Language::Japanese,
+            Language::Malay,
+            Language::Portuguese,
+            Language::Thai,
+            Language::Turkish,
+        ] {
+            assert!(!lang.back_text().is_empty());
+            assert_ne!(lang.back_text(), lang.cancel_text());
         }
     }
 }

--- a/refbox/src/app/view_builders/beep_test_settings.rs
+++ b/refbox/src/app/view_builders/beep_test_settings.rs
@@ -931,7 +931,7 @@ fn make_beep_test_cancel_apply_footer<'a>(
     apply_message: Message,
     has_changes: bool,
 ) -> Element<'a, Message> {
-    let cancel = make_button(fl!("cancel"))
+    let cancel = make_button(cancel_or_back_label(has_changes))
         .style(red_button)
         .width(Length::Fill)
         .on_press(cancel_message);

--- a/refbox/src/app/view_builders/beep_test_settings.rs
+++ b/refbox/src/app/view_builders/beep_test_settings.rs
@@ -753,7 +753,12 @@ pub(in super::super) fn build_beep_test_language_picker<'a>(
         container(t).center(Length::Fill)
     };
 
-    let cancel_btn = button(make_label(selected.cancel_text(), selected_font))
+    let footer_label = if has_changes {
+        selected.cancel_text()
+    } else {
+        selected.back_text()
+    };
+    let cancel_btn = button(make_label(footer_label, selected_font))
         .padding(PADDING)
         .height(Length::Fixed(MIN_BUTTON_SIZE))
         .style(red_button)

--- a/refbox/src/app/view_builders/configuration.rs
+++ b/refbox/src/app/view_builders/configuration.rs
@@ -895,11 +895,10 @@ fn make_event_config_page<'a>(
     // does not block.
     let game_block_too_short =
         !using_uwhportal && matches!(game_block_validity(config), GameBlockValidity::TooShort);
-    let apply_enabled = page_has_changes(ConfigPage::Game, settings, page_entry_snapshot)
-        && !apply_blocked
-        && !game_block_too_short;
+    let has_changes = page_has_changes(ConfigPage::Game, settings, page_entry_snapshot);
+    let apply_enabled = has_changes && !apply_blocked && !game_block_too_short;
 
-    let cancel_btn = make_button(fl!("cancel"))
+    let cancel_btn = make_button(cancel_or_back_label(has_changes))
         .style(red_button)
         .width(Length::Fill)
         .on_press(Message::CancelConfigPage(ConfigPage::Game));

--- a/refbox/src/app/view_builders/configuration.rs
+++ b/refbox/src/app/view_builders/configuration.rs
@@ -1993,7 +1993,15 @@ fn make_language_select_page<'a>(
                 container(t).center(Length::Fill)
             };
 
-            let cancel_btn = button(make_label(selected.cancel_text(), selected_font))
+            // `apply_enabled` here is exactly page_has_changes(ConfigPage::Language, …)
+            // (the Language page has no extra Apply gate), so it doubles as the
+            // has-changes signal for the Cancel/Back swap.
+            let footer_label = if apply_enabled {
+                selected.cancel_text()
+            } else {
+                selected.back_text()
+            };
+            let cancel_btn = button(make_label(footer_label, selected_font))
                 .padding(PADDING)
                 .height(Length::Fixed(MIN_BUTTON_SIZE))
                 .style(red_button)

--- a/refbox/src/app/view_builders/configuration.rs
+++ b/refbox/src/app/view_builders/configuration.rs
@@ -432,9 +432,10 @@ fn make_cancel_apply_footer<'a>(
     // otherwise pressing Apply would only open a wasteful "fix something and try
     // again" dialog. Other pages have no committability gate.
     let apply_blocked = matches!(page, ConfigPage::Game) && edited.uwhportal_incomplete();
-    let apply_enabled = page_has_changes(page, edited, snapshot) && !apply_blocked;
+    let has_changes = page_has_changes(page, edited, snapshot);
+    let apply_enabled = has_changes && !apply_blocked;
 
-    let cancel = make_button(fl!("cancel"))
+    let cancel = make_button(cancel_or_back_label(has_changes))
         .style(red_button)
         .width(Length::Fill)
         .on_press(Message::CancelConfigPage(page));

--- a/refbox/src/app/view_builders/configuration.rs
+++ b/refbox/src/app/view_builders/configuration.rs
@@ -1677,13 +1677,15 @@ pub(in super::super) fn build_game_parameter_editor<'a>(
         LengthParameter::OvertimeHalfTime => config.ot_half_time_duration,
         LengthParameter::PreSuddenDeath => config.pre_sudden_death_duration,
     };
-    let apply_enabled = !matches!(game_block_validity, Some(GameBlockValidity::TooShort))
-        && param_edit_has_changes(length, old_length, param, single_half, config.single_half);
+    let has_changes =
+        param_edit_has_changes(length, old_length, param, single_half, config.single_half);
+    let apply_enabled =
+        !matches!(game_block_validity, Some(GameBlockValidity::TooShort)) && has_changes;
 
     col.push(vertical_space())
         .push(
             row![
-                make_button(fl!("cancel"))
+                make_button(cancel_or_back_label(has_changes))
                     .style(red_button)
                     .width(Length::Fill)
                     .on_press(Message::ParameterEditComplete { canceled: true }),

--- a/refbox/src/app/view_builders/fouls.rs
+++ b/refbox/src/app/view_builders/fouls.rs
@@ -60,7 +60,7 @@ pub(in super::super) fn build_foul_overview_page<'a>(
         .spacing(SPACING)
         .height(Length::Fill),
         row![
-            make_button(fl!("cancel"))
+            make_button(cancel_or_back_label(has_changes))
                 .style(red_button)
                 .width(Length::Fill)
                 .on_press(Message::FoulOverviewComplete { canceled: true }),

--- a/refbox/src/app/view_builders/penalties.rs
+++ b/refbox/src/app/view_builders/penalties.rs
@@ -63,7 +63,7 @@ pub(in super::super) fn build_penalty_overview_page<'a>(
         .spacing(SPACING)
         .height(Length::Fill),
         row![
-            make_button(fl!("cancel"))
+            make_button(cancel_or_back_label(has_changes))
                 .style(red_button)
                 .width(Length::Fill)
                 .on_press(Message::PenaltyOverviewComplete { canceled: true }),

--- a/refbox/src/app/view_builders/score_edit.rs
+++ b/refbox/src/app/view_builders/score_edit.rs
@@ -139,6 +139,15 @@ pub(in super::super) fn build_score_edit_view<'a>(
             )
     };
 
+    // Confirmation mode keeps the (disabled) "Cancel" label — the operator is
+    // committing a final score, not navigating back. Edit mode swaps to "Back"
+    // when the scores are unchanged.
+    let cancel_label = if is_confirmation {
+        fl!("cancel")
+    } else {
+        cancel_or_back_label(score_edit_has_changes(scores, old_scores))
+    };
+
     main_col
         .push(
             row![
@@ -153,7 +162,7 @@ pub(in super::super) fn build_score_edit_view<'a>(
         .push(vertical_space())
         .push(
             row![
-                make_button(fl!("cancel"))
+                make_button(cancel_label)
                     .on_press_maybe(cancel_btn_msg)
                     .style(red_button),
                 horizontal_space(),

--- a/refbox/src/app/view_builders/shared_elements.rs
+++ b/refbox/src/app/view_builders/shared_elements.rs
@@ -1016,6 +1016,23 @@ pub(super) fn config_string_game_num(
     (result, game_number)
 }
 
+/// Label for a config-page footer's red button: `CANCEL` when the page has
+/// pending edits to discard, `BACK` when it does not. "Cancel" implies
+/// discarding changes; with nothing to discard the button is plain navigation,
+/// so it reads "Back". Driven off the page's *has-changes* predicate, NOT its
+/// Apply-enabled flag — a page can hold pending changes that Apply still
+/// refuses (e.g. an incomplete portal selection), and those must still read
+/// "Cancel". Mirrors the cancel/back swap already used in `make_updates_page`.
+/// The two language pickers do not use this — they label their buttons in the
+/// *previewed* language via `Language::back_text()`.
+pub(super) fn cancel_or_back_label(has_changes: bool) -> String {
+    if has_changes {
+        fl!("cancel")
+    } else {
+        fl!("back")
+    }
+}
+
 pub(super) fn make_button<'a, Message: 'a + Clone, T: IntoFragment<'a>>(
     label: T,
 ) -> Button<'a, Message> {
@@ -1352,5 +1369,15 @@ mod tests {
     fn crosses_portal_rugby_to_hockey_is_true() {
         assert!(crosses_portal(Mode::Rugby, Mode::Hockey6V6));
         assert!(crosses_portal(Mode::Rugby, Mode::Hockey3V3));
+    }
+
+    #[test]
+    fn cancel_or_back_label_swaps_on_changes() {
+        // Pending changes → the "cancel" label; nothing to discard → the "back" label.
+        // Compared against the same fl! keys so the assertion holds regardless of which
+        // locale the loader resolves to.
+        assert_eq!(cancel_or_back_label(true), fl!("cancel"));
+        assert_eq!(cancel_or_back_label(false), fl!("back"));
+        assert_ne!(cancel_or_back_label(true), cancel_or_back_label(false));
     }
 }

--- a/refbox/src/app/view_builders/time_edit.rs
+++ b/refbox/src/app/view_builders/time_edit.rs
@@ -41,6 +41,8 @@ pub(in super::super) fn build_time_edit_view<'a>(
             .push(horizontal_space());
     }
 
+    let has_changes = time_edit_has_changes(time, timeout_time, old_time, old_timeout_time);
+
     column![
         make_game_time_button(
             snapshot,
@@ -58,7 +60,7 @@ pub(in super::super) fn build_time_edit_view<'a>(
             .align_x(Horizontal::Center),
         vertical_space(),
         row![
-            make_button(fl!("cancel"))
+            make_button(cancel_or_back_label(has_changes))
                 .style(red_button)
                 .width(Length::Fill)
                 .on_press(Message::TimeEditComplete { canceled: true }),
@@ -67,8 +69,7 @@ pub(in super::super) fn build_time_edit_view<'a>(
                 .style(green_button)
                 .width(Length::Fill)
                 .on_press_maybe(
-                    time_edit_has_changes(time, timeout_time, old_time, old_timeout_time)
-                        .then_some(Message::TimeEditComplete { canceled: false }),
+                    has_changes.then_some(Message::TimeEditComplete { canceled: false }),
                 ),
         ]
         .spacing(SPACING),

--- a/refbox/src/app/view_builders/warnings.rs
+++ b/refbox/src/app/view_builders/warnings.rs
@@ -54,7 +54,7 @@ pub(in super::super) fn build_warning_overview_page<'a>(
         .spacing(SPACING)
         .height(Length::Fill),
         row![
-            make_button(fl!("cancel"))
+            make_button(cancel_or_back_label(has_changes))
                 .style(red_button)
                 .width(Length::Fill)
                 .on_press(Message::WarningOverviewComplete { canceled: true }),


### PR DESCRIPTION
## What changed

On every settings-and-edit page that has an **Apply** button, the red footer button now reads
**BACK** when there are no unsaved changes (Apply is greyed out) and **CANCEL** as soon as you
change something — reverting to BACK if you undo the change. Pressing the button does exactly what
it did before; only the wording changes. "Cancel" implies discarding changes, so when there's
nothing to discard, "Back" is the more honest, less alarming label.

Covered pages:

- **Settings:** App Options, Display Options, Sound Options, Remotes, Game Options, the length
  editors (Half Length, Game Block, etc.), BeepTest → Sound settings, BeepTest → Edit Levels,
  and both Language pickers (main + BeepTest).
- **Game actions:** the Penalties, Warnings, and Fouls overview screens, the Time-edit screen,
  and the Score-edit screen.

The post-game **Score Confirmation** screen intentionally keeps "Cancel" (its button is disabled —
the operator must press Done to commit the final score, so "Back" would be misleading).

## Why

A greyed-out Apply next to a button labelled "Cancel" reads oddly — operators asked why it says
"Cancel" when they haven't changed anything. This removes that friction uniformly across the app.

## Scope

Changes are limited to the `refbox` crate's view builders plus a small helper:

- New shared helper `cancel_or_back_label(has_changes)` in `shared_elements.rs` (returns the
  existing `cancel` / `back` translation key based on whether the page has pending changes).
- New `Language::back_text()` in `languages.rs` for the two language pickers, which render their
  buttons in the language being previewed rather than the active locale (15 values, matching the
  existing `back` translation key in every locale).
- Label wired into the footers of `configuration.rs`, `beep_test_settings.rs`, `penalties.rs`,
  `warnings.rs`, `fouls.rs`, `score_edit.rs`, and `time_edit.rs`.

No new translation key is needed (`back` already exists in all 15 locales). No button's action or
save/commit model changed — this is label-only. No new dependencies.

The label is driven by each page's *has-changes* signal, not by whether Apply is clickable: on
Game Options, a pending-but-uncommittable change (incomplete portal selection, or a too-short Game
Block) correctly still reads CANCEL even while Apply is greyed.

## How to verify

Open any covered page: the red button reads **BACK** on entry, flips to **CANCEL** after you change
something, and returns to **BACK** if you undo it. Specific cases worth checking:

- **Game Options** (portal off): set a too-short Game Block → button stays **CANCEL** (you have an
  unsaved change even though Apply is greyed).
- **Language picker:** opens **BACK** in the current language; pick a different language → its
  word for **CANCEL** appears; reselect the current language → **BACK** again.
- **Score Confirmation** (post-game): button still shows a greyed-out **CANCEL**, not Back.

`just check` passes locally (formatting, linter with `-D warnings`, 375 tests, security audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
