### PR TITLE
fix(ci): restore green CI — apt install, cargo-audit, clippy + pinned toolchain

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,10 +30,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v5
-    - uses: awalsh128/cache-apt-pkgs-action@latest
-      with:
-        packages: libssl-dev pkg-config libasound2-dev
-        version: latest
+    - run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config libasound2-dev
     - uses: Swatinem/rust-cache@v2
     - name: Versions
       run: cargo --version && rustc --version && cargo fmt -- --version && cargo clippy -- --version
@@ -64,12 +61,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v5
-    - uses: awalsh128/cache-apt-pkgs-action@latest
-      with:
-        # xvfb provides a virtual display so the capture window can render;
-        # libxkbcommon-x11-0 is the winit X11 runtime dep iced needs headless.
-        packages: libssl-dev pkg-config libasound2-dev xvfb libxkbcommon-x11-0
-        version: latest
+    # xvfb provides a virtual display so the capture window can render;
+    # libxkbcommon-x11-0 is the winit X11 runtime dep iced needs headless.
+    - run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config libasound2-dev xvfb libxkbcommon-x11-0
     - uses: Swatinem/rust-cache@v2
     - name: Versions
       run: cargo --version && rustc --version
@@ -105,10 +99,7 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     - if: ${{ matrix.os == 'ubuntu-latest' }}
-      uses: awalsh128/cache-apt-pkgs-action@latest
-      with:
-        packages: libssl-dev pkg-config libasound2-dev
-        version: latest
+      run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config libasound2-dev
     - uses: Swatinem/rust-cache@v2
       with:
         workspaces: |
@@ -127,10 +118,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v5
-    - uses: awalsh128/cache-apt-pkgs-action@latest
-      with:
-        packages: libssl-dev pkg-config libasound2-dev
-        version: latest
+    - run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config libasound2-dev
     - uses: Swatinem/rust-cache@v2
       with:
         workspaces: |
@@ -153,10 +141,7 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     - if: ${{ matrix.os == 'ubuntu-latest' }}
-      uses: awalsh128/cache-apt-pkgs-action@latest
-      with:
-        packages: libssl-dev pkg-config libasound2-dev
-        version: latest
+      run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config libasound2-dev
     - uses: Swatinem/rust-cache@v2
       with:
         workspaces: |
@@ -175,10 +160,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v5
-    - uses: awalsh128/cache-apt-pkgs-action@latest
-      with:
-        packages: libssl-dev pkg-config libasound2-dev
-        version: latest
+    - run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config libasound2-dev
     - uses: Swatinem/rust-cache@v2
       with:
         workspaces: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,7 +49,10 @@ jobs:
         file: Cargo.lock
         # RUSTSEC-2026-0009: time CVE fix requires Rust 1.88+, above current MSRV 1.85
         # See docs/decisions/002-time-cve-msrv.md
-        ignore: RUSTSEC-2024-0384,RUSTSEC-2024-0388,RUSTSEC-2026-0009
+        # RUSTSEC-2026-0194/0195 (quick-xml), RUSTSEC-2025-0052 (async-std): transitive via
+        # iced/winit, not fixable without an out-of-scope iced upgrade; not meaningfully
+        # exploitable here. See docs/decisions/024-cargo-audit-iced-transitive-advisories.md
+        ignore: RUSTSEC-2024-0384,RUSTSEC-2024-0388,RUSTSEC-2026-0009,RUSTSEC-2026-0194,RUSTSEC-2026-0195,RUSTSEC-2025-0052
     - uses: actions-rust-lang/audit@v1
       with:
         workingDirectory: wireless-remote

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1309,9 +1309,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/ci/check-msrv-present.sh
+++ b/ci/check-msrv-present.sh
@@ -5,6 +5,7 @@ excluded_files=(
   './Cargo.toml'
   './Cross.toml'
   './refbox/i18n.toml'
+  './rust-toolchain.toml'
   './wireless-remote/rust-toolchain.toml'
   './wireless-remote/.cargo/config.toml'
 )

