### PR TITLE
fix(refbox): repaint whole screen on display-mode change

### DIFF
--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -196,6 +196,10 @@ pub struct RefBoxApp {
     /// `Message::BeepTestCycleDisplayLayout`.
     beep_test_display_layout: crate::sim_frame::FrontDisplayLayout,
     list_all_events: bool,
+    /// `true` when started with `--fullscreen` (the Pi). Read by
+    /// `force_display_repaint` to decide whether a display-mode change needs a
+    /// full-screen repaint. See `should_force_repaint`.
+    fullscreen: bool,
     mouse_alarm_held: bool,
     spacebar_held: bool,
     alarm_delay_token: u64,
@@ -1859,6 +1863,7 @@ impl RefBoxApp {
             beep_test_has_run: false,
             beep_test_display_layout: crate::sim_frame::FrontDisplayLayout::Default,
             list_all_events,
+            fullscreen,
             mouse_alarm_held: false,
             spacebar_held: false,
             alarm_delay_token: 0,
@@ -2843,7 +2848,7 @@ impl RefBoxApp {
                 self.config.display_mode = next;
                 crate::app::theme::set_display_mode(next);
                 self.persist_config();
-                Task::none()
+                self.force_display_repaint()
             }
             Message::ChangeConfigPage(new_page) => {
                 if let AppState::EditGameConfig(ref mut page) = self.app_state {
@@ -5262,6 +5267,36 @@ impl RefBoxApp {
             text_color,
         }
     }
+
+    /// Force the whole window to repaint after a display-mode change.
+    ///
+    /// On the Pi (Linux/tiny-skia, fullscreen) a palette-only change otherwise
+    /// leaves stale background pixels in one of the double-buffered frames,
+    /// producing a persistent flicker. Briefly leaving and re-entering
+    /// fullscreen is a genuine surface resize, which makes iced clear its
+    /// per-buffer layer history so both buffers repaint in the new palette.
+    /// Gated off everywhere else (no bug there; would just blink for nothing).
+    /// Mirrors the startup fullscreen task at the top of `new()`.
+    fn force_display_repaint(&self) -> Task<Message> {
+        if !should_force_repaint(self.fullscreen) {
+            return Task::none();
+        }
+        window::get_latest().and_then(|w| {
+            window::change_mode(w, window::Mode::Windowed)
+                .chain(window::change_mode(w, window::Mode::Fullscreen))
+        })
+    }
+}
+
+/// Whether changing the display mode must force a full-screen repaint.
+///
+/// Only the Pi hits the flicker: Linux uses the tiny-skia software renderer
+/// with a double-buffered Wayland surface, and a palette-only change repaints
+/// just one of the two buffers (the other keeps stale background pixels). On
+/// Windows/Mac (wgpu) and on windowed/single-buffered setups there is no such
+/// bug, so we never force a repaint — avoiding a needless on-screen blink.
+const fn should_force_repaint(fullscreen: bool) -> bool {
+    cfg!(target_os = "linux") && fullscreen
 }
 
 /// Decide whether a remembered link note should be restored at startup:
@@ -5548,5 +5583,30 @@ mod countdown_beep_tests {
         ] {
             assert!(!should_play_countdown_beep(p, 5, 6, true), "{p:?}");
         }
+    }
+}
+
+#[cfg(test)]
+mod repaint_gate_tests {
+    use super::*;
+
+    #[test]
+    fn windowed_never_repaints() {
+        // A windowed window has no stale second buffer to clear, on any platform.
+        assert!(!should_force_repaint(false));
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn linux_fullscreen_repaints() {
+        // The Pi (Linux/tiny-skia, fullscreen) is the one place the flicker occurs.
+        assert!(should_force_repaint(true));
+    }
+
+    #[test]
+    #[cfg(not(target_os = "linux"))]
+    fn non_linux_never_repaints() {
+        // Windows/Mac use wgpu and don't have the bug; never force a repaint.
+        assert!(!should_force_repaint(true));
     }
 }


### PR DESCRIPTION
## What changed

On the Raspberry Pi, switching the display mode (e.g. to **High Contrast**) left a flickering
patchwork of old and new colors that **persisted** until the app was restarted. This change makes
the whole screen repaint immediately when the display mode changes, so the new palette applies
everywhere at once. The repaint happens **only on the Pi** (Linux, running fullscreen); on the
desktop and on Windows/Mac the behavior is unchanged (no blink).

## Why

The Pi renders in software (tiny-skia) over a double-buffered Wayland surface — it keeps two hidden
copies of the screen and alternates them. On a color-only change the renderer fully repaints just
**one** of the two copies; the other keeps the old background color in the empty areas, and the
per-frame diff never re-clears it — so the patchwork persists and flickers as the copies cycle.
Briefly leaving and re-entering fullscreen is a genuine surface resize, which makes iced clear its
per-buffer layer history so **both** copies repaint in the new palette. (Root cause confirmed by
reading the iced `0.13` / softbuffer source; corroborated by a falsification test on the
single-buffered X11 path, which switches cleanly as predicted.)

## Scope

`refbox` crate only — `refbox/src/app/mod.rs`:
- a small gated repaint helper (`force_display_repaint`) wired into the display-mode handler,
- a pure, unit-tested gate (`should_force_repaint` — Linux + fullscreen only),
- storing the existing `--fullscreen` startup flag on the app so the handler can read it.

No other crates, no palette or translation changes, no new dependencies.

## How to verify

- **Automated:** `cargo test -p refbox` (388 pass, incl. new `repaint_gate_tests`),
  `cargo clippy -p refbox -- -D warnings` clean, `just check` green.
- **On the Pi (the only place the bug reproduces):** Settings → **VIEW MODE** → cycle
  Light / Dark / High Contrast. Each switch should repaint the **whole** screen cleanly (a brief
  blink on the tap is fine), including with a game clock running and after moving between pages.

## ⚠️ Pending Pi verification

The flicker-stopping behavior has **not yet been confirmed on hardware** — it cannot be reproduced
on WSL/desktop (single-buffered / wgpu). Verify on a **spare Pi** (via self-update) before rolling
out to any field Pi. If the fullscreen bounce does not rebuild the surface on the Pi's compositor,
the fallback is a one-line swap to the existing restart path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
