### PR TITLE
fix(refbox): throttle portal retries and advance the attempt counter

### DIFF
--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -2684,6 +2684,9 @@ impl RefBoxApp {
                     PortalEvent::ScoreSentStatsPending(id) => {
                         self.portal_manager.on_score_sent_stats_pending(id);
                     }
+                    PortalEvent::ItemAttempted { id, attempts, at } => {
+                        self.portal_manager.on_item_attempted(id, attempts, at);
+                    }
                     PortalEvent::HealthChanged | PortalEvent::ItemUpdated => {
                         self.portal_manager.ui_tick();
                     }

--- a/refbox/src/portal_manager/health.rs
+++ b/refbox/src/portal_manager/health.rs
@@ -148,13 +148,32 @@ async fn run_task(
             _ = sleep(POLL_INTERVAL) => {
                 // Tick: try each eligible queued item, then health-check if due.
                 let now = OffsetDateTime::now_utc();
-                for item in &queue_snapshot.items {
-                    if !item.score_sent
-                        && is_item_retry_eligible(item, now)
-                        && attempt_item(&io, item, &event_tx).await
-                    {
+                for idx in 0..queue_snapshot.items.len() {
+                    let item = &queue_snapshot.items[idx];
+                    if item.score_sent || !is_item_retry_eligible(item, now) {
+                        continue;
+                    }
+                    if attempt_item(&io, item, &event_tx).await {
                         last_success = Some(TokioInstant::now());
                     }
+                    // Record the attempt on our own snapshot copy so this task
+                    // self-throttles to ITEM_RETRY_INTERVAL: `is_item_retry_eligible`
+                    // keys off `last_attempt_at`, so without stamping it here the item
+                    // would look eligible on every POLL_INTERVAL tick and we'd re-send
+                    // it every ~2s instead of every ~15s. Also notify the main thread
+                    // so it mirrors the attempt onto the authoritative queue (the honest
+                    // "(attempt N)" counter and the detail-page retry countdown). See
+                    // finding H4.
+                    let item = &mut queue_snapshot.items[idx];
+                    item.attempts = item.attempts.saturating_add(1);
+                    item.last_attempt_at = Some(now);
+                    let _ = event_tx
+                        .send(PortalEvent::ItemAttempted {
+                            id: item.id.clone(),
+                            attempts: item.attempts,
+                            at: now,
+                        })
+                        .await;
                 }
 
                 let elapsed = match current_health {
@@ -853,6 +872,90 @@ mod tests {
         assert_eq!(scores_count.load(std::sync::atomic::Ordering::SeqCst), 1);
         assert_eq!(stats_count.load(std::sync::atomic::Ordering::SeqCst), 1);
 
+        drop(handle);
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn failing_item_is_attempted_once_then_throttled_not_every_poll() {
+        // Regression for the retry-flood (H4): a failing item used to be
+        // re-sent on every POLL_INTERVAL (~2s) tick because `last_attempt_at`
+        // was never stamped, so `is_item_retry_eligible` saw `None` forever.
+        // The task now stamps it on its own snapshot copy, so within one
+        // ITEM_RETRY_INTERVAL the item is attempted exactly once. (Wall-clock
+        // barely advances under paused time, so the 15s throttle stays closed
+        // across the poll ticks below.)
+        let scores_count = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let io = FakeIo {
+            verify_results: Mutex::new(vec![]),
+            verify_count: Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            scores_results: Mutex::new(vec![
+                Err(PortalCallError::Failed("x".into())),
+                Err(PortalCallError::Failed("x".into())),
+                Err(PortalCallError::Failed("x".into())),
+                Err(PortalCallError::Failed("x".into())),
+            ]),
+            scores_count: scores_count.clone(),
+            stats_results: Mutex::new(vec![]),
+            stats_count: Arc::new(std::sync::atomic::AtomicU32::new(0)),
+        };
+        let handle = spawn(io);
+        handle
+            .command_tx
+            .send(PortalCommand::QueueUpdated(queue_with_one_eligible_item()))
+            .await
+            .unwrap();
+
+        // Fire several poll ticks, all within ITEM_RETRY_INTERVAL.
+        for _ in 0..4 {
+            tokio::task::yield_now().await;
+            tokio::time::advance(Duration::from_secs(2)).await;
+            tokio::task::yield_now().await;
+            tokio::task::yield_now().await;
+        }
+
+        assert_eq!(
+            scores_count.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "a failing item must be attempted once then throttled, not re-sent on every poll"
+        );
+        drop(handle);
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn attempt_emits_item_attempted_event_with_incremented_count() {
+        let io = FakeIo {
+            verify_results: Mutex::new(vec![]),
+            verify_count: Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            scores_results: Mutex::new(vec![Err(PortalCallError::Failed("x".into()))]),
+            scores_count: Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            stats_results: Mutex::new(vec![]),
+            stats_count: Arc::new(std::sync::atomic::AtomicU32::new(0)),
+        };
+        let mut handle = spawn(io);
+        let queue = queue_with_one_eligible_item();
+        let expected_id = queue.items[0].id.clone();
+        handle
+            .command_tx
+            .send(PortalCommand::QueueUpdated(queue))
+            .await
+            .unwrap();
+
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_secs(3)).await;
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_millis(500)).await;
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+
+        let events = drain_events(&mut handle.event_rx);
+        assert!(
+            events.iter().any(|ev| matches!(
+                ev,
+                PortalEvent::ItemAttempted { id, attempts, .. }
+                    if id == &expected_id && *attempts == 1
+            )),
+            "an attempt must emit ItemAttempted with the item id and attempts == 1, got {events:?}"
+        );
         drop(handle);
     }
 }

--- a/refbox/src/portal_manager/mod.rs
+++ b/refbox/src/portal_manager/mod.rs
@@ -257,6 +257,18 @@ pub enum PortalEvent {
     HealthChanged,
     ItemResolved(ItemId),
     ItemUpdated,
+    /// The background task just made a retry attempt for this queued item.
+    /// Carries the item's new attempt count and the timestamp, so the main
+    /// thread mirrors them onto the authoritative queue: the on-screen
+    /// "(attempt N)" counter advances and the detail-page "retry in 0:NN"
+    /// countdown is computed from a real `last_attempt_at`. The background
+    /// task self-throttles on its own snapshot copy, so this is purely for
+    /// the operator-facing record (no resend is triggered).
+    ItemAttempted {
+        id: ItemId,
+        attempts: u32,
+        at: OffsetDateTime,
+    },
     /// The score posted successfully but the stats upload failed. The
     /// main thread flips the item to stats-pending (`score_sent = true`)
     /// so the auto-retry loop, the stuck escalation, and the indicator
@@ -744,6 +756,25 @@ impl PortalManager {
         self.push_queue_snapshot();
     }
 
+    /// Mirror a background retry attempt onto the authoritative queue. Sets
+    /// the item's attempt count and last-attempt timestamp from the values the
+    /// background task reported, so the detail page shows an honest
+    /// "(attempt N)" and a live retry countdown. A no-op for an unknown id (the
+    /// item resolved or was discarded since the attempt was made).
+    ///
+    /// Deliberately does NOT persist to disk or push a fresh snapshot:
+    /// `attempts` / `last_attempt_at` are runtime hints (a restart legitimately
+    /// re-attempts immediately and re-counts from zero), the background task
+    /// self-throttles on its own snapshot copy, and skipping the write avoids an
+    /// SD-card save on every retry tick. The next queue mutation persists the
+    /// current values.
+    pub fn on_item_attempted(&mut self, id: ItemId, attempts: u32, at: OffsetDateTime) {
+        if let Some(item) = self.find_mut(&id) {
+            item.attempts = attempts;
+            item.last_attempt_at = Some(at);
+        }
+    }
+
     /// Called from the UI thread after the background task reports that
     /// a queued item was successfully posted to the portal. Removes the
     /// item from the queue, records it in the recent-success ring
@@ -981,6 +1012,43 @@ mod tests {
         m.on_token_status(false);
         assert_eq!(m.indicator_state().health, HealthState::Red);
         assert!(m.indicator_state().token_expired);
+    }
+
+    #[test]
+    fn on_item_attempted_sets_attempts_and_last_attempt_at() {
+        // The background task reports each retry attempt; the authoritative
+        // queue must reflect the new count and timestamp so the detail page's
+        // "(attempt N)" counter advances and the retry countdown is real.
+        let item = mk_young_item();
+        let id = item.id.clone();
+        let q = QueueFile {
+            version: 1,
+            items: vec![item],
+        };
+        let mut m = PortalManager::new_for_test(q, false, false);
+        assert_eq!(m.queue.items[0].attempts, 0);
+        assert!(m.queue.items[0].last_attempt_at.is_none());
+
+        let at = OffsetDateTime::now_utc();
+        m.on_item_attempted(id, 1, at);
+        assert_eq!(m.queue.items[0].attempts, 1);
+        assert_eq!(m.queue.items[0].last_attempt_at, Some(at));
+    }
+
+    #[test]
+    fn on_item_attempted_with_unknown_id_is_noop() {
+        // An attempt reported for an item that resolved/was discarded since
+        // must be a silent no-op, never a panic.
+        let mut m = PortalManager::new_for_test(QueueFile::empty(), false, false);
+        m.on_item_attempted(
+            ItemId {
+                event_id: "gone".into(),
+                game_number: "G9".into(),
+            },
+            3,
+            OffsetDateTime::now_utc(),
+        );
+        assert!(m.queue.items.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## What changed
When the portal is unreachable or rejecting and games are waiting in the upload queue, the refbox used to **re-send each queued game roughly every 2 seconds** (instead of the intended ~15s) and show a frozen "(attempt 0)" next to each waiting game — so it looked like nothing was happening while the box actually hammered the poolside wifi.

Now each queued game is retried at the intended ~15-second spacing, and the "(attempt N)" count climbs with each real attempt, so the operator can see the background retry is alive.

## Why
The background uploader works from a *copy* of the queue and never recorded that it had just tried an item, so `last_attempt_at` stayed `None` forever — `is_item_retry_eligible` always returned `true`, defeating the 15-second throttle — and `attempts` was never incremented, so the detail-page counter sat at 0. On congested tournament wifi, re-sending every ~2s can worsen the outage and risk rate-limiting. This is finding **H4** of the portal token/event-selection adversarial review.

## Scope
`refbox` only:
- `refbox/src/portal_manager/health.rs` — the `run_task` poll loop now, after attempting each eligible item, stamps `last_attempt_at` and bumps `attempts` on its own snapshot copy (so it self-throttles to `ITEM_RETRY_INTERVAL` without depending on a snapshot round-trip), and emits a new `PortalEvent::ItemAttempted { id, attempts, at }`.
- `refbox/src/portal_manager/mod.rs` — new `on_item_attempted` mirrors those values onto the authoritative queue (honest "(attempt N)" + the detail-page retry countdown).
- `refbox/src/app/mod.rs` — one match arm routing the new event.

No change to `uwh-common`, the `Message` enum (the inner `PortalEvent` is matched opaquely), the `POLL_INTERVAL` / `ITEM_RETRY_INTERVAL` values, or the stats / force / discard behavior. Deliberately no disk write per attempt: `attempts` / `last_attempt_at` are runtime hints (a restart legitimately re-attempts immediately and re-counts from zero), and skipping the write avoids an SD-card save on every retry tick (the H6 concern). The next queue mutation persists the current values.

## How to verify
- **Automated:** `just check` passes (refbox tests 386, +4). New tests: a failing item is attempted **once** within the retry window and not re-sent on every poll (fails on the old code); an attempt emits `ItemAttempted` with an incremented count; and `on_item_attempted` records the count + timestamp on the authoritative queue (and is a no-op for an unknown id). The ≥15s throttle-release boundary is already covered by the existing `is_item_retry_eligible` tests.
- **By behavior:** with the portal unreachable and a game queued, open the portal status page (tap the colored dot). The "(attempt N)" number should climb step by step rather than sitting at 0, and the box should retry on the slow ~15s cadence rather than continuously.
