### PR TITLE
fix(refbox): log and continue when saving settings to disk fails

### DIFF
--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -1502,7 +1502,9 @@ impl RefBoxApp {
     }
 
     fn persist_config(&self) {
-        confy::store(APP_NAME, None, &self.config).unwrap();
+        if let Err(e) = confy::store(APP_NAME, None, &self.config) {
+            error!("Failed to persist config: {e}");
+        }
     }
 
     /// Initialize `edited_settings` from the current app/TM state and
@@ -3616,7 +3618,9 @@ impl RefBoxApp {
                         let original = settings.original_language.unwrap_or(Language::English);
                         let needs_restart = font_family_id(original) != font_family_id(lang);
                         self.config.language = Some(lang);
-                        confy::store(crate::APP_NAME, None, &self.config).unwrap();
+                        if let Err(e) = confy::store(crate::APP_NAME, None, &self.config) {
+                            error!("Failed to persist config: {e}");
+                        }
                         if needs_restart {
                             // Kill every simulator child so they do not linger as
                             // orphans after the iced runtime closes its windows.
@@ -4480,7 +4484,9 @@ impl RefBoxApp {
                 if let Some(lang) = lang_opt {
                     let needs_restart = font_family_id(original) != font_family_id(lang);
                     self.config.language = Some(lang);
-                    confy::store(crate::APP_NAME, None, &self.config).unwrap();
+                    if let Err(e) = confy::store(crate::APP_NAME, None, &self.config) {
+                        error!("Failed to persist config: {e}");
+                    }
                     if needs_restart {
                         // Kill every simulator child so they do not linger as
                         // orphans after the iced runtime closes its windows.


### PR DESCRIPTION
## What changed
The app saves settings to disk in three places — the main settings-save helper (`persist_config`) and two language-change spots. Each used `confy::store(...).unwrap()`, so a failed write aborted the **entire** application. Now a failed write is logged and the app keeps running, matching the graceful pattern already used on the restart-save path.

## Why
On a Raspberry Pi with a full, worn, or read-only SD card (a realistic tournament condition), confirming the portal/event setup with APPLY — or merely changing the display mode or language — would crash the whole referee screen mid-game. Surfaced by the 2026-06-25 adversarial review of the portal token/event-selection flow (finding H6).

## Scope
`refbox` only — `refbox/src/app/mod.rs` (`persist_config` plus the two language-store sites). No happy-path behaviour change: the in-memory setting still applies for the session; only the on-failure behaviour changes (log + continue instead of crash).

## How to verify
- The change mirrors, line-for-line, the existing graceful restart-save pattern in the same file.
- `just check` passes (formatting, linter, all tests, security audit).
- Behaviour: a failed settings save no longer closes the app; the setting still takes effect for the session and the failure is recorded in the log.
