### PR TITLE
fix(refbox): always clear the Game Info REFRESH spinner when a refresh ends

### DIFF
--- a/refbox/src/app/message.rs
+++ b/refbox/src/app/message.rs
@@ -102,6 +102,11 @@ pub enum Message {
     /// for the same item confirms and removes it from the queue.
     PortalDiscardTapped(ItemId),
     RequestPortalRefresh,
+    /// Emitted when a portal schedule refresh triggered by
+    /// `RequestPortalRefresh` ends without delivering a schedule (e.g. the
+    /// fetch failed). Clears the Game Info REFRESH button's "Refreshing..."
+    /// spinner; the success case is cleared in `RecvSchedule`.
+    PortalRefreshFinished,
     /// Emitted when the operator taps RETRY ALL on the portal detail
     /// page. `update()` calls `PortalManager::retry_all`, which resets
     /// every queued game (including stuck ones) so the background task
@@ -316,6 +321,7 @@ impl Message {
             | Self::TimeUpdaterStarted(_)
             | Self::PortalEvent(_)
             | Self::PortalUiTick
+            | Self::PortalRefreshFinished
             | Self::BeepTestTick
             | Self::NoAction
             | Self::OpenNewDisplay => true,
@@ -451,6 +457,7 @@ impl PartialEq for Message {
             | (Self::ClosePortalAttentionAction, Self::ClosePortalAttentionAction)
             | (Self::PortalUiTick, Self::PortalUiTick)
             | (Self::RequestPortalRefresh, Self::RequestPortalRefresh)
+            | (Self::PortalRefreshFinished, Self::PortalRefreshFinished)
             | (Self::PortalRetryAll, Self::PortalRetryAll)
             | (Self::ShowWarnings, Self::ShowWarnings)
             | (Self::ShowParameterHelp, Self::ShowParameterHelp)
@@ -679,6 +686,7 @@ impl PartialEq for Message {
             | (Self::PortalForceSubmit(_), _)
             | (Self::PortalDiscardTapped(_), _)
             | (Self::RequestPortalRefresh, _)
+            | (Self::PortalRefreshFinished, _)
             | (Self::PortalRetryAll, _)
             | (Self::ShowWarnings, _)
             | (Self::ShowParameterHelp, _)

--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -2758,14 +2758,30 @@ impl RefBoxApp {
                 Task::none()
             }
             Message::RequestPortalRefresh => {
-                if let AppState::GameDetailsPage(ref mut is_refreshing) = self.app_state {
-                    *is_refreshing = true;
-                }
-                if let Some(ref event_id) = self.current_event_id {
-                    self.request_schedule(event_id.clone())
+                // Only spin the REFRESH button when there is actually an event
+                // to refresh; otherwise nothing would arrive to clear the flag.
+                if let Some(event_id) = self.current_event_id.clone() {
+                    if let AppState::GameDetailsPage(ref mut is_refreshing) = self.app_state {
+                        *is_refreshing = true;
+                    }
+                    // request_schedule yields NoAction when the fetch fails;
+                    // translate that into a refresh-finished signal so the
+                    // "Refreshing..." button cannot stick on a network error.
+                    self.request_schedule(event_id).map(|msg| match msg {
+                        Message::NoAction => Message::PortalRefreshFinished,
+                        other => other,
+                    })
                 } else {
                     Task::none()
                 }
+            }
+            Message::PortalRefreshFinished => {
+                // The refresh ended without a schedule (failure path). Stop the
+                // REFRESH spinner; the success path clears it in RecvSchedule.
+                if let AppState::GameDetailsPage(ref mut is_refreshing) = self.app_state {
+                    *is_refreshing = false;
+                }
+                Task::none()
             }
             Message::ShowWarnings => {
                 self.app_state = AppState::WarningsSummaryPage;
@@ -3940,6 +3956,12 @@ impl RefBoxApp {
                 Task::none()
             }
             Message::RecvSchedule(event_id, mut schedule) => {
+                // A manual REFRESH (RequestPortalRefresh) spins the Game Info
+                // button until a schedule arrives. Clear it for every success
+                // path here, not just the between-games branch below.
+                if let AppState::GameDetailsPage(ref mut is_refreshing) = self.app_state {
+                    *is_refreshing = false;
+                }
                 if let Some(id) = self.current_event_id.as_ref().or_else(|| {
                     self.edited_settings
                         .as_ref()
@@ -4025,12 +4047,6 @@ impl RefBoxApp {
                                                 std::mem::drop(tm);
                                                 self.config.game = new_game_config;
                                                 return self.apply_snapshot(snapshot);
-                                            }
-                                            if let AppState::GameDetailsPage(
-                                                ref mut is_refreshing,
-                                            ) = self.app_state
-                                            {
-                                                *is_refreshing = false;
                                             }
                                         }
                                     }


### PR DESCRIPTION
## What changed
Tapping REFRESH on the Game Info page no longer leaves the button stuck on "Refreshing…". The spinner now clears whenever a refresh ends, in every case:
- the schedule arrives in **any** game state (not just between games),
- the fetch **fails** (e.g. network down) — the previously silent failure is mapped to a new `PortalRefreshFinished` signal that clears the spinner,
- there is **no event** linked — the spinner is never turned on in the first place.

## Why
The 2026-06-25 adversarial review of the portal flow (finding H2) found the spinner was only cleared in one deeply-guarded success sub-path (between games, no edit open, next game found in the schedule). In the common cases — most importantly **refreshing during a live game** — it hung forever, leaving the operator unable to refresh again without leaving and re-opening the page.

## Scope
`refbox` only — `refbox/src/app/mod.rs` (the `RequestPortalRefresh` and `RecvSchedule` handlers, plus a small new `PortalRefreshFinished` handler) and one new message variant in `refbox/src/app/message.rs`. It only touches the spinner flag; nothing about what is fetched or any game state changes, and the shared `request_schedule` fetch (5 callers) is left untouched.

## How to verify
- `just check` passes (formatting, linter, all tests, security audit).
- Logic traced against all four cases (live-game success, no-next-game success, network failure, no event).
- This lives in the iced message-handling loop, which this codebase does not unit-test (its tests cover pure helpers and the game clock; the `.feature` files are written specs, not executed), so it is verified by code-tracing and the build/lint/test gate rather than a new unit test — consistent with PR #1519.
