### PR TITLE
fix(refbox): treat an unreachable portal as offline, not login-expired

### DIFF
--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -2690,6 +2690,9 @@ impl RefBoxApp {
                     PortalEvent::TokenStatus(valid) => {
                         self.portal_manager.on_token_status(valid);
                     }
+                    PortalEvent::TokenUnreachable => {
+                        self.portal_manager.on_token_unreachable();
+                    }
                 }
                 // The background task fires verify_token on its cadence
                 // (~5 min when healthy). Use that heartbeat to refresh the link

--- a/refbox/src/portal_manager/health.rs
+++ b/refbox/src/portal_manager/health.rs
@@ -100,17 +100,26 @@ pub trait PortalTaskIo {
 
 #[derive(Debug)]
 pub enum PortalCallError {
-    /// The portal call did not succeed. We cannot distinguish a conflict
-    /// (409), token-expiry (401), or network/5xx failure from the current
-    /// uwh-common API — all non-success outcomes collapse to this one
-    /// variant. See ADR 011 amendment (2026-04-21) for the rationale.
+    /// The portal responded, but with a non-success status. From the
+    /// current uwh-common API we cannot tell a conflict (409), token
+    /// rejection (401), or server error (5xx) apart — they all collapse to
+    /// this one variant. See ADR 011 amendment (2026-04-21) for the
+    /// rationale.
     Failed(String),
+    /// The portal could not be reached at all: the HTTP exchange never
+    /// completed (DNS, connect, timeout, TLS, or a dropped response). The
+    /// login may be perfectly valid — this is a connectivity problem, not a
+    /// token problem — so callers must not push the operator to re-login.
+    /// Produced by `classify_error` downcasting the underlying `reqwest`
+    /// transport error.
+    Unreachable(String),
 }
 
 impl std::fmt::Display for PortalCallError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Failed(msg) => write!(f, "portal call failed: {msg}"),
+            Self::Unreachable(msg) => write!(f, "portal unreachable: {msg}"),
         }
     }
 }
@@ -164,7 +173,19 @@ async fn run_task(
                             current_health = HealthState::Green;
                             let _ = event_tx.send(PortalEvent::TokenStatus(true)).await;
                         }
-                        Err(_) => {
+                        Err(PortalCallError::Unreachable(_)) => {
+                            // Couldn't reach the portal (wifi blip / outage).
+                            // Degrade the indicator, but do NOT report a token
+                            // problem: the login may be fine, so the UI must
+                            // not push the operator to re-login or grey out the
+                            // schedule REFRESH button.
+                            current_health = HealthState::Red;
+                            let _ = event_tx.send(PortalEvent::TokenUnreachable).await;
+                        }
+                        Err(PortalCallError::Failed(_)) => {
+                            // The portal responded but rejected the request (or
+                            // returned a server error). Treat as a token
+                            // problem so the operator is prompted to re-login.
                             current_health = HealthState::Red;
                             let _ = event_tx.send(PortalEvent::TokenStatus(false)).await;
                         }
@@ -414,6 +435,83 @@ mod tests {
         tokio::task::yield_now().await;
 
         assert!(count.load(std::sync::atomic::Ordering::SeqCst) >= 1);
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn unreachable_verify_emits_token_unreachable_not_token_status() {
+        // A verify_token that cannot reach the portal must surface as
+        // TokenUnreachable (a connectivity problem), never TokenStatus(false)
+        // — which the UI reads as "login expired" and uses to grey out the
+        // schedule REFRESH button.
+        let io = FakeIo {
+            verify_results: Mutex::new(vec![Err(PortalCallError::Unreachable("blip".into()))]),
+            verify_count: Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            scores_results: Mutex::new(vec![]),
+            scores_count: Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            stats_results: Mutex::new(vec![]),
+            stats_count: Arc::new(std::sync::atomic::AtomicU32::new(0)),
+        };
+        let mut handle = spawn(io);
+
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_secs(3)).await;
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_millis(500)).await;
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+
+        let events = drain_events(&mut handle.event_rx);
+        assert!(
+            events
+                .iter()
+                .any(|ev| matches!(ev, PortalEvent::TokenUnreachable)),
+            "unreachable verify must emit TokenUnreachable, got {events:?}"
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|ev| matches!(ev, PortalEvent::TokenStatus(_))),
+            "unreachable verify must NOT emit TokenStatus, got {events:?}"
+        );
+        drop(handle);
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn rejected_verify_emits_token_status_false() {
+        // A verify_token that reached the portal but was rejected must
+        // surface as TokenStatus(false) so the operator is prompted to
+        // re-login — and must NOT be confused with an outage.
+        let io = FakeIo {
+            verify_results: Mutex::new(vec![Err(PortalCallError::Failed("401".into()))]),
+            verify_count: Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            scores_results: Mutex::new(vec![]),
+            scores_count: Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            stats_results: Mutex::new(vec![]),
+            stats_count: Arc::new(std::sync::atomic::AtomicU32::new(0)),
+        };
+        let mut handle = spawn(io);
+
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_secs(3)).await;
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_millis(500)).await;
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+
+        let events = drain_events(&mut handle.event_rx);
+        assert!(
+            events
+                .iter()
+                .any(|ev| matches!(ev, PortalEvent::TokenStatus(false))),
+            "rejected verify must emit TokenStatus(false), got {events:?}"
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|ev| matches!(ev, PortalEvent::TokenUnreachable)),
+            "rejected verify must NOT emit TokenUnreachable, got {events:?}"
+        );
+        drop(handle);
     }
 
     /// Build a `QueueFile` with a single freshly-queued item (no prior

