### PR TITLE
fix(refbox): make the show-countdown toggle take effect on Apply

### DIFF
--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -955,6 +955,7 @@ impl RefBoxApp {
         let show_behind_schedule_time = edited.show_behind_schedule_time;
         let confirm_score = edited.confirm_score;
         let audible_countdown = edited.audible_countdown;
+        let hide_time = edited.hide_time;
 
         // Cross-portal Mode change requires explicit confirmation and an app
         // restart. Raise the confirmation before committing any fields so that
@@ -980,6 +981,17 @@ impl RefBoxApp {
         self.config.show_behind_schedule_time = show_behind_schedule_time;
         self.config.confirm_score = confirm_score;
         self.config.audible_countdown = audible_countdown;
+        // The "show countdown for last 10 seconds" toggle lives on this App page,
+        // so its commit must happen here. Notify the update server only when it
+        // actually changed. Bounded channel with one message per Apply from the
+        // GUI loop, so it cannot be full; Closed means the update-server task is
+        // gone (application-fatal), matching the other unwrap sites.
+        if self.config.hide_time != hide_time {
+            self.config.hide_time = hide_time;
+            self.update_sender
+                .set_hide_time(self.config.hide_time)
+                .unwrap();
+        }
         None
     }
 
@@ -989,12 +1001,6 @@ impl RefBoxApp {
         };
         self.config.hardware.white_on_right = edited.white_on_right;
         self.config.hardware.brightness = edited.brightness;
-        if self.config.hide_time != edited.hide_time {
-            self.config.hide_time = edited.hide_time;
-            self.update_sender
-                .set_hide_time(self.config.hide_time)
-                .unwrap();
-        }
         self.config.front_display_layout = edited.front_display_layout;
         // A real LED panel always renders Default; mirror the button's gating so
         // Apply never pushes a full-screen layout to the hardware path.

--- a/refbox/src/app/update_sender.rs
+++ b/refbox/src/app/update_sender.rs
@@ -1164,6 +1164,43 @@ mod test {
         assert!(matches!(error_formatter(closed), TrySendError::Closed(_)));
     }
 
+    #[test]
+    fn show_countdown_off_hides_final_under_10s_not_at_10s() {
+        // "Show countdown for last 10 seconds" = OFF (hide_time = true): during
+        // the last <10s of a pre-game break the displayed time switches to the
+        // upcoming period length instead of the live countdown. The window is 10s
+        // (it was 15s before v0.4.x); this guards the threshold against drift.
+        let (_tx, rx) = mpsc::channel(1);
+        let mut server = Server::new(rx, vec![], true, false, FrontDisplayLayout::Default);
+        let snap = |secs| GameSnapshot {
+            current_period: GamePeriod::BetweenGames,
+            secs_in_period: secs,
+            next_period_len_secs: Some(900),
+            ..Default::default()
+        };
+        // 9s left -> hidden: shows the 900s (15:00) upcoming period length.
+        server.encode(snap(9));
+        assert_eq!(server.snapshot.secs_in_period, 900);
+        // Exactly 10s left -> still the live countdown (threshold is `< 10`).
+        server.encode(snap(10));
+        assert_eq!(server.snapshot.secs_in_period, 10);
+    }
+
+    #[test]
+    fn show_countdown_on_never_hides_final_seconds() {
+        // hide_time = false ("show countdown" = ON): the live countdown is always
+        // shown, even in the final seconds of a pre-game break.
+        let (_tx, rx) = mpsc::channel(1);
+        let mut server = Server::new(rx, vec![], false, false, FrontDisplayLayout::Default);
+        server.encode(GameSnapshot {
+            current_period: GamePeriod::BetweenGames,
+            secs_in_period: 3,
+            next_period_len_secs: Some(900),
+            ..Default::default()
+        });
+        assert_eq!(server.snapshot.secs_in_period, 3);
+    }
+
     #[tokio::test]
     async fn open_serial_ports_skips_ports_that_fail_to_open() {
         let bad = tokio_serial::new("/dev/refbox_nonexistent_test_port", 115200);


### PR DESCRIPTION
## What changed
The "Show countdown for last 10 seconds" toggle on the **App** settings page now actually takes effect when you press Apply. Previously, flipping it there did nothing to the scoreboard display.

## Why
When this setting was relocated to the App settings page, the code that carries the change into the live scoreboard output was left behind in the old **Display** page's Apply. So pressing Apply on the App page lit up the button as if it saved, but never applied the change — the setting was effectively a dead switch.

## Scope
Limited to the `refbox` crate:
- `refbox/src/app/mod.rs` — move the commit (config write + update-server notify) from `apply_display_options` into `apply_app_options`, where the toggle now lives.
- `refbox/src/app/update_sender.rs` — add two `Server::encode` regression tests.

No changes to game logic, the wire format, or `uwh-common`.

## How to verify
1. Settings → **App** page → set **SHOW COUNTDOWN FOR LAST 10 SECONDS** to **NO** → **Apply**.
2. Start a game; during the pre-game countdown, the final ~10 seconds on the **scoreboard / LED display** (the simulator panel) show the upcoming half's length (e.g. `15:00`) instead of counting `10, 9, 8…`.
3. Flip to **YES**, Apply → the final seconds count down live again.

Note: this setting only changes the scoreboard/LED output, **not** the operator's control clock — watch the simulator scoreboard window, not the main control screen.

`just check` passes. Two new automated tests lock in the 10-second threshold (it was 15s before v0.4.x) and cover both toggle states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
