### PR TITLE
fix(refbox): re-arm APPLY after declining the portal-switch prompt

### DIFF
--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -1231,6 +1231,15 @@ impl RefBoxApp {
                     ConfigPage::Main
                 };
                 self.revert_from_snapshot();
+                // revert_from_snapshot() consumes the page-entry snapshot, so
+                // re-capture one for the landing page. Without this the App
+                // Options APPLY button compares against a missing snapshot,
+                // reads "nothing changed", and stays greyed for every later
+                // edit until the operator leaves and re-enters the page
+                // (finding H1). Mirrors navigate_to_parent's re-capture; a
+                // no-op for the Main landing, where capture_snapshot_for
+                // early-returns for navigation-only pages.
+                self.capture_snapshot_for(landing);
                 AppState::EditGameConfig(landing)
             }
             ConfirmationOption::GoBack => AppState::EditGameConfig(ConfigPage::Game),


### PR DESCRIPTION
## What changed
On the App Options screen, changing App Mode in a way that crosses the portal boundary (e.g. Hockey → Rugby) and pressing APPLY raises a "switch portal and restart?" confirmation. If the operator taps **Cancel** (declines), the APPLY button is now correctly re-armed so the next change can be applied normally.

## Why
Before this fix, declining that prompt left APPLY **greyed out and stuck**: any further setting changed on the page wouldn't enable APPLY, so settings silently couldn't be saved — the only escape was leaving the page and re-entering it.

Declining routes through `apply_game_confirmation`'s `DiscardChanges` arm, which calls `revert_from_snapshot()` (consuming the page-entry snapshot) and lands back on App Options without taking a fresh one. APPLY only enables when the edited settings differ from that snapshot, so with none present it reads "nothing changed." This is finding **H1** of the portal token/event-selection adversarial review — the same class as the already-fixed APPLY-stuck bugs #1264 / #1275.

## Scope
One arm in `refbox/src/app/mod.rs` (`apply_game_confirmation`'s `DiscardChanges`): after `revert_from_snapshot()`, re-capture the landing page's snapshot via `capture_snapshot_for(landing)`, mirroring the existing re-capture in `navigate_to_parent`. This is a no-op for the Main landing (`capture_snapshot_for` early-returns for navigation-only pages), so only the App / `PortalTenantSwitch` case is affected.

No changes to `uwh-common`, the `Message` enum, any view, or the accept/restart path.

## How to verify
- **Automated:** `just check` passes. This path (the settings/confirmation `update()` flow) isn't unit-testable here — same as #1264/#1275 — so it's verified by code-tracing the proven sibling pattern (`navigate_to_parent`) plus `just check`.
- **By behavior:** App Options → change App Mode across the portal boundary (Hockey ↔ Rugby) → APPLY → tap **Cancel** on "switch portal and restart?". You land back on App Options; now change any setting → APPLY lights up and saves normally. (Before the fix, APPLY stayed greyed for every subsequent change.)