--- a/docs/decisions/024-cargo-audit-iced-transitive-advisories.md
+++ b/docs/decisions/024-cargo-audit-iced-transitive-advisories.md
@@ -1,0 +1,49 @@
+# 024 — Accepting iced-transitive cargo-audit advisories
+
+**Date:** 2026-07-16
+**Status:** accepted
+
+## Context
+
+`cargo audit` (the `audit` CI job) began failing after the RustSec advisory database
+published new advisories affecting transitive dependencies. Three were flagged that are not
+covered by the existing ignore list:
+
+- **RUSTSEC-2026-0204** — `crossbeam-epoch` 0.9.18: invalid pointer dereference in the
+  `fmt::Pointer` impl for `Atomic`/`Shared` when the underlying pointer is invalid. Fixed in
+  `>=0.9.20`. Pulled transitively via `crossbeam-deque` → `rayon` → `image`.
+- **RUSTSEC-2026-0194 / RUSTSEC-2026-0195** — `quick-xml` 0.37.5 (severity 7.5, high):
+  quadratic run time when checking a start tag for duplicate attribute names. Fixed in
+  `>=0.41.0`. Pulled **only** by `wayland-scanner` (a build-time proc-macro) →
+  `smithay-client-toolkit` → `winit` → `iced`.
+- **RUSTSEC-2025-0052** — `async-std` 1.13.2: unmaintained (a *warning*, not a vulnerability).
+  Pulled by `iced_futures` → `iced`.
+
+## Decision
+
+- **Fix what is cleanly fixable.** Bump `crossbeam-epoch` to 0.9.20 via a lockfile update
+  (`cargo update -p crossbeam-epoch --precise 0.9.20`). This is a semver-compatible patch bump,
+  no code change, and stays within the MSRV 1.85.
+- **Accept (ignore) the iced-locked advisories** in the `audit` CI job's ignore list:
+  - `RUSTSEC-2026-0194`, `RUSTSEC-2026-0195` (`quick-xml`)
+  - `RUSTSEC-2025-0052` (`async-std`)
+
+## Rationale
+
+- `quick-xml` and `async-std` reach the tree only through `iced`/`winit`. Their fixed versions
+  require newer `winit`/`iced` releases, and upgrading `iced` is out of scope (a major, breaking
+  change requiring separate discussion — see the project rules on iced upgrades).
+- The `quick-xml` advisory is a denial-of-service vector against *untrusted* XML input. In this
+  project `quick-xml` is used only by `wayland-scanner`, a **build-time proc-macro** that parses
+  the trusted, shipped Wayland protocol XML at compile time. It never processes untrusted input,
+  so the real-world exposure is effectively nil.
+- `async-std`'s advisory is an "unmaintained" warning, not a vulnerability.
+
+## Consequences
+
+- The `audit` CI job passes again (`cargo audit` exits 0 with the updated ignore list).
+- When `iced`/`winit` are next upgraded (a separate decision), re-evaluate and remove the
+  `quick-xml` and `async-std` entries from the ignore list. Renovate may also resolve them via
+  its own dependency-update branches; drop the ignores once the upgraded versions land.
+- This acceptance is scoped to the advisories listed above; any new advisory must be evaluated
+  on its own merits rather than assumed covered.

