### PR TITLE
fix(refbox): delete the portal-link note when switching off mid-game

### DIFF
--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -1041,6 +1041,15 @@ impl RefBoxApp {
         self.schedule = None;
         self.config.game = manual_config;
         self.persist_config();
+        // Delete the saved portal-link note now that the portal is off, so a
+        // later restart starts dormant instead of silently re-linking the old
+        // event. Mirrors the Apply path's `persist_config(); persist_link_session();`
+        // pairing: the mid-game switch-to-manual confirmation returns early into
+        // a ConfirmationPage and never reaches that Apply-path call, so without
+        // this the note would survive and the restore on next launch would turn
+        // the portal back on (finding H3). With the portal now off and no event
+        // selected, `persist_link_session` takes its delete branch.
+        self.persist_link_session();
     }
 
     /// Commit the Game-Options slice (game config + game number) to the live state.


### PR DESCRIPTION
## What changed
When the operator turns the portal **off in the middle of a game**, the refbox now deletes the saved "I'm linked to this event" note (`portal_link.json`) — just as it already does when the portal is switched off between games or from the normal settings Apply.

## Why
Before this fix, turning the portal off mid-game cleared it on screen but left a stale link note on disk. The mid-game switch is the one route that commits through a confirmation page, so it returns early and never reaches the Apply handler's `persist_link_session()` call that deletes the note when the portal is off. On the next restart (language change, self-update, crash, power cycle — all routine on the poolside Pi), startup restore would read that stale note and **silently re-enable the portal**, re-select the old event, and resume counting it down — undoing the operator's deliberate "off." This is finding **H3** of the portal token/event-selection adversarial review.

## Scope
One function in `refbox/src/app/mod.rs`: `clear_portal_selections_to_manual` now calls `self.persist_link_session()` right after `self.persist_config()`, mirroring the Apply path's `persist_config(); persist_link_session();` pairing. With the portal now off and no event selected, `persist_link_session` takes its delete branch.

This single call site is the chokepoint for "go manual" (3 callers): it fixes both mid-game confirmation arms (`EndGameAndApply`, `KeepGameAndApply`) and is harmless for the between-games caller, which already deletes the note again via the Apply handler (idempotent).

No changes to `uwh-common`, the game clock / state machine, the startup-restore logic, or any view. No new dependencies.

## How to verify
- **Automated:** `just check` passes (382 refbox tests green). The pieces this fix relies on are already covered by their own tests and unchanged: deleting the note (`link_session::delete`) and the startup restore gate (`decide_restore`). The app `update()`/method layer isn't unit-testable here (no test constructor for the app), matching how the sibling portal fixes (H2/M1/M3) shipped.
- **By behavior:** link the portal, start a game, then turn the portal off mid-game (choose either *End game* or *Keep game*). Quit and relaunch the refbox → it comes back manual/dormant, **not** re-linked to the old event with a running clock. (Before the fix, it would re-link.)
