### PR TITLE
chore(workspace): bump version to 0.4.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2190,7 +2190,7 @@ dependencies = [
 
 [[package]]
 name = "fonts"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "embedded-graphics",
 ]
@@ -3563,7 +3563,7 @@ checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
 
 [[package]]
 name = "led-panel-sim"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "matrix-drawing",
  "uwh-common",
@@ -3887,7 +3887,7 @@ dependencies = [
 
 [[package]]
 name = "matrix-drawing"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -4740,7 +4740,7 @@ dependencies = [
 
 [[package]]
 name = "overlay"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "alphagen",
  "clap",
@@ -5438,7 +5438,7 @@ dependencies = [
 
 [[package]]
 name = "refbox"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "arrayref",
  "async-trait",
@@ -5867,7 +5867,7 @@ dependencies = [
 
 [[package]]
 name = "schedule-processor"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "clap",
  "csv",
@@ -7301,7 +7301,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uwh-common"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -8283,7 +8283,7 @@ dependencies = [
 
 [[package]]
 name = "wireless-modes"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "lora-modulation",
 ]

--- a/fonts/Cargo.toml
+++ b/fonts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fonts"
-version = "0.4.5"
+version = "0.4.6"
 authors = ["Atlantis Sports <maintainers@atlantissports.org>"]
 edition = "2024"
 rust-version = "1.85"

--- a/led-panel-sim/Cargo.toml
+++ b/led-panel-sim/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "led-panel-sim"
-version = "0.4.5"
+version = "0.4.6"
 authors = ["Atlantis Sports <maintainers@atlantissports.org>"]
 edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-matrix-drawing = { version = "0.4.5", path = "../matrix-drawing" }
-uwh-common = { version = "0.4.5", path = "../uwh-common" }
+matrix-drawing = { version = "0.4.6", path = "../matrix-drawing" }
+uwh-common = { version = "0.4.6", path = "../uwh-common" }
 
 [lib]
 name = "led_panel_sim"

--- a/matrix-drawing/Cargo.toml
+++ b/matrix-drawing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matrix-drawing"
-version = "0.4.5"
+version = "0.4.6"
 authors = ["Atlantis Sports <maintainers@atlantissports.org>"]
 edition = "2024"
 rust-version = "1.85"
@@ -15,9 +15,9 @@ arrayvec = { version = "0.7", default-features = false }
 derivative = "2"
 embedded-graphics = "0.8"
 enum-derive-2018 = { version = "3", optional = true }
-fonts = { version = "0.4.5", path = "../fonts" }
+fonts = { version = "0.4.6", path = "../fonts" }
 macro-attr-2018 = { version = "3", optional = true }
 more-asserts = "0.3"
 serde = { version = "1", default-features = false }
 serde_derive = "1"
-uwh-common = { version = "0.4.5", path = "../uwh-common", default-features = false }
+uwh-common = { version = "0.4.6", path = "../uwh-common", default-features = false }

--- a/overlay/Cargo.toml
+++ b/overlay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "overlay"
-version = "0.4.5"
+version = "0.4.6"
 edition = "2024"
 rust-version = "1.85"
 

--- a/refbox/Cargo.toml
+++ b/refbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "refbox"
-version = "0.4.5"
+version = "0.4.6"
 description = "UI for Atlantis Sports's Underwater Hockey Refbox"
 authors = ["Atlantis Sports <maintainers@atlantissports.org>"]
 edition = "2024"
@@ -37,12 +37,12 @@ iced_graphics = "0.13"
 iced_renderer = "0.13"
 iced_runtime = "0.13"
 iced_winit = "0.13"
-led-panel-sim = { version = "0.4.5", path = "../led-panel-sim" }
+led-panel-sim = { version = "0.4.6", path = "../led-panel-sim" }
 log = "0.4"
 log-panics = { version = "2", features = ["with-backtrace"]}
 log4rs = { version = "1", default-features = false, features = ["background_rotation", "compound_policy", "console_appender", "fixed_window_roller", "gzip", "pattern_encoder", "rolling_file_appender", "size_trigger"]}
 macro-attr-2018 = "3"
-matrix-drawing = { version = "0.4.5", path = "../matrix-drawing"}
+matrix-drawing = { version = "0.4.6", path = "../matrix-drawing"}
 more-asserts = "0.3"
 once_cell = "1.21.3"
 paste = "1"
@@ -59,7 +59,7 @@ tokio = { version = "1", features = ["io-util", "macros", "net", "rt", "sync", "
 tokio-serial = "5"
 toml = "0.9"
 unic-langid = "0.9.6"
-uwh-common = { version = "0.4.5", path = "../uwh-common"}
+uwh-common = { version = "0.4.6", path = "../uwh-common"}
 web-audio-api = { version = "1.2", default-features = false, features = ["cpal"] }
 
 [dev-dependencies]
@@ -77,7 +77,7 @@ embedded-hal-async = "1.0.0"
 iced = { version = "0.13", default-features = false, features = ["canvas", "image", "svg", "tiny-skia", "tokio"] }
 lora-phy = "3.0.1"
 rppal = { version = "0.22", features = ["embedded-hal", "hal-unproven"] }
-wireless-modes = { version = "0.4.5", path = "../wireless-modes" }
+wireless-modes = { version = "0.4.6", path = "../wireless-modes" }
 
 [target.'cfg(not(target_os = "linux"))'.dependencies]
 iced = { version = "0.13", default-features = false, features = ["canvas", "image", "svg", "tokio", "wgpu"] }

--- a/schedule-processor/Cargo.toml
+++ b/schedule-processor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "schedule-processor"
-version = "0.4.5"
+version = "0.4.6"
 authors = ["Atlantis Sports <maintainers@atlantissports.org>"]
 edition = "2024"
 rust-version = "1.85"

--- a/uwh-common/Cargo.toml
+++ b/uwh-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uwh-common"
-version = "0.4.5"
+version = "0.4.6"
 authors = ["Atlantis Sports <maintainers@atlantissports.org>"]
 edition = "2024"
 rust-version = "1.85"
@@ -16,7 +16,7 @@ defmt = "1.0"
 derivative = { version = "2", features = ["use_core"] }
 displaydoc = { version = "0.2", default-features = false }
 enum-iterator = "2"
-fonts = { version = "0.4.5", path = "../fonts" }
+fonts = { version = "0.4.6", path = "../fonts" }
 image = "0.25"
 indexmap = { version = "2.9.0", optional = true, features = ["serde"] }
 log = "0.4"

--- a/wireless-modes/Cargo.toml
+++ b/wireless-modes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wireless-modes"
-version = "0.4.5"
+version = "0.4.6"
 authors = ["Atlantis Sports <maintainers@atlantissports.org>"]
 edition = "2024"
 rust-version = "1.85"

--- a/wireless-remote/Cargo.toml
+++ b/wireless-remote/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wireless-remote"
-version = "0.4.5"
+version = "0.4.6"
 authors = ["Atlantis Sports <maintainers@atlantissports.org>"]
 edition = "2024"
 rust-version = "1.85"
@@ -20,7 +20,7 @@ embedded-hal-bus = { version = "0.3.0", features = ["async", "defmt-03"] }
 lora-phy = "3.0.1"
 panic-probe = { version = "1.0", features = ["print-defmt"] }
 portable-atomic = { version = "1.9.0", features = ["critical-section", "require-cas"] }
-wireless-modes = { version = "0.4.5", path = "../wireless-modes" }
+wireless-modes = { version = "0.4.6", path = "../wireless-modes" }
 
 
 [profile.release]


### PR DESCRIPTION
## What changed

Bumps **every** crate version from `0.4.5` to `0.4.6` — including the separate
`wireless-remote` workspace — the routine version bump that precedes cutting release **v0.4.6**.
Version numbers only; no code changes.

## Why

Release v0.4.6 will contain two `refbox` bug fixes already on `master`:
- the show-countdown toggle now taking effect on Apply (#1602), and
- the High Contrast display-mode repaint on the Pi (#1614).

Per `docs/release-checklist.md`, the version bump is its own commit/PR before tagging.

## Scope

All 9 crates' `Cargo.toml` (own `version` + internal path-dependency references) and the
regenerated main `Cargo.lock`: `fonts`, `matrix-drawing`, `uwh-common`, `wireless-modes`,
`overlay`, `led-panel-sim`, `schedule-processor`, `refbox`, and `wireless-remote`. The
`wireless-remote` bump is a version number only — no firmware change, no re-flashing of the
physical remotes.

## How to verify

- `cargo check --workspace` passes and regenerates `Cargo.lock` to `0.4.6`.
- No `version = "0.4.5"` remains in any `Cargo.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
