### PR TITLE
fix(refbox): keep the portal event id consistent across apply and token check

### DIFF
--- a/refbox/src/app/message.rs
+++ b/refbox/src/app/message.rs
@@ -166,7 +166,10 @@ pub enum Message {
     RecvTeamsList(EventId, TeamList),
     RecvSchedule(EventId, Schedule),
     RecvPortalToken(PortalTokenResponse),
-    RecvTokenValid(bool),
+    /// Result of a portal token-validity check for a specific event. Carries
+    /// the `EventId` it was checked for so a late reply for a previously
+    /// selected event can be dropped instead of overwriting the current one.
+    RecvTokenValid(EventId, bool),
     StopClock,
     StartClock,
     /// Operator pressed Start in BeepTest mode.
@@ -312,7 +315,7 @@ impl Message {
             | Self::RecvTeamsList(_, _)
             | Self::RecvSchedule(_, _)
             | Self::RecvPortalToken(_)
-            | Self::RecvTokenValid(_)
+            | Self::RecvTokenValid(_, _)
             | Self::TimeUpdaterStarted(_)
             | Self::PortalEvent(_)
             | Self::PortalUiTick
@@ -635,7 +638,7 @@ impl PartialEq for Message {
             (Self::RecvTeamsList(a, b), Self::RecvTeamsList(c, d)) => a == c && b == d,
             (Self::RecvSchedule(a, b), Self::RecvSchedule(c, d)) => a == c && b == d,
             (Self::RecvPortalToken(a), Self::RecvPortalToken(b)) => a == b,
-            (Self::RecvTokenValid(a), Self::RecvTokenValid(b)) => a == b,
+            (Self::RecvTokenValid(a, b), Self::RecvTokenValid(c, d)) => a == c && b == d,
             (Self::SetTeamTimeoutCount(a), Self::SetTeamTimeoutCount(b)) => a == b,
             (Self::SetTeamTimeoutLength(a), Self::SetTeamTimeoutLength(b)) => a == b,
             (Self::UpdatesCheckDone(a), Self::UpdatesCheckDone(b)) => a == b,
@@ -716,7 +719,7 @@ impl PartialEq for Message {
             | (Self::RecvTeamsList(_, _), _)
             | (Self::RecvSchedule(_, _), _)
             | (Self::RecvPortalToken(_), _)
-            | (Self::RecvTokenValid(_), _)
+            | (Self::RecvTokenValid(_, _), _)
             | (Self::StopClock, _)
             | (Self::StartClock, _)
             | (Self::BeepTestStart, _)

--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -779,15 +779,18 @@ impl RefBoxApp {
         if let Some(client) = &self.uwhportal_client {
             // why this cannot panic: see `request_event_list` above.
             let request = client.lock().unwrap().verify_token(event_id);
+            // Tag the result with the event it was checked for so the handler
+            // can drop a late reply for a previously-selected event.
+            let event_id = event_id.clone();
             Task::future(async move {
                 match request.await {
                     Ok(()) => {
                         info!("Portal token validated");
-                        Message::RecvTokenValid(true)
+                        Message::RecvTokenValid(event_id, true)
                     }
                     Err(e) => {
                         error!("Portal token validity check failed: {e}");
-                        Message::RecvTokenValid(false)
+                        Message::RecvTokenValid(event_id, false)
                     }
                 }
             })
@@ -1174,10 +1177,19 @@ impl RefBoxApp {
         }
 
         std::mem::drop(tm);
-        self.using_uwhportal = edited.using_uwhportal;
-        self.current_event_id = edited.current_event_id.clone();
-        self.current_court = edited.current_court.clone();
-        self.schedule = edited.schedule.clone();
+        // Snapshot the fields we need so the immutable borrow on `edited` ends
+        // before we call `set_current_event_id` (which takes `&mut self`).
+        let using_uwhportal = edited.using_uwhportal;
+        let event_id = edited.current_event_id.clone();
+        let current_court = edited.current_court.clone();
+        let schedule = edited.schedule.clone();
+
+        self.using_uwhportal = using_uwhportal;
+        // Route through set_current_event_id so portal_event_id stays in sync
+        // for the background health check (ADR 011 amendment 2026-04-23).
+        self.set_current_event_id(event_id);
+        self.current_court = current_court;
+        self.schedule = schedule;
 
         None
     }
@@ -4101,9 +4113,15 @@ impl RefBoxApp {
                 trace!("AppState changed to {:?}", self.app_state);
                 task
             }
-            Message::RecvTokenValid(valid) => {
+            Message::RecvTokenValid(event_id, valid) => {
                 if let Some(ref mut settings) = self.edited_settings {
-                    settings.uwhportal_token_valid = Some(valid);
+                    // Drop a stale reply for an event the operator has since
+                    // switched away from, so a late "valid" for a previous
+                    // event can't paint a false OK for the current one. The
+                    // schedule and auto-court paths already guard on event id.
+                    if settings.current_event_id.as_ref() == Some(&event_id) {
+                        settings.uwhportal_token_valid = Some(valid);
+                    }
                 }
                 Task::none()
             }


### PR DESCRIPTION
## What changed
Two event-identity slips in the portal setup flow, both fixed by reusing patterns already proven elsewhere in the same file:

- **M1 (false red dot):** One "apply" commit path wrote `self.current_event_id` directly instead of through `set_current_event_id`, so the `portal_event_id` handle the background health task reads went stale. After correcting a mis-link to a *different* event with the same timings, the health check kept testing the **old** event and showed a red connection dot (and greyed REFRESH) despite a valid login. The write now routes through `set_current_event_id`, matching the two sibling apply paths.
- **M3 (false green "OK"):** `check_uwhportal_auth` returned `RecvTokenValid(bool)` with no event tag, so an out-of-order reply for a previously-selected event could set a green "OK" for the current one. The reply now carries its `EventId` (like `RecvSchedule`), and the handler ignores it when it no longer matches the selected event.

## Why
Both were flagged by the 2026-06-25 adversarial review of the portal flow (findings M1, M3). They're misleading-indicator bugs: the box could report the portal connection broken when it isn't, or the login valid when it isn't — undermining trust in the indicators during a tournament. Neither loses score data.

## Scope
`refbox` only — `refbox/src/app/mod.rs` (the apply commit path, `check_uwhportal_auth`, and the `RecvTokenValid` handler) and `refbox/src/app/message.rs` (the `RecvTokenValid` variant now carries an `EventId`). No change to the health-check or auth network logic; the shared `request_schedule`/`set_current_event_id` are reused, not modified.

## How to verify
- `just check` passes (formatting, linter, all tests, security audit).
- M1 mirrors the sibling apply path's snapshot + `set_current_event_id` routing (mod.rs); M3 mirrors `RecvSchedule`'s event-id tagging and the event-id guard the schedule/auto-court paths already use.
- These live in the iced message/commit logic the codebase doesn't unit-test, so they're verified by code-tracing + the build/lint/test gate rather than a new unit test — consistent with PR #1519/#1539.