--- a/refbox/src/portal_manager/mod.rs
+++ b/refbox/src/portal_manager/mod.rs
@@ -99,13 +99,22 @@ impl UwhPortalIo {
     }
 }
 
-/// Collapse a portal-client error into `PortalCallError::Failed`. The
-/// uwh-common API does not distinguish token-expiry, conflict, server
-/// error, or network failure — they all come back as `Box<dyn Error>` —
-/// so the background task treats every failure the same way (retry later
-/// on its cadence). See ADR 011 amendment (2026-04-21).
-fn classify_error<E: std::fmt::Display>(e: E) -> health::PortalCallError {
-    health::PortalCallError::Failed(e.to_string())
+/// Classify a portal-client error. A `reqwest` transport error means the
+/// HTTP exchange never completed (DNS, connect, timeout, TLS, or a dropped
+/// response): the portal is unreachable, which is a connectivity problem,
+/// NOT a token rejection. A non-OK HTTP response surfaces as uwh-common's
+/// own error type instead and is mapped to `Failed` (could be a 401 token
+/// rejection, a 409 conflict, or a 5xx). Keeping the two apart lets the
+/// indicator avoid mislabelling an ordinary wifi drop as "login expired".
+/// The retry/cadence logic treats both the same (retry later); only the
+/// `verify_token` token-status path acts on the distinction. See ADR 011
+/// amendment (2026-04-21).
+fn classify_error(e: Box<dyn std::error::Error>) -> health::PortalCallError {
+    if e.downcast_ref::<reqwest::Error>().is_some() {
+        health::PortalCallError::Unreachable(e.to_string())
+    } else {
+        health::PortalCallError::Failed(e.to_string())
+    }
 }
 
 /// Parse an `event_id` string (from a `QueuedItem`) into an `EventId`.
@@ -220,7 +229,8 @@ pub struct PortalIndicatorState {
     /// This is the specific Red cause that makes a schedule refresh
     /// pointless (it can only fail until the operator re-logs-in), so
     /// the game-info REFRESH button greys out on it. A Red caused only
-    /// by a stuck queue item leaves this `false`.
+    /// by a stuck queue item — or by a connectivity problem (the portal
+    /// is unreachable, but the login may be fine) — leaves this `false`.
     pub token_expired: bool,
 }
 
@@ -252,11 +262,17 @@ pub enum PortalEvent {
     /// so the auto-retry loop, the stuck escalation, and the indicator
     /// all stop treating it as outstanding. Carries the item id.
     ScoreSentStatsPending(ItemId),
-    /// Result of the latest periodic `verify_token` probe.
-    /// `true` = portal accepted the token, `false` = rejected. The
+    /// Result of the latest periodic `verify_token` probe that reached the
+    /// portal. `true` = portal accepted the token, `false` = rejected. The
     /// main-thread handler maps this onto `token_known_problem` so the
     /// indicator and detail-page row reflect the current token state.
     TokenStatus(bool),
+    /// The latest periodic `verify_token` probe could not reach the portal
+    /// at all (a connectivity failure, not a token rejection). The
+    /// main-thread handler flags a connection problem so the indicator
+    /// degrades WITHOUT claiming the login expired — the operator keeps the
+    /// schedule REFRESH button and is not pushed into a pointless re-login.
+    TokenUnreachable,
 }
 
 /// One row rendered on the portal detail page. The ordering of the
@@ -322,10 +338,17 @@ pub fn is_item_stuck(item: &QueuedItem, now: OffsetDateTime) -> bool {
 pub struct PortalManager {
     queue: QueueFile,
     check_in_flight: bool,
-    /// Set true when the last `verify_token` probe failed. Cleared on
-    /// the next successful probe or by `token_refreshed()` after the
-    /// operator re-logs-in.
+    /// Set true when the last `verify_token` probe reached the portal and
+    /// it rejected the token. Cleared on the next reached probe that
+    /// succeeds, or by `token_refreshed()` after the operator re-logs-in.
     token_known_problem: bool,
+    /// Set true when the last `verify_token` probe could not reach the
+    /// portal at all (connectivity failure). Drives the Red indicator like
+    /// a token problem does, but deliberately leaves `token_expired` false
+    /// so an ordinary wifi drop neither greys the schedule REFRESH button
+    /// nor shows the re-login row. Cleared by the next probe that reaches
+    /// the portal (whether it accepts or rejects the token).
+    connection_problem: bool,
     indicator_state: PortalIndicatorState,
     command_tx: mpsc::Sender<health::PortalCommand>,
     config_dir: std::path::PathBuf,
@@ -348,6 +371,7 @@ impl PortalManager {
             queue,
             check_in_flight,
             token_known_problem,
+            connection_problem: false,
             indicator_state: PortalIndicatorState::default(),
             command_tx: tx,
             config_dir: std::env::temp_dir(),
@@ -394,7 +418,7 @@ impl PortalManager {
     }
 
     fn recompute_indicator(&mut self) {
-        let health = if self.needs_attention() {
+        let health = if self.needs_attention() || self.connection_problem {
             HealthState::Red
         } else if self.check_in_flight || self.has_score_pending_items() {
             HealthState::Yellow
@@ -450,6 +474,7 @@ impl PortalManager {
             queue,
             check_in_flight: false,
             token_known_problem: false,
+            connection_problem: false,
             indicator_state: PortalIndicatorState::default(),
             command_tx,
             config_dir: config_dir.to_path_buf(),
@@ -485,6 +510,7 @@ impl PortalManager {
             check_in_flight: false,
             // Key: indicator will show Red so the operator sees the problem.
             token_known_problem: true,
+            connection_problem: false,
             indicator_state: PortalIndicatorState::default(),
             command_tx,
             config_dir: std::env::temp_dir(),
@@ -663,6 +689,21 @@ impl PortalManager {
     /// notice a silent token expiration without having to open Settings.
     pub fn on_token_status(&mut self, valid: bool) {
         self.token_known_problem = !valid;
+        // A probe that reached the portal (whether it accepted or rejected
+        // the token) proves connectivity, so clear any prior "unreachable"
+        // flag.
+        self.connection_problem = false;
+        self.recompute_indicator();
+    }
+
+    /// Apply a `verify_token` probe that could not reach the portal at all.
+    /// Flags a connection problem so the indicator degrades to Red, but
+    /// deliberately leaves `token_known_problem` untouched: a connectivity
+    /// failure is not evidence the login expired, so the operator is not
+    /// pushed to re-login and the schedule REFRESH button stays usable.
+    /// The next probe that reaches the portal clears this flag.
+    pub fn on_token_unreachable(&mut self) {
+        self.connection_problem = true;
         self.recompute_indicator();
     }
 
@@ -903,6 +944,43 @@ mod tests {
     fn healthy_connection_is_not_token_expired() {
         let m = PortalManager::new_for_test(QueueFile::empty(), false, false);
         assert!(!m.indicator_state().token_expired);
+    }
+
+    #[test]
+    fn connection_problem_is_red_but_not_token_expired() {
+        // An ordinary wifi drop (verify_token could not reach the portal)
+        // must degrade the indicator to Red WITHOUT reporting token_expired:
+        // the login may be fine, so the schedule REFRESH button must stay
+        // usable and no re-login row should appear.
+        let mut m = PortalManager::new_for_test(QueueFile::empty(), false, false);
+        m.on_token_unreachable();
+        assert_eq!(m.indicator_state().health, HealthState::Red);
+        assert!(!m.indicator_state().token_expired);
+    }
+
+    #[test]
+    fn reaching_the_portal_clears_a_prior_connection_problem() {
+        // Once a probe reaches the portal again (here: the token is
+        // accepted), the connection problem clears and the indicator
+        // returns to Green.
+        let mut m = PortalManager::new_for_test(QueueFile::empty(), false, false);
+        m.on_token_unreachable();
+        assert_eq!(m.indicator_state().health, HealthState::Red);
+        m.on_token_status(true);
+        assert_eq!(m.indicator_state().health, HealthState::Green);
+        assert!(!m.indicator_state().token_expired);
+    }
+
+    #[test]
+    fn server_rejection_after_outage_reports_token_expired() {
+        // A probe that reaches the portal but is rejected clears the
+        // connectivity flag and reports a genuine token problem (the
+        // re-login row + greyed REFRESH).
+        let mut m = PortalManager::new_for_test(QueueFile::empty(), false, false);
+        m.on_token_unreachable();
+        m.on_token_status(false);
+        assert_eq!(m.indicator_state().health, HealthState::Red);
+        assert!(m.indicator_state().token_expired);
     }
 
     #[test]


### PR DESCRIPTION
## What changed
When the refbox's background connection check to the portal fails, it used to assume a single cause — "your portal login has expired" — regardless of what actually went wrong. So an ordinary wifi blip would (1) tell the operator to log in again (pointless and impossible while offline — the login is fine) and (2) grey out the **REFRESH** button on the Game Info screen, the one control that would re-pull the schedule once the connection returns.

This PR teaches the refbox to tell two situations apart:

- **Couldn't reach the portal at all** (wifi drop / no internet): the connection dot still turns red so the operator sees something is off, but it does **not** show the re-login row and **leaves REFRESH usable**. The dot clears itself on the next successful check once the connection is back.
- **Reached the portal and it rejected the token** (a genuine expired/invalid login): unchanged — shows the re-login row and greys REFRESH.

## Why
A red dot that says "log in again" during a routine wifi hiccup sends the operator chasing a login problem that doesn't exist, and disables the button that would actually recover the schedule. This is finding **M7** of the portal token/event-selection adversarial review.

## Scope
Limited to `refbox`:
- `refbox/src/portal_manager/health.rs` — new `PortalCallError::Unreachable` variant; the background `verify_token` failure branch now emits a new `TokenUnreachable` event for connectivity failures vs. the existing `TokenStatus(false)` for genuine rejections.
- `refbox/src/portal_manager/mod.rs` — `classify_error` downcasts the `reqwest` transport error to decide unreachable-vs-rejected; new `connection_problem` flag drives the red dot without setting `token_expired`; new `on_token_unreachable` handler; `on_token_status` clears the flag on any reached probe.
- `refbox/src/app/mod.rs` — 3-line handler routing the new event.

No changes to `uwh-common`, the wire format, the view builders, or the `Message` enum.

**Known limitation:** the portal's error responses carry no status code the refbox can read, so a *sustained server error* (the portal responding with errors, as opposed to being unreachable) is still treated as a token problem. Rare; the common wifi-blip case is fully fixed. Closing it completely would require a `uwh-common` change, deliberately out of scope here.

## How to verify
- **Automated:** `just check` passes. 5 new tests lock in the behavior — an unreachable probe degrades the indicator to red without `token_expired`, recovers to green when the portal is reached again, and a reached-but-rejected probe still reports a token problem.
- **By behavior:** with the portal linked, briefly drop wifi → the connection dot goes red but Game Info's REFRESH stays tappable and no "log in again" prompt appears; restore wifi → the dot returns to green on the next background check.
