### PR TITLE
fix(refbox): degrade visibly when the portal client fails to start

### DIFF
--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -1741,46 +1741,56 @@ impl RefBoxApp {
         // sees the problem — but the core game clock and scoring still
         // work, which is what matters at the pool.
         //
-        // The production `UwhPortalIo` is built from a clone of the
-        // shared `UwhPortalClient` handle so that token mutations on the
-        // UI thread are immediately visible to the background retry task.
-        // If the client failed to construct (only possible on a bad
-        // https-only config), fall back to `NullIo` for the non-degraded
-        // path — no portal calls will be made, but the queue can still
-        // accept items and persist them for a later attempt.
+        // The production `UwhPortalIo` is built from a clone of the shared
+        // `UwhPortalClient` handle so that token mutations on the UI thread are
+        // immediately visible to the background retry task. If the client
+        // failed to construct (only possible on a bad https-only config), we go
+        // straight to degraded mode (a visible red indicator, no background
+        // task) rather than a `NullIo` uploader — a `NullIo`-backed manager
+        // would report success for every call, keeping the dot green while it
+        // fake-resolved (deleted) every queued game and nothing reached the
+        // portal (finding M6).
         std::fs::create_dir_all(&config_dir).ok();
 
-        // Try `config_dir` first, then `std::env::temp_dir()`, then fall
-        // back to degraded mode. Each attempt gets its own freshly-built
-        // `PortalTaskIo`: either the real `UwhPortalIo` (if we have a
-        // portal client) or `NullIo` (if client construction failed
-        // earlier). The I/O is generic in the `PortalTaskIo` impl so the
-        // retry helper is a closure that owns the attempt.
-        let try_new_manager = |dir: &std::path::Path| match &uwhportal_client {
-            Some(client) => PortalManager::new(
-                dir,
-                UwhPortalIo::new(Arc::clone(client), Arc::clone(&portal_event_id)),
-            ),
-            None => PortalManager::new(dir, crate::portal_manager::NullIo),
-        };
-
-        let (portal_manager, portal_event_rx) = match try_new_manager(&config_dir) {
-            Ok(pair) => pair,
-            Err(primary_err) => {
-                error!(
-                    "portal manager startup failed on config dir ({}); falling back to temp dir",
-                    primary_err
+        let (portal_manager, portal_event_rx) = match &uwhportal_client {
+            // No portal client: degraded mode (red, not-sending). See above.
+            None => {
+                warn!(
+                    "portal client unavailable; portal subsystem starting in degraded \
+                     (red, not-sending) mode — no results will be uploaded this session"
                 );
-                match try_new_manager(&std::env::temp_dir()) {
+                PortalManager::new_degraded()
+            }
+            // Have a client: build the real uploader, trying `config_dir` first,
+            // then `std::env::temp_dir()`, then falling back to degraded mode if
+            // even the temp dir refuses I/O. Each attempt gets its own freshly
+            // built `UwhPortalIo`, so the retry helper is a closure.
+            Some(client) => {
+                let try_new_manager = |dir: &std::path::Path| {
+                    PortalManager::new(
+                        dir,
+                        UwhPortalIo::new(Arc::clone(client), Arc::clone(&portal_event_id)),
+                    )
+                };
+                match try_new_manager(&config_dir) {
                     Ok(pair) => pair,
-                    Err(secondary_err) => {
+                    Err(primary_err) => {
                         error!(
-                            "portal manager also failed on temp dir ({}); \
-                             continuing in degraded mode — retry queue will not persist, \
-                             portal indicator will show red",
-                            secondary_err
+                            "portal manager startup failed on config dir ({}); falling back to temp dir",
+                            primary_err
                         );
-                        PortalManager::new_degraded()
+                        match try_new_manager(&std::env::temp_dir()) {
+                            Ok(pair) => pair,
+                            Err(secondary_err) => {
+                                error!(
+                                    "portal manager also failed on temp dir ({}); \
+                                     continuing in degraded mode — retry queue will not persist, \
+                                     portal indicator will show red",
+                                    secondary_err
+                                );
+                                PortalManager::new_degraded()
+                            }
+                        }
                     }
                 }
             }

--- a/refbox/src/portal_manager/mod.rs
+++ b/refbox/src/portal_manager/mod.rs
@@ -20,12 +20,20 @@ use crate::portal_manager::queue::{QueueFile, QueuedItem};
 /// detail page. When a sixth success lands, the oldest is evicted.
 pub const RECENT_SUCCESS_CAP: usize = 5;
 
-/// Placeholder `PortalTaskIo` used in tests and in the degraded-fallback
-/// startup path. This type is intentionally do-nothing — the background
-/// retry task spawned by `PortalManager::new` calls its methods but they
-/// always succeed without contacting any server.
+/// Placeholder `PortalTaskIo` used by the unit tests: a do-nothing uploader
+/// whose calls always succeed without contacting any server.
+///
+/// Intentionally NOT a production type. A failed portal-client construction
+/// must route to `new_degraded()` (a visible red, not-sending mode), never to
+/// a `NullIo`-backed manager — `NullIo` reports success for every call, so its
+/// background task would keep the indicator green and fake-resolve (delete)
+/// every queued game while nothing reached the portal (finding M6). The
+/// `#[cfg(test)]` gate makes that misuse impossible: the type does not exist in
+/// a release build.
+#[cfg(test)]
 pub(crate) struct NullIo;
 
+#[cfg(test)]
 #[async_trait::async_trait]
 impl health::PortalTaskIo for NullIo {
     async fn verify_token(&self) -> Result<(), health::PortalCallError> {


### PR DESCRIPTION
## What changed
If the portal connection software fails to start up (for example a broken security-certificate setup on a locked-down field Pi or a loaner laptop), the refbox now shows the connection dot **red** and clearly **does not send** anything — instead of the previous behaviour, where it showed every game as a green "submitted" while silently sending nothing.

## Why
Previously, when the portal client couldn't construct, startup fell back to a do-nothing uploader (`NullIo`) that **reports success for every call**. Its background task kept the dot green and fake-resolved every queued game — recording a green "submitted" and **deleting the queued item** — while nothing reached the portal. An operator could finish a whole tournament believing every result was uploaded when nothing was, and a restart would not re-send (the queue had been emptied). This is finding **M6** of the portal token/event-selection adversarial review.

## Scope
`refbox` only:
- `refbox/src/app/mod.rs` — startup now routes a missing portal client straight to `PortalManager::new_degraded()` (a visible red indicator with **no** background task), matching the existing total-I/O-failure fallback, instead of building a `NullIo`-backed manager.
- `refbox/src/portal_manager/mod.rs` — `NullIo` is gated behind `#[cfg(test)]`, so it exists only in the test build. This makes the fake-success production fallback impossible to reintroduce by mistake (a future attempt to wire it in won't compile), and its doc comment now spells out why.

No changes to `uwh-common`, the `Message` enum, any view, the normal (working-client) startup path, or the degraded-mode design.

## How to verify
- **Automated:** `just check` passes (386 refbox tests). The degraded mode this now routes to is already covered by tests: `new_degraded_indicator_has_token_known_problem_and_no_spawned_task` (red indicator, no task) and `new_degraded_does_not_touch_disk`.
- **Compile-time guarantee:** `NullIo` is test-only, so production cannot fall back to a fake-success uploader.
- **By behavior:** with a deliberately broken portal config so the client can't start, launch the refbox → the portal dot is red and games are not reported as sent, rather than showing a false green "submitted".