--- a/overlay/src/pages/final_scores.rs
+++ b/overlay/src/pages/final_scores.rs
@@ -90,7 +90,7 @@ impl PageRenderer {
         }
         let (x_off, text) = fit_text(
             270f32,
-            &format!("GAME #{}", &state.snapshot.game_number()),
+            &format!("GAME #{}", state.snapshot.game_number()),
             25,
             &self.assets.font,
             Justify::Center,

--- a/overlay/src/pages/next_game.rs
+++ b/overlay/src/pages/next_game.rs
@@ -94,7 +94,7 @@ impl PageRenderer {
         }
         let (x_off, text) = fit_text(
             270f32,
-            &format!("GAME #{}", &state.snapshot.game_number()),
+            &format!("GAME #{}", state.snapshot.game_number()),
             25,
             &self.assets.font,
             Justify::Center,

--- a/overlay/src/pages/roster/list.rs
+++ b/overlay/src/pages/roster/list.rs
@@ -274,7 +274,7 @@ pub fn draw(renderer: &mut PageRenderer, state: &State) {
     }
     let (x_off, text) = fit_text(
         270f32,
-        &format!("GAME #{}", &state.snapshot.game_number()),
+        &format!("GAME #{}", state.snapshot.game_number()),
         25,
         &renderer.assets.font,
         Justify::Center,

--- a/refbox/src/app/update_sender.rs
+++ b/refbox/src/app/update_sender.rs
@@ -671,7 +671,7 @@ impl Server {
 
 impl Drop for Server {
     fn drop(&mut self) {
-        for (_, handle) in self.senders.iter() {
+        for handle in self.senders.values() {
             handle.join.abort();
         }
     }

--- a/refbox/src/app/view_builders/game_info.rs
+++ b/refbox/src/app/view_builders/game_info.rs
@@ -22,7 +22,6 @@ pub(in super::super) fn build_game_info_page<'a>(
         clock_running,
         teams,
         portal_indicator,
-        has_led_panel: _,
         ..
     } = data;
 

--- a/refbox/src/app/view_builders/list_selector.rs
+++ b/refbox/src/app/view_builders/list_selector.rs
@@ -34,7 +34,6 @@ pub(in super::super) fn build_list_selector_page<'a>(
         clock_running,
         teams,
         portal_indicator,
-        has_led_panel: _,
         ..
     } = data;
 

--- a/refbox/src/app/view_builders/main_view.rs
+++ b/refbox/src/app/view_builders/main_view.rs
@@ -32,7 +32,6 @@ pub(in super::super) fn build_main_view<'a>(
         clock_running,
         teams,
         portal_indicator,
-        has_led_panel: _,
         ..
     } = data;
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,8 @@
+# Pin the toolchain used to build, lint, and format the main workspace so CI (and local
+# builds) are reproducible and a new stable Rust release cannot spontaneously introduce
+# lint/warning failures (as happened when the CI runner moved to 1.97 and clippy flagged
+# previously-clean code). Bump this deliberately; Renovate can propose updates.
+# The wireless-remote sub-workspace keeps its own rust-toolchain.toml.
+[toolchain]
+channel = "1.96.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## What changed

Restores green CI, which had gone fully red on every open PR. **Three** independent, pre-existing, environment-driven CI failures are fixed here — the common theme is CI tracking "latest" versions that drifted:

### 1. System libraries no longer install (ALSA) — every build broke

The install used `awalsh128/cache-apt-pkgs-action@latest`, which recently stopped installing the packages, so every build failed with `The system library 'alsa' required by crate 'alsa-sys' was not found`. Fix: all six uses in `.github/workflows/rust.yml` replaced with a direct `sudo apt-get update && sudo apt-get install -y …`, preserving each step's package list.

### 2. `cargo audit` failing on newly-published advisories

- **`crossbeam-epoch`** (RUSTSEC-2026-0204): bumped 0.9.18 → 0.9.20 via a lockfile patch (MSRV-safe, no code change).
- **`quick-xml`** (RUSTSEC-2026-0194/0195, high) and **`async-std`** (RUSTSEC-2025-0052, unmaintained warning): accepted via the audit ignore list — both are iced/winit-transitive and unfixable without an out-of-scope iced upgrade; `quick-xml` is used only by the build-time `wayland-scanner` proc-macro (trusted input), so not meaningfully exploitable. Documented in `docs/decisions/024-cargo-audit-iced-transitive-advisories.md`.

### 3. Clippy failing on new lints from a newer compiler

CI's Clippy ran on the runner's latest stable, which moved to Rust 1.97 and began flagging previously-clean code (`unneeded_wildcard_pattern`, `useless_borrows_in_formatting`, `for_kv_map`) in `refbox` and `overlay`. Fix: pin the main workspace to a fixed toolchain (`rust-toolchain.toml`, 1.96.0) so a new stable release can't spontaneously fail CI again, and apply clippy's own suggested fixes so the code is also clean under 1.97. (The `wireless-remote` sub-workspace keeps its own toolchain file.)

## Why

All three were blocking CI on **every** open PR (e.g. #1672, #1673, #1675), not any one change. This restores the whole repo's CI to green, and the pinned toolchain prevents the recurring "CI drifted to a newer version" failure mode.

## Scope

`.github/workflows/rust.yml` (CI config), `Cargo.lock` (crossbeam-epoch patch bump only), `rust-toolchain.toml` (new pin), a new `docs/decisions/024-…md`, and mechanical clippy fixes in `refbox`/`overlay` (no behaviour change). No other dependency or application-logic changes.

## How to verify

- Locally on the pinned toolchain (1.96.0): `cargo clippy --all -- -D warnings` and `--no-default-features` both pass, `cargo fmt --all -- --check` passes, `cargo audit` (with the updated ignore list) exits 0, `cargo build --all` + `cargo test -p refbox` pass.
- In CI: all checks (Clippy, build/test on all platforms, preview-drift, audit, fmt) should be green.

## Follow-up

When `iced`/`winit` are next upgraded (separate decision), drop the `quick-xml`/`async-std` ignore entries (see decision 024). Bump the pinned toolchain deliberately (Renovate can propose it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
