### PR TITLE
fix(refbox): prevent end-of-game crash on zero-overtime finals templates

### DIFF
--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -5400,6 +5400,60 @@ fn font_family_id(lang: Language) -> u8 {
     }
 }
 
+/// Fallback re-poll delay for the time updater when the clock is running but
+/// the game state has no concrete next-update instant. This happens only in
+/// degenerate zero-duration timing rules (e.g. the portal "FINALS" rule, whose
+/// pre-overtime break is zero, producing a zero-length score-confirm pause).
+/// Re-polling soon lets the state machine advance; it must never panic.
+const UPDATER_NO_NEXT_TIME_FALLBACK: Duration = Duration::from_millis(100);
+
+/// Decide when [`time_updater`] should next wake.
+///
+/// - Clock stopped: `None` — await the next clock-running change.
+/// - Clock running with a concrete next-update instant: wake at that instant.
+/// - Clock running but no next-update instant (degenerate state): re-poll after
+///   [`UPDATER_NO_NEXT_TIME_FALLBACK`] so the state machine can advance.
+///
+/// Replaces an earlier `next_update_time(now).unwrap()` that crashed the whole
+/// app (poisoning the shared game lock) when the value was absent.
+fn next_updater_wake(
+    clock_running: bool,
+    next_update_time: Option<Instant>,
+    now: Instant,
+) -> Option<Instant> {
+    clock_running.then(|| next_update_time.unwrap_or(now + UPDATER_NO_NEXT_TIME_FALLBACK))
+}
+
+#[cfg(test)]
+mod updater_wake_tests {
+    use super::*;
+
+    #[test]
+    fn stopped_clock_has_no_scheduled_wake() {
+        let now = Instant::now();
+        assert_eq!(next_updater_wake(false, Some(now), now), None);
+        assert_eq!(next_updater_wake(false, None, now), None);
+    }
+
+    #[test]
+    fn running_clock_uses_concrete_next_time() {
+        let now = Instant::now();
+        let next = now + Duration::from_secs(1);
+        assert_eq!(next_updater_wake(true, Some(next), now), Some(next));
+    }
+
+    #[test]
+    fn running_clock_with_empty_next_time_falls_back_without_panicking() {
+        // The FINALS-template crash case: clock running but no concrete next
+        // update instant. Must NOT panic; schedules a short re-poll instead.
+        let now = Instant::now();
+        assert_eq!(
+            next_updater_wake(true, None, now),
+            Some(now + UPDATER_NO_NEXT_TIME_FALLBACK)
+        );
+    }
+}
+
 fn time_updater() -> impl Stream<Item = Message> {
     use iced::futures::SinkExt;
     debug!("Updater starting");
@@ -5482,11 +5536,7 @@ fn time_updater() -> impl Stream<Item = Message> {
                     }
                 };
 
-                next_time = if clock_running {
-                    Some(tm_.next_update_time(now).unwrap())
-                } else {
-                    None
-                };
+                next_time = next_updater_wake(clock_running, tm_.next_update_time(now), now);
 
                 (msg_type, snapshot)
             };

--- a/refbox/src/tournament_manager/mod.rs
+++ b/refbox/src/tournament_manager/mod.rs
@@ -1034,6 +1034,19 @@ impl TournamentManager {
         min(time_remaining_at_start, MAX_TIME_VAL)
     }
 
