### PR TITLE
fix(ci): install apt build deps directly instead of via flaky cache action

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,10 +30,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v5
-    - uses: awalsh128/cache-apt-pkgs-action@latest
-      with:
-        packages: libssl-dev pkg-config libasound2-dev
-        version: latest
+    - run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config libasound2-dev
     - uses: Swatinem/rust-cache@v2
     - name: Versions
       run: cargo --version && rustc --version && cargo fmt -- --version && cargo clippy -- --version
@@ -64,12 +61,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v5
-    - uses: awalsh128/cache-apt-pkgs-action@latest
-      with:
-        # xvfb provides a virtual display so the capture window can render;
-        # libxkbcommon-x11-0 is the winit X11 runtime dep iced needs headless.
-        packages: libssl-dev pkg-config libasound2-dev xvfb libxkbcommon-x11-0
-        version: latest
+    # xvfb provides a virtual display so the capture window can render;
+    # libxkbcommon-x11-0 is the winit X11 runtime dep iced needs headless.
+    - run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config libasound2-dev xvfb libxkbcommon-x11-0
     - uses: Swatinem/rust-cache@v2
     - name: Versions
       run: cargo --version && rustc --version
@@ -105,10 +99,7 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     - if: ${{ matrix.os == 'ubuntu-latest' }}
-      uses: awalsh128/cache-apt-pkgs-action@latest
-      with:
-        packages: libssl-dev pkg-config libasound2-dev
-        version: latest
+      run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config libasound2-dev
     - uses: Swatinem/rust-cache@v2
       with:
         workspaces: |
@@ -127,10 +118,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v5
-    - uses: awalsh128/cache-apt-pkgs-action@latest
-      with:
-        packages: libssl-dev pkg-config libasound2-dev
-        version: latest
+    - run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config libasound2-dev
     - uses: Swatinem/rust-cache@v2
       with:
         workspaces: |
@@ -153,10 +141,7 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     - if: ${{ matrix.os == 'ubuntu-latest' }}
-      uses: awalsh128/cache-apt-pkgs-action@latest
-      with:
-        packages: libssl-dev pkg-config libasound2-dev
-        version: latest
+      run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config libasound2-dev
     - uses: Swatinem/rust-cache@v2
       with:
         workspaces: |
@@ -175,10 +160,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v5
-    - uses: awalsh128/cache-apt-pkgs-action@latest
-      with:
-        packages: libssl-dev pkg-config libasound2-dev
-        version: latest
+    - run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config libasound2-dev
     - uses: Swatinem/rust-cache@v2
       with:
         workspaces: |


### PR DESCRIPTION
## What changed
The CI build jobs now install their Linux system libraries (OpenSSL, pkg-config,
ALSA audio) with a plain `apt-get update && apt-get install` step, replacing the
third-party `awalsh128/cache-apt-pkgs-action` that had started failing
intermittently.

## Why
The cached-package action began failing to provide the ALSA audio library —
first as a 404 fetching a superseded .deb, then as a missing pkg-config entry —
which broke clippy and every build/test job (the app can't compile without it).
It's a build-environment problem, unrelated to any application code, and it
blocks all merges through the merge queue.

## Scope
CI only: `.github/workflows/rust.yml` (6 job steps). No application code, no
dependency changes. The release-build workflow (`release.yml`) was already
unaffected (it uses cross-compilation / native builds).

## How to verify
CI on this PR runs green — clippy and all Test jobs succeed, where before they
failed with "system library `alsa` was not found".
