### PR TITLE
fix(refbox): clamp scroll index so a shrinking list can't crash

### DIFF
--- a/refbox/src/app/view_builders/portal_detail.rs
+++ b/refbox/src/app/view_builders/portal_detail.rs
@@ -46,6 +46,11 @@ pub(in super::super) fn build_portal_detail_page<'a>(
 
     let num_items = rows.len();
 
+    // Clamp a stale scroll position so a list that shrank under us (queued
+    // games uploading in the background) can't skip past the end and show
+    // blank rows. make_scroll_list clamps its own scrollbar math too.
+    let scroll_index = scroll_index.min(num_items.saturating_sub(PORTAL_DETAIL_LIST_LEN));
+
     // RETRY ALL is actionable only when there is at least one unsent
     // game (a stuck/red or pending/yellow row). Recent-success and
     // token-expired rows don't count.

--- a/refbox/src/app/view_builders/shared_elements.rs
+++ b/refbox/src/app/view_builders/shared_elements.rs
@@ -60,6 +60,13 @@ pub(super) fn make_scroll_list<'a, const LIST_LEN: usize>(
         main_col = main_col.push(button);
     }
 
+    // A remembered scroll index can outlive the list it points into: e.g. the
+    // portal detail list shrinks as queued games upload while the operator is
+    // scrolled down. Clamp it to the last valid offset so the
+    // `num_items - LIST_LEN - index` math below cannot underflow (a debug panic
+    // / release u16 wrap).
+    let index = index.min(num_items.saturating_sub(LIST_LEN));
+
     let top_len;
     let bottom_len;
     let can_scroll_up;
@@ -1379,5 +1386,27 @@ mod tests {
         assert_eq!(cancel_or_back_label(true), fl!("cancel"));
         assert_eq!(cancel_or_back_label(false), fl!("back"));
         assert_ne!(cancel_or_back_label(true), cancel_or_back_label(false));
+    }
+
+    #[test]
+    fn make_scroll_list_handles_index_past_end_of_shrunken_list() {
+        // Regression for the portal-detail crash (H7): a list can shrink under
+        // a remembered scroll position (queued games uploading in the
+        // background) so the index points past the new end. The scrollbar math
+        // `num_items - LIST_LEN - index` must not underflow (a debug panic /
+        // release u16 wrap). num_items=5 (> LIST_LEN=4, so it enters the
+        // subtraction branch) with index=6 (> num_items - LIST_LEN = 1) is the
+        // exact trigger; before the clamp this panicked here in debug builds.
+        const LIST_LEN: usize = 4;
+        let buttons: [Element<'static, Message>; LIST_LEN] =
+            core::array::from_fn(|_| horizontal_space().into());
+        let _list = make_scroll_list::<LIST_LEN>(
+            buttons,
+            5,
+            6,
+            text("test"),
+            ScrollOption::PortalDetail,
+            transparent_container,
+        );
     }
 }


### PR DESCRIPTION
## What changed
Scroll lists remembered their scroll offset as a plain index that was never re-checked when the underlying list shrank. The offset could then point past the new end, making the scrollbar math `num_items - LIST_LEN - index` underflow — a panic in debug builds, a `u16` wrap (garbled scrollbar) in release. The offset is now clamped to the current list length in two places: the shared `make_scroll_list` helper (hardening every scroll list) and the portal detail page before it builds rows (which also fixes blank, unscrollable rows when the list shrinks to ≤ the visible count). A regression test reproduces the exact underflow.

## Why
The portal status page's list shrinks on its own as queued games upload. An operator watching a backlog finish while scrolled down would crash the page (desktop) or garble it into an unusable strip (Pi) — at the worst possible moment. Surfaced by the 2026-06-25 adversarial review of the portal token/event-selection flow (finding H7).

## Scope
`refbox` only — `refbox/src/app/view_builders/shared_elements.rs` (clamp in `make_scroll_list` + regression test) and `refbox/src/app/view_builders/portal_detail.rs` (clamp `scroll_index`). The clamps only affect the previously out-of-range case; normal scrolling is unchanged.

## How to verify
- New test `make_scroll_list_handles_index_past_end_of_shrunken_list` fails before the fix (subtract-overflow panic at `shared_elements.rs`) and passes after — confirmed both ways.
- `just check` passes (formatting, linter, all tests, security audit).