+    /// A portal timing rule can enable overtime while leaving every overtime
+    /// period zero-length. The portal "FINALS" rule does exactly this: zero
+    /// overtime halves and a zero pre-overtime break, with sudden death properly
+    /// configured. That really means "no timed overtime — sudden death decides a
+    /// tie". Honor that intent so the engine never builds a zero-length overtime
+    /// or zero-length score-confirm pause (which crashed the app at the end of
+    /// such a game). Applied to configs adopted from a portal timing rule.
+    fn normalize_degenerate_overtime(config: &mut GameConfig) {
+        if config.overtime_allowed && config.ot_half_play_duration.is_zero() {
+            config.overtime_allowed = false;
+        }
+    }
+
     pub fn apply_next_game_start(&mut self, now: Instant) -> Result<()> {
         if self.current_period != GamePeriod::BetweenGames {
             return Err(TournamentManagerError::GameInProgress);
@@ -1046,7 +1059,9 @@ impl TournamentManager {
         };
 
         if let Some(ref timing) = next_game_info.timing {
-            self.config = timing.clone().into();
+            let mut config: GameConfig = timing.clone().into();
+            Self::normalize_degenerate_overtime(&mut config);
+            self.config = config;
         }
 
         let time_remaining_at_start = self.calc_time_to_next_game(now, now);
@@ -1150,6 +1165,7 @@ impl TournamentManager {
 
         if let Some(timing) = self.next_game.take().and_then(|info| info.timing) {
             self.config = timing.into();
+            Self::normalize_degenerate_overtime(&mut self.config);
         }
 
         info!(
@@ -7699,6 +7715,113 @@ mod test {
         // tolerate this empty value instead of unwrapping it.
         let after = game_end + Duration::from_millis(1);
         assert_eq!(tm.next_update_time(after), None);
+    }
+
+    #[test]
+    fn test_normalize_degenerate_overtime() {
+        // Overtime "allowed" but zero-length overtime periods (the FINALS rule):
+        // treat as no overtime.
+        let mut zero_ot = GameConfig {
+            overtime_allowed: true,
+            ot_half_play_duration: Duration::ZERO,
+            ..Default::default()
+        };
+        TournamentManager::normalize_degenerate_overtime(&mut zero_ot);
+        assert!(!zero_ot.overtime_allowed);
+
+        // Real overtime is left enabled.
+        let mut real_ot = GameConfig {
+            overtime_allowed: true,
+            ot_half_play_duration: Duration::from_secs(180),
+            ..Default::default()
+        };
+        TournamentManager::normalize_degenerate_overtime(&mut real_ot);
+        assert!(real_ot.overtime_allowed);
+
+        // Overtime already off is left off.
+        let mut no_ot = GameConfig {
+            overtime_allowed: false,
+            ot_half_play_duration: Duration::ZERO,
+            ..Default::default()
+        };
+        TournamentManager::normalize_degenerate_overtime(&mut no_ot);
+        assert!(!no_ot.overtime_allowed);
+    }
+
+    /// A faithful copy of the portal "FINALS" timing rule that crashed the app:
+    /// overtime "allowed" but every overtime period zero-length, sudden death
+    /// properly configured.
+    fn finals_timing_rule() -> TimingRule {
+        TimingRule {
+            name: "FINALS".to_string(),
+            team_timeout_count: 1,
+            team_timeouts_counted_per_half: true,
+            overtime_allowed: true,
+            sudden_death_allowed: true,
+            last_2_min_stop_time: false,
+            half_play_duration: Duration::from_secs(600),
+            half_time_duration: Duration::from_secs(120),
+            team_timeout_duration: Duration::from_secs(60),
+            ot_half_play_duration: Duration::ZERO,
+            ot_half_time_duration: Duration::ZERO,
+            pre_overtime_break: Duration::ZERO,
+            pre_sudden_death_duration: Duration::from_secs(60),
+            minimum_break: Duration::from_secs(180),
+            game_block: None,
+        }
+    }
+
+    #[test]
+    fn test_finals_next_game_disables_overtime() {
+        // The actual production path: a FINALS rule arrives as the next game and
+        // is adopted via apply_next_game_start, which must normalize overtime off.
+        initialize();
+        let mut tm = TournamentManager::new(GameConfig::default());
+        tm.set_period_and_game_clock_time(GamePeriod::BetweenGames, Duration::from_secs(60));
+        tm.set_next_game(NextGameInfo {
+            number: "53".to_string(),
+            timing: Some(finals_timing_rule()),
+            start_time: Some(OffsetDateTime::now_utc() + time::Duration::minutes(30)),
+        });
+        tm.apply_next_game_start(Instant::now()).unwrap();
+        assert!(!tm.config.overtime_allowed);
+        assert!(tm.config.sudden_death_allowed);
+    }
+
+    #[test]
+    fn test_finals_normalized_nonzero_pause_and_tie_to_sudden_death() {
+        initialize();
+        let mut config: GameConfig = finals_timing_rule().into();
+        TournamentManager::normalize_degenerate_overtime(&mut config);
+        assert!(!config.overtime_allowed);
+        let mut tm = TournamentManager::new(config);
+
+        let start = Instant::now();
+        let game_end = start + Duration::from_secs(600); // half_play_duration
+        tm.set_period_and_game_clock_time(GamePeriod::SecondHalf, Duration::from_secs(600));
+        tm.set_game_start(start);
+        tm.start_game_clock(start);
+        tm.set_scores(BlackWhiteBundle { black: 1, white: 1 }, start); // tie
+
+        assert_eq!(Ok(true), tm.could_end_game(game_end));
+        tm.pause_for_confirm(game_end).unwrap();
+
+        // No longer a zero-length pause: derived from sudden-death / break timing.
+        let pause_dur = tm
+            .time_pause_confirmation
+            .as_ref()
+            .unwrap()
+            .duration_of_pause;
+        assert!(pause_dur > Duration::ZERO);
+        // The clock now has a concrete next-update instant (crash condition gone).
+        assert!(
+            tm.next_update_time(game_end + Duration::from_millis(1))
+                .is_some()
+        );
+
+        // A tie ends in sudden death, not zero-length overtime.
+        tm.end_confirm_pause(game_end + pause_dur).unwrap();
+        assert_eq!(tm.current_period, GamePeriod::PreSuddenDeath);
     }
 
     #[test]

--- a/refbox/src/tournament_manager/mod.rs
+++ b/refbox/src/tournament_manager/mod.rs
@@ -7665,6 +7665,43 @@ mod test {
     }
 
     #[test]
+    fn test_finals_template_yields_empty_next_update_time() {
+        initialize();
+        // A FINALS-style timing rule: overtime enabled, but the pre-overtime
+        // break is zero. This is the degenerate config that crashed the refbox.
+        let config = GameConfig {
+            overtime_allowed: true,
+            sudden_death_allowed: true,
+            pre_overtime_break: Duration::ZERO,
+            pre_sudden_death_duration: Duration::from_secs(60),
+            minimum_break: Duration::from_secs(180),
+            ..Default::default()
+        };
+        let mut tm = TournamentManager::new(config);
+
+        let start = Instant::now();
+        let game_end = start + Duration::from_secs(30);
+
+        tm.set_period_and_game_clock_time(GamePeriod::SecondHalf, Duration::from_secs(30));
+        tm.set_game_start(start);
+        tm.start_game_clock(start);
+        tm.set_scores(BlackWhiteBundle { black: 1, white: 2 }, start);
+
+        assert_eq!(Ok(true), tm.could_end_game(game_end));
+        tm.pause_for_confirm(game_end).unwrap();
+
+        // Confirm pause is zero-length: min(pre_overtime_break, minimum_break)/2 == 0.
+        let confirm = tm.time_pause_confirmation.as_ref().unwrap();
+        assert_eq!(confirm.duration_of_pause, Duration::ZERO);
+
+        // One tick after the pause begins, the remaining-pause computation
+        // underflows, so there is no concrete next-update instant. The app must
+        // tolerate this empty value instead of unwrapping it.
+        let after = game_end + Duration::from_millis(1);
+        assert_eq!(tm.next_update_time(after), None);
+    }
+
+    #[test]
     fn test_pause_score_confirm_with_only_sd_score_changed_to_tie() {
         initialize();
         let config = GameConfig {


### PR DESCRIPTION
## What changed
The referee box no longer crashes at the end of a game played with a "finals"-style timing template — one where overtime is switched on but every overtime value is zero. Such a template is now correctly treated as **"no timed overtime — sudden death decides a tie,"** so the end-of-game step completes cleanly. Normal games with real overtime are unaffected.

## Why
The portal "FINALS" template has overtime switched on but with zero-length overtime periods and a zero pre-overtime break. At the end of the second half the app built a **zero-length score-confirmation pause**, which led to an impossible internal time calculation and crashed the whole app (with a follow-on crash from the same root cause). The real intent of that template is "no overtime, go to sudden death," so the app now interprets it that way — which removes the zero-length pause at its source.

## Scope
Changes are limited to the `refbox` crate:
- `refbox/src/tournament_manager/mod.rs` — treat a timing rule with zero-length overtime as having no overtime (the primary fix), plus tests.
- `refbox/src/app/mod.rs` — make the background clock updater tolerate a missing "next update time" instead of crashing (defense-in-depth).

No changes to `uwh-common`, portal data, or any other crate.

## How to verify
- **Automated:** `just check` passes. New tests:
  - `test_finals_next_game_disables_overtime` — a finals template arriving as the next game is treated as no-overtime.
  - `test_finals_normalized_nonzero_pause_and_tie_to_sudden_death` — the end-of-game pause is non-zero and a tie heads to sudden death.
  - `test_normalize_degenerate_overtime`, `test_finals_template_yields_empty_next_update_time`, plus three `next_updater_wake` tests.
- **Manual (done):** loaded a real finals game (event 2305-A, game 51) and played to the end of the second half. Previously this crashed; now the game ends cleanly and the game-info table shows **Overtime: NO / Sudden Death: YES**.

## Follow-up (separate)
Propose upstream validation in the portal/schedule tooling to reject a schedule whose timing rule enables overtime with zero-length overtime durations, so the contradictory template never reaches the refbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
