### PR TITLE
feat(schedule-processor): scoresheet generation with portal support

### DIFF
--- a/refbox/src/app/view_builders/configuration.rs
+++ b/refbox/src/app/view_builders/configuration.rs
@@ -2359,6 +2359,7 @@ mod tests {
             timing_rules: vec![],
             standings_order: None,
             final_results_order: None,
+            referees_by_game_number: None,
         }
     }
 

--- a/schedule-processor/src/csv_parser.rs
+++ b/schedule-processor/src/csv_parser.rs
@@ -151,6 +151,7 @@ pub fn parse_csv(
         timing_rules,
         standings_order: None,
         final_results_order: None,
+        referees_by_game_number: None,
     })
 }
 

--- a/schedule-processor/src/main.rs
+++ b/schedule-processor/src/main.rs
@@ -79,19 +79,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         log_panics::init();
     }
 
-    info!("Please select a CSV schedule to process in the file dialog.");
-    let csv_path = FileDialog::new()
-        .add_filter("CSV files", &["csv"])
-        .set_title("Select Schedule CSV File")
-        .pick_file();
-
-    let csv_path = if let Some(path) = csv_path {
-        path
-    } else {
-        error!("No file selected. Exiting.");
-        return Err("No file selected".into());
-    };
-
     let options = vec!["Underwater Hockey", "Underwater Rugby"];
     let sport_choice = Select::new("Select the sport for the schedule:", options)
         .prompt()
@@ -151,85 +138,78 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let offset = event.date_range.start.offset();
     info!("Using timezone offset: {offset}");
 
-    info!("Reading csv file: {}", csv_path.display());
-    let csv = std::fs::read_to_string(&csv_path)?;
-    let schedule = match parse_csv(&csv, offset, event.id.clone()) {
-        Ok(schedule) => schedule,
-        Err(e) => {
-            error!("Failed to parse CSV file: {e}");
-            Text::new("Press any key close the app")
-                .with_placeholder("Press Enter to proceed")
-                .prompt()
-                .unwrap_or_else(|_| {
-                    error!("Failed to proceed. Exiting.");
-                    std::process::exit(1);
-                });
-            return Err(e);
-        }
-    };
+    // Load the schedule CSV lazily — only when an action needs it (Upload / Save /
+    // Print Schedule). Portal-based actions (score sheets, coin tosses) never require it.
+    let load_schedule = || -> Result<Schedule, Box<dyn std::error::Error>> {
+        info!("Please select a CSV schedule to process in the file dialog.");
+        let Some(csv_path) = FileDialog::new()
+            .add_filter("CSV files", &["csv"])
+            .set_title("Select Schedule CSV File")
+            .pick_file()
+        else {
+            return Err("No file selected".into());
+        };
+        info!("Reading csv file: {}", csv_path.display());
+        let csv = std::fs::read_to_string(&csv_path)?;
+        let schedule = parse_csv(&csv, offset, event.id.clone())?;
 
-    let mut success_string = "Successfully parsed schedule. Details:".to_string();
-    write!(
-        &mut success_string,
-        "\n    Number of games: {}",
-        schedule.games.len()
-    )
-    .unwrap();
-    write!(
-        &mut success_string,
-        "\n    Groups: {}",
-        schedule.groups.iter().map(|g| &g.name).join(", ")
-    )
-    .unwrap();
-    write!(
-        &mut success_string,
-        "\n    Timing rules: {}",
-        schedule.timing_rules.iter().map(|tr| &tr.name).join(", ")
-    )
-    .unwrap();
-    write!(
-        &mut success_string,
-        "\n    Courts: {}",
-        schedule
+        let mut success_string = "Successfully parsed schedule. Details:".to_string();
+        write!(
+            &mut success_string,
+            "\n    Number of games: {}",
+            schedule.games.len()
+        )
+        .unwrap();
+        write!(
+            &mut success_string,
+            "\n    Groups: {}",
+            schedule.groups.iter().map(|g| &g.name).join(", ")
+        )
+        .unwrap();
+        write!(
+            &mut success_string,
+            "\n    Timing rules: {}",
+            schedule.timing_rules.iter().map(|tr| &tr.name).join(", ")
+        )
+        .unwrap();
+        write!(
+            &mut success_string,
+            "\n    Courts: {}",
+            schedule
+                .games
+                .iter()
+                .map(|(_, g)| &g.court)
+                .unique()
+                .join(", ")
+        )
+        .unwrap();
+        let unassigned_teams: Vec<_> = schedule
             .games
             .iter()
-            .map(|(_, g)| &g.court)
+            .flat_map(|(_, g)| vec![&g.light, &g.dark])
+            .filter_map(|t| t.pending().map(|name| name.to_string()))
             .unique()
-            .join(", ")
-    )
-    .unwrap();
-    let unassigned_teams: Vec<_> = schedule
-        .games
-        .iter()
-        .flat_map(|(_, g)| vec![&g.light, &g.dark])
-        .filter_map(|t| t.pending().map(|name| name.to_string()))
-        .unique()
-        .collect();
-    write!(
-        &mut success_string,
-        "\n    Unassigned teams ({}): \"{}\"",
-        unassigned_teams.len(),
-        unassigned_teams.iter().join("\", \"")
-    )
-    .unwrap();
-    info!("{success_string}");
+            .collect();
+        write!(
+            &mut success_string,
+            "\n    Unassigned teams ({}): \"{}\"",
+            unassigned_teams.len(),
+            unassigned_teams.iter().join("\", \"")
+        )
+        .unwrap();
+        info!("{success_string}");
 
-    info!("Running schedule checks");
-    if let Err(e) = run_schedule_checks(&schedule) {
-        error!("Schedule checks failed: {e}");
-        if !args.allow_failures {
-            Text::new("Press any key to close the app")
-                .with_placeholder("Press Enter to proceed")
-                .prompt()
-                .unwrap_or_else(|_| {
-                    error!("Failed to proceed. Exiting.");
-                    std::process::exit(1);
-                });
-            return Err(e);
+        info!("Running schedule checks");
+        if let Err(e) = run_schedule_checks(&schedule) {
+            error!("Schedule checks failed: {e}");
+            if !args.allow_failures {
+                return Err(e);
+            }
         }
-    }
+        Ok(schedule)
+    };
 
-    let sendable_schedule = schedule.clone().into();
+    let mut schedule: Option<Schedule> = None;
 
     let mut team_map = vec![];
 
@@ -311,6 +291,26 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         match step_choice {
             StepChoice::MapTeams => {
+                if schedule.is_none() {
+                    match load_schedule() {
+                        Ok(s) => schedule = Some(s),
+                        Err(e) => {
+                            error!("Could not load the schedule CSV: {e}");
+                            continue 'outer;
+                        }
+                    }
+                }
+                // Safe: `schedule` is Some — set just above, or the Err arm continued.
+                let unassigned_teams: Vec<String> = schedule
+                    .as_ref()
+                    .expect("schedule loaded above")
+                    .games
+                    .iter()
+                    .flat_map(|(_, g)| vec![&g.light, &g.dark])
+                    .filter_map(|t| t.pending().map(|name| name.to_string()))
+                    .unique()
+                    .collect();
+
                 let event_teams = match portal_client.get_event_teams(&event.id).await {
                     Ok(teams) => teams,
                     Err(e) => {
@@ -449,6 +449,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
             }
             StepChoice::Upload => {
+                if schedule.is_none() {
+                    match load_schedule() {
+                        Ok(s) => schedule = Some(s),
+                        Err(e) => {
+                            error!("Could not load the schedule CSV: {e}");
+                            continue 'outer;
+                        }
+                    }
+                }
+                // Safe: `schedule` is Some — set just above, or the Err arm continued.
+                let sendable_schedule: SendableSchedule = schedule
+                    .as_ref()
+                    .expect("schedule loaded above")
+                    .clone()
+                    .into();
+
                 if !portal_client.has_token() {
                     let email = match Text::new("Enter your uwhportal email:").prompt() {
                         Ok(email) => email,
@@ -530,6 +546,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 error!("Upload cannot be performed at this time. Please map teams first.");
             }
             StepChoice::SaveSchedule => {
+                if schedule.is_none() {
+                    match load_schedule() {
+                        Ok(s) => schedule = Some(s),
+                        Err(e) => {
+                            error!("Could not load the schedule CSV: {e}");
+                            continue 'outer;
+                        }
+                    }
+                }
+                // Safe: `schedule` is Some — set just above, or the Err arm continued.
+                let sendable_schedule: SendableSchedule = schedule
+                    .as_ref()
+                    .expect("schedule loaded above")
+                    .clone()
+                    .into();
+
                 let output_path = FileDialog::new()
                     .add_filter("JSON files", &["json"])
                     .set_title("Save Schedule as JSON")
@@ -545,6 +577,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
             }
             StepChoice::PrintSchedule => {
+                if schedule.is_none() {
+                    match load_schedule() {
+                        Ok(s) => schedule = Some(s),
+                        Err(e) => {
+                            error!("Could not load the schedule CSV: {e}");
+                            continue 'outer;
+                        }
+                    }
+                }
+                // Safe: `schedule` is Some — set just above, or the Err arm continued.
+                let sendable_schedule: SendableSchedule = schedule
+                    .as_ref()
+                    .expect("schedule loaded above")
+                    .clone()
+                    .into();
                 let output = serde_json::to_string_pretty(&sendable_schedule)?;
                 println!("{output}");
             }
@@ -905,7 +952,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     }
                 }
 
-                let csv_schedule_opt = Some(&schedule);
+                let csv_schedule_opt = schedule.as_ref();
                 match generate_scoresheets_for_event(
                     &mut portal_client,
                     &event,
@@ -950,7 +997,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                     continue 'outer;
                                 }
                             }
-                            let csv_schedule_opt = Some(&schedule);
+                            let csv_schedule_opt = schedule.as_ref();
                             match generate_scoresheets_for_event(
                                 &mut portal_client,
                                 &event,

--- a/schedule-processor/src/main.rs
+++ b/schedule-processor/src/main.rs
@@ -14,7 +14,7 @@ use std::{
     fmt::{Display, Write},
     vec,
 };
-use uwh_common::uwhportal::{UwhPortalClient, schedule::*};
+use uwh_common::uwhportal::{CoinFlipTeam, SetCoinFlipModel, UwhPortalClient, schedule::*};
 
 mod csv_parser;
 use csv_parser::parse_csv;
@@ -23,6 +23,9 @@ mod schedule_checks;
 use schedule_checks::run_schedule_checks;
 
 mod scoresheets;
+use scoresheets::{
+    RenderInputs, SheetStyle, generate_example_rule_sheets, generate_scoresheets_for_event,
+};
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
@@ -239,6 +242,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             UploadDisabled,
             SaveSchedule,
             PrintSchedule,
+            ResolveCoinTosses,
+            GenerateScoreSheets,
+            GenerateExampleSheets,
             SaveTeamMap,
             SaveTeamMapDisabled,
             PrintTeamMap,
@@ -254,6 +260,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     StepChoice::UploadDisabled => write!(f, "U̶p̶l̶o̶a̶d̶ ̶S̶c̶h̶e̶d̶u̶l̶e̶"),
                     StepChoice::SaveSchedule => write!(f, "Save Schedule to File"),
                     StepChoice::PrintSchedule => write!(f, "Print Schedule"),
+                    StepChoice::ResolveCoinTosses => write!(f, "Resolve Coin Tosses"),
+                    StepChoice::GenerateScoreSheets => write!(f, "Generate Score Sheets"),
+                    StepChoice::GenerateExampleSheets => {
+                        write!(f, "Generate Example Sheets (rule options)")
+                    }
                     StepChoice::SaveTeamMap => write!(f, "Save Team Map to File"),
                     StepChoice::SaveTeamMapDisabled => write!(f, "S̶a̶v̶e̶ ̶T̶e̶a̶m̶ ̶M̶a̶p̶ ̶t̶o̶ ̶F̶i̶l̶e̶"),
                     StepChoice::PrintTeamMap => write!(f, "Print Team Map"),
@@ -269,6 +280,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 StepChoice::UploadDisabled,
                 StepChoice::SaveSchedule,
                 StepChoice::PrintSchedule,
+                StepChoice::ResolveCoinTosses,
+                StepChoice::GenerateScoreSheets,
+                StepChoice::GenerateExampleSheets,
                 StepChoice::SaveTeamMapDisabled,
                 StepChoice::PrintTeamMapDisabled,
                 StepChoice::Exit,
@@ -279,6 +293,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 StepChoice::Upload,
                 StepChoice::SaveSchedule,
                 StepChoice::PrintSchedule,
+                StepChoice::ResolveCoinTosses,
+                StepChoice::GenerateScoreSheets,
+                StepChoice::GenerateExampleSheets,
                 StepChoice::SaveTeamMap,
                 StepChoice::PrintTeamMap,
                 StepChoice::Exit,
@@ -557,6 +574,423 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 error!(
                     "Printing team map cannot be performed at this time. Please map teams first."
                 );
+            }
+            StepChoice::ResolveCoinTosses => {
+                // Requires login to access privileged coin-flip endpoints.
+                if !portal_client.has_token() {
+                    #[allow(non_snake_case)]
+                    let emailOrusername =
+                        match Text::new("Enter your uwhportal emailOrusername:").prompt() {
+                            Ok(v) => v,
+                            Err(_) => {
+                                error!("No emailOrusername provided. Please try again.");
+                                continue 'outer;
+                            }
+                        };
+                    let password = match Password::new("Enter your uwhportal password:")
+                        .with_display_mode(PasswordDisplayMode::Masked)
+                        .without_confirmation()
+                        .prompt()
+                    {
+                        Ok(pass) => pass,
+                        Err(_) => {
+                            error!("No password provided. Please try again.");
+                            continue 'outer;
+                        }
+                    };
+                    match portal_client
+                        .login_with_email_and_password(&emailOrusername, &password)
+                        .await
+                    {
+                        Ok(token) => portal_client.set_token(&token),
+                        Err(e) => {
+                            error!("uwhportal login failed. Please try again. Reason: {e}");
+                            continue 'outer;
+                        }
+                    }
+                }
+
+                let team_lookup: BTreeMap<String, String> =
+                    match portal_client.get_event_teams(&event.id).await {
+                        Ok(teams) => teams
+                            .into_iter()
+                            .map(|(id, name)| (id.full().to_string(), name))
+                            .collect(),
+                        Err(_) => BTreeMap::new(),
+                    };
+
+                let details = match portal_client.get_coin_flips(&event.slug).await {
+                    Ok(d) => d,
+                    Err(e) => {
+                        error!("Failed to fetch coin tosses: {e}");
+                        continue 'outer;
+                    }
+                };
+
+                #[derive(Clone)]
+                struct FlipOption {
+                    label: String,
+                    group_identifier: Option<String>,
+                    coin_flip_identifier: String,
+                    teams: Vec<CoinFlipTeam>,
+                }
+                impl Display for FlipOption {
+                    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(f, "{}", self.label)
+                    }
+                }
+
+                let team_label = |t: &CoinFlipTeam| -> String {
+                    if let Some(id) = &t.team_id {
+                        team_lookup
+                            .get(id)
+                            .cloned()
+                            .unwrap_or_else(|| format!("Team {id}"))
+                    } else if let Some(n) = &t.pending_assignment_name {
+                        n.clone()
+                    } else {
+                        "<unknown>".to_string()
+                    }
+                };
+
+                let mut options: Vec<FlipOption> = Vec::new();
+                for g in details.groups {
+                    for flip in g.coin_flips {
+                        if flip.result.is_none() {
+                            let teams_str = flip.tied_teams.iter().map(team_label).join(" vs ");
+                            options.push(FlipOption {
+                                label: format!("Group {} — {}", g.name, teams_str),
+                                group_identifier: Some(g.identifier.clone()),
+                                coin_flip_identifier: flip.identifier.clone(),
+                                teams: flip.tied_teams,
+                            });
+                        }
+                    }
+                }
+                for flip in details.games {
+                    if flip.result.is_none() {
+                        let teams_str = flip.tied_teams.iter().map(team_label).join(" vs ");
+                        options.push(FlipOption {
+                            label: format!("Tied Game — {teams_str}"),
+                            group_identifier: None,
+                            coin_flip_identifier: flip.identifier,
+                            teams: flip.tied_teams,
+                        });
+                    }
+                }
+
+                if options.is_empty() {
+                    error!("No pending coin tosses for this event.");
+                    continue 'outer;
+                }
+
+                let selected = match Select::new("Select a coin toss to resolve:", options).prompt()
+                {
+                    Ok(s) => s,
+                    Err(_) => {
+                        error!("No selection made. Skipping.");
+                        continue 'outer;
+                    }
+                };
+
+                #[derive(Clone)]
+                struct TeamChoice {
+                    label: String,
+                    ident: String,
+                }
+                impl Display for TeamChoice {
+                    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(f, "{}", self.label)
+                    }
+                }
+
+                let team_choices: Vec<TeamChoice> = selected
+                    .teams
+                    .iter()
+                    .map(|t| TeamChoice {
+                        label: team_label(t),
+                        ident: t
+                            .team_id
+                            .clone()
+                            .or(t.pending_assignment_name.clone())
+                            .unwrap_or_default(),
+                    })
+                    .collect();
+
+                if team_choices.is_empty() {
+                    error!("No teams found on selected coin toss.");
+                    continue 'outer;
+                }
+
+                let picked_team = match Select::new(
+                    "Which team should win the coin toss?",
+                    team_choices,
+                )
+                .prompt()
+                {
+                    Ok(t) => t,
+                    Err(_) => {
+                        error!("No team selected.");
+                        continue 'outer;
+                    }
+                };
+
+                let kind = match Select::new("Outcome kind:", vec!["Favor", "Against"]).prompt() {
+                    Ok(k) => k.to_string(),
+                    Err(_) => {
+                        error!("No outcome kind selected.");
+                        continue 'outer;
+                    }
+                };
+
+                let model = SetCoinFlipModel {
+                    group_identifier: selected.group_identifier.clone(),
+                    coin_flip_identifier: selected.coin_flip_identifier.clone(),
+                    team_id_or_pending_assignment_name: picked_team.ident,
+                    kind,
+                };
+
+                match portal_client
+                    .set_coin_flip_result(&event.slug, &model, false)
+                    .await
+                {
+                    Ok(()) => info!("Coin toss resolved successfully."),
+                    Err(e) => error!("Failed to set coin toss: {e}"),
+                }
+            }
+            StepChoice::GenerateScoreSheets => {
+                let Some(output_dir) = FileDialog::new()
+                    .set_title("Select output folder for score sheets")
+                    .pick_folder()
+                else {
+                    error!("No output folder selected. Aborting.");
+                    continue 'outer;
+                };
+
+                let path_str = output_dir.to_string_lossy();
+                if path_str.contains('\'')
+                    || path_str.contains('"')
+                    || path_str.contains('&')
+                    || path_str.contains('!')
+                {
+                    log::warn!(
+                        "Output folder path contains special characters which may prevent PDF \
+                        generation. Consider a path without special characters."
+                    );
+                }
+
+                let style = match Select::new(
+                    "Sheet style:",
+                    vec!["Detailed", "Simple", "Simple (Team Refs)", "Col_3x3"],
+                )
+                .prompt()
+                {
+                    Ok("Simple") => SheetStyle::Simple,
+                    Ok("Simple (Team Refs)") => SheetStyle::SimpleTeamRefs,
+                    Ok("Col_3x3") => SheetStyle::Col3x3,
+                    Ok(_) => SheetStyle::Detailed,
+                    Err(_) => SheetStyle::Detailed,
+                };
+
+                let (left_logo, right_logo) = if style == SheetStyle::Detailed {
+                    let left = loop {
+                        let p = FileDialog::new()
+                            .add_filter("Images", &["png", "jpg", "jpeg", "svg"])
+                            .set_title("Select sanctioning body logo (left) — optional")
+                            .pick_file();
+                        match p {
+                            Some(p) if p.is_file() => break Some(p),
+                            Some(p) if p.is_dir() => {
+                                error!("Selected a folder. Please select an image file.");
+                                continue;
+                            }
+                            _ => break None,
+                        }
+                    };
+                    let right = loop {
+                        let p = FileDialog::new()
+                            .add_filter("Images", &["png", "jpg", "jpeg", "svg"])
+                            .set_title("Select tournament logo (right) — optional")
+                            .pick_file();
+                        match p {
+                            Some(p) if p.is_file() => break Some(p),
+                            Some(p) if p.is_dir() => {
+                                error!("Selected a folder. Please select an image file.");
+                                continue;
+                            }
+                            _ => break None,
+                        }
+                    };
+                    (left, right)
+                } else {
+                    (None, None)
+                };
+
+                let (ref_csv_path, prefer_portal_officials) = if style == SheetStyle::SimpleTeamRefs
+                {
+                    (None, false)
+                } else {
+                    let include_referees = Confirm::new("Include referee names on the scoresheet?")
+                        .with_default(true)
+                        .prompt()
+                        .unwrap_or(true);
+
+                    let csv_path = if include_referees {
+                        FileDialog::new()
+                            .add_filter("CSV files", &["csv"])
+                            .set_title("Select Referee Schedule CSV (optional)")
+                            .pick_file()
+                    } else {
+                        None
+                    };
+
+                    let prefer_officials = if csv_path.is_some() {
+                        Confirm::new(
+                            "Use portal display names instead of names from the Referee CSV?",
+                        )
+                        .with_default(true)
+                        .prompt()
+                        .unwrap_or(true)
+                    } else {
+                        false
+                    };
+
+                    (csv_path, prefer_officials)
+                };
+
+                let inputs = RenderInputs {
+                    left_logo,
+                    right_logo,
+                    output_dir,
+                    style,
+                    prefer_portal_officials,
+                };
+
+                if !portal_client.has_token() && style != SheetStyle::SimpleTeamRefs {
+                    if let Ok(true) =
+                        Confirm::new("Use display names for officials? (requires uwhportal login)")
+                            .with_default(true)
+                            .prompt()
+                    {
+                        #[allow(non_snake_case)]
+                        let emailOrusername =
+                            match Text::new("Enter your uwhportal emailOrusername:").prompt() {
+                                Ok(v) => v,
+                                Err(_) => {
+                                    error!(
+                                        "No emailOrusername provided. Proceeding without login."
+                                    );
+                                    String::new()
+                                }
+                            };
+                        if !emailOrusername.is_empty() {
+                            let password = Password::new("Enter your uwhportal password:")
+                                .with_display_mode(PasswordDisplayMode::Masked)
+                                .without_confirmation()
+                                .prompt()
+                                .unwrap_or_default();
+                            if !password.is_empty() {
+                                match portal_client
+                                    .login_with_email_and_password(&emailOrusername, &password)
+                                    .await
+                                {
+                                    Ok(token) => portal_client.set_token(&token),
+                                    Err(e) => error!(
+                                        "uwhportal login failed. Proceeding without login. \
+                                        Reason: {e}"
+                                    ),
+                                }
+                            }
+                        }
+                    }
+                }
+
+                let csv_schedule_opt = Some(&schedule);
+                match generate_scoresheets_for_event(
+                    &mut portal_client,
+                    &event,
+                    inputs.clone(),
+                    csv_schedule_opt,
+                    ref_csv_path.as_deref(),
+                )
+                .await
+                {
+                    Ok(()) => info!("Score sheets generated."),
+                    Err(e) => {
+                        let msg = e.to_string();
+                        if msg.contains("authentication required for schedule") {
+                            info!("Public schedule not available; prompting for login...");
+                            #[allow(non_snake_case)]
+                            let emailOrusername =
+                                match Text::new("Enter your uwhportal emailOrusername:").prompt() {
+                                    Ok(v) => v,
+                                    Err(_) => {
+                                        error!("No emailOrusername provided.");
+                                        continue 'outer;
+                                    }
+                                };
+                            let password = match Password::new("Enter your uwhportal password:")
+                                .with_display_mode(PasswordDisplayMode::Masked)
+                                .without_confirmation()
+                                .prompt()
+                            {
+                                Ok(pass) => pass,
+                                Err(_) => {
+                                    error!("No password provided.");
+                                    continue 'outer;
+                                }
+                            };
+                            match portal_client
+                                .login_with_email_and_password(&emailOrusername, &password)
+                                .await
+                            {
+                                Ok(token) => portal_client.set_token(&token),
+                                Err(e) => {
+                                    error!("Login failed: {e}");
+                                    continue 'outer;
+                                }
+                            }
+                            let csv_schedule_opt = Some(&schedule);
+                            match generate_scoresheets_for_event(
+                                &mut portal_client,
+                                &event,
+                                inputs,
+                                csv_schedule_opt,
+                                ref_csv_path.as_deref(),
+                            )
+                            .await
+                            {
+                                Ok(()) => info!("Score sheets generated."),
+                                Err(e2) => error!("Failed to generate score sheets: {e2}"),
+                            }
+                        } else {
+                            error!("Failed to generate score sheets: {e}");
+                        }
+                    }
+                }
+            }
+            StepChoice::GenerateExampleSheets => {
+                let Some(output_dir) = FileDialog::new()
+                    .set_title("Select output folder for example sheets")
+                    .pick_folder()
+                else {
+                    error!("No output folder selected. Aborting.");
+                    continue 'outer;
+                };
+
+                let style = match Select::new("Sheet style:", vec!["Detailed", "Simple", "Col_3x3"])
+                    .prompt()
+                {
+                    Ok("Simple") => SheetStyle::Simple,
+                    Ok("Col_3x3") => SheetStyle::Col3x3,
+                    Ok(_) => SheetStyle::Detailed,
+                    Err(_) => SheetStyle::Detailed,
+                };
+
+                match generate_example_rule_sheets(&output_dir, style) {
+                    Ok(()) => info!("Example sheets generated in {}", output_dir.display()),
+                    Err(e) => error!("Failed to generate example sheets: {e}"),
+                }
             }
             StepChoice::Exit => {
                 info!("Exiting the application.");

--- a/schedule-processor/src/main.rs
+++ b/schedule-processor/src/main.rs
@@ -114,7 +114,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         std::time::Duration::from_secs(10),
     )?;
 
-    let events = portal_client.get_event_list(false, false).await?;
+    let mut events = portal_client.get_event_list(false, false).await?;
+    // Show soonest events first: nearest date at the top, further-future toward the bottom.
+    events.sort_by_key(|e| e.date_range.start);
 
     struct SelectableEvent(Event);
 

--- a/schedule-processor/src/main.rs
+++ b/schedule-processor/src/main.rs
@@ -873,9 +873,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     (None, None)
                 };
 
-                let (ref_csv_path, prefer_portal_officials) = if style == SheetStyle::SimpleTeamRefs
+                let (ref_csv_path, prefer_portal_officials, include_referees) = if style
+                    == SheetStyle::SimpleTeamRefs
                 {
-                    (None, false)
+                    // Team-refs style uses team-based assignments, not official names.
+                    (None, false, false)
                 } else {
                     let include_referees = Confirm::new("Include referee names on the scoresheet?")
                         .with_default(true)
@@ -902,7 +904,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         false
                     };
 
-                    (csv_path, prefer_officials)
+                    (csv_path, prefer_officials, include_referees)
                 };
 
                 let inputs = RenderInputs {
@@ -911,9 +913,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     output_dir,
                     style,
                     prefer_portal_officials,
+                    include_referees,
                 };
 
-                if !portal_client.has_token() && style != SheetStyle::SimpleTeamRefs {
+                // Offer login only when referee names are wanted AND the portal is the chosen
+                // source (no CSV given, or a CSV was given but portal names are preferred).
+                // Portal official display names require a login.
+                let wants_portal_names =
+                    include_referees && (ref_csv_path.is_none() || prefer_portal_officials);
+                if wants_portal_names && !portal_client.has_token() {
                     if let Ok(true) =
                         Confirm::new("Use display names for officials? (requires uwhportal login)")
                             .with_default(true)

--- a/schedule-processor/src/main.rs
+++ b/schedule-processor/src/main.rs
@@ -22,6 +22,8 @@ use csv_parser::parse_csv;
 mod schedule_checks;
 use schedule_checks::run_schedule_checks;
 
+mod scoresheets;
+
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
 struct Args {

--- a/schedule-processor/src/scoresheets.rs
+++ b/schedule-processor/src/scoresheets.rs
@@ -253,10 +253,8 @@ pub async fn generate_scoresheets_for_event(
             ),
         };
 
-        let html_path = inputs
-            .output_dir
-            .join(format!("game-{}.html", sanitize(num)));
-        fs::write(&html_path, html.as_bytes())?;
+        // Per-game HTML is intermediate only (never read back); the PDF is built from the
+        // combined HTML below, so we don't write per-game files to the output folder.
 
         // Capture CSS from the first page and append this page fragment for combined output
         if combined_css.is_none() {
@@ -402,7 +400,18 @@ pub async fn generate_scoresheets_for_event(
             }
         }
 
-        if !printed {
+        if printed {
+            // Success: leave only the PDF. Remove the intermediate combined HTML and the
+            // copied logo images (already baked into the PDF).
+            let _ = fs::remove_file(&all_html_path);
+            if let Some(rel) = &left_logo_rel {
+                let _ = fs::remove_file(inputs.output_dir.join(rel));
+            }
+            if let Some(rel) = &right_logo_rel {
+                let _ = fs::remove_file(inputs.output_dir.join(rel));
+            }
+        } else {
+            // Keep the combined HTML on failure so there's something to inspect/recover.
             log::error!(
                 "Could not find or run a browser to produce combined PDF. Saved combined HTML at {}",
                 all_html_path.display()
@@ -411,12 +420,6 @@ pub async fn generate_scoresheets_for_event(
     }
 
     Ok(())
-}
-
-fn sanitize(s: &str) -> String {
-    s.chars()
-        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
-        .collect()
 }
 
 fn copy_logo(

--- a/schedule-processor/src/scoresheets.rs
+++ b/schedule-processor/src/scoresheets.rs
@@ -1,0 +1,2574 @@
+use std::collections::HashMap;
+use std::{
+    fmt, fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+use time::{
+    Duration as TimeDur, OffsetDateTime, format_description::FormatItem, macros::format_description,
+};
+use uwh_common::uwhportal::UwhPortalClient;
+use uwh_common::uwhportal::schedule::{
+    DateRange, Event, EventId, Game, ScheduledTeam, TeamId, TeamList, TimingRule,
+};
+
+#[derive(Clone, Debug)]
+pub struct PlayerInfo {
+    pub number: Option<u8>,
+    pub name: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct TeamRosterInfo {
+    pub players: Vec<PlayerInfo>,
+    pub captain: Option<String>,
+}
+
+#[derive(Debug)]
+struct AuthRequiredError;
+impl fmt::Display for AuthRequiredError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "authentication required for schedule")
+    }
+}
+impl std::error::Error for AuthRequiredError {}
+
+// Output style for scoresheets
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SheetStyle {
+    Detailed,
+    Simple,
+    SimpleTeamRefs,
+    Col3x3,
+}
+
+// Simple container for user inputs
+#[derive(Clone, Debug)]
+pub struct RenderInputs {
+    pub left_logo: Option<PathBuf>,
+    pub right_logo: Option<PathBuf>,
+    pub output_dir: PathBuf,
+    pub style: SheetStyle,
+    pub prefer_portal_officials: bool,
+}
+
+pub async fn generate_scoresheets_for_event(
+    portal_client: &mut UwhPortalClient,
+    event: &Event,
+    inputs: RenderInputs,
+    csv_schedule: Option<&uwh_common::uwhportal::schedule::Schedule>,
+    ref_csv_path: Option<&Path>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let schedule = if portal_client.has_token() {
+        // Prefer privileged schedule when we can; it includes referee assignments
+        portal_client
+            .get_event_schedule_privileged(&event.id)
+            .await?
+    } else {
+        match portal_client.get_event_schedule_public(&event.id).await {
+            Ok(s) => s,
+            Err(_) => return Err(Box::new(AuthRequiredError)),
+        }
+    };
+    let teams = portal_client.get_event_teams(&event.id).await?;
+
+    fs::create_dir_all(&inputs.output_dir)?;
+
+    // Copy logos into output dir for stable relative paths
+    let left_logo_rel = copy_logo(&inputs.output_dir, inputs.left_logo.as_deref(), "left")?;
+    let right_logo_rel = copy_logo(&inputs.output_dir, inputs.right_logo.as_deref(), "right")?;
+
+    // Load optional referee overrides from a CSV mapping (Game # -> names)
+    let ref_overrides: HashMap<String, OfficialNames> = if let Some(p) = ref_csv_path {
+        match parse_referee_csv(p) {
+            Ok(map) => map,
+            Err(e) => {
+                log::warn!(
+                    "Failed to parse referee schedule CSV ({}): {}",
+                    p.display(),
+                    e
+                );
+                HashMap::new()
+            }
+        }
+    } else {
+        HashMap::new()
+    };
+
+    let mut name_cache: HashMap<String, String> = HashMap::new();
+    // Pre-fill official name cache: try public /referees first (no auth), then merge /participants (auth)
+    match portal_client
+        .get_event_referee_name_map_from_referees(&event.id)
+        .await
+    {
+        Ok(map) => {
+            let count = map.len();
+            for (uid, name) in map {
+                name_cache.entry(uid).or_insert(name);
+            }
+            log::debug!("Prefilled {} official names from /referees", count);
+        }
+        Err(e) => {
+            log::warn!("Could not prefill officials from /referees: {}", e);
+        }
+    }
+    match portal_client.get_event_referee_name_map(&event.id).await {
+        Ok(map) => {
+            let mut added = 0usize;
+            for (uid, name) in map {
+                if name_cache.insert(uid.clone(), name).is_none() {
+                    added += 1;
+                }
+            }
+            log::debug!("Merged {} official names from /participants", added);
+        }
+        Err(e) => {
+            log::debug!(
+                "Participants map not available (unauthenticated or forbidden): {}",
+                e
+            );
+        }
+    }
+
+    // For combined single-PDF generation
+    let mut combined_pages: String = String::new();
+    let mut combined_css: Option<String> = None;
+
+    for (num, game) in schedule.games.iter() {
+        let (white_suffix, white_name) = placeholder_suffix_and_name(&game.light, &teams);
+        let (black_suffix, black_name) = placeholder_suffix_and_name(&game.dark, &teams);
+
+        // Decide official names based on preference: portal display names vs CSV
+        let officials = if inputs.prefer_portal_officials {
+            let resolved =
+                resolve_officials(&*portal_client, &event.id, game, &mut name_cache).await;
+            // Fallback to CSV for this game if portal provides nothing
+            if resolved.chief.is_empty()
+                && resolved.water1.is_empty()
+                && resolved.water2.is_empty()
+                && resolved.water3.is_empty()
+                && resolved.ts_keeper.is_empty()
+                && resolved.ts_helper.is_empty()
+            {
+                ref_overrides.get(num).cloned().unwrap_or(resolved)
+            } else {
+                resolved
+            }
+        } else if let Some(o) = ref_overrides.get(num) {
+            o.clone()
+        } else {
+            resolve_officials(&*portal_client, &event.id, game, &mut name_cache).await
+        };
+
+        let tr = find_timing_rule(game, csv_schedule, &schedule)?;
+
+        // Fetch rosters for Col3x3 scoresheet
+        let (black_roster, white_roster) = if matches!(inputs.style, SheetStyle::Col3x3) {
+            log::info!("Fetching rosters for game {}", num);
+            let black = fetch_team_roster(&*portal_client, game.dark.assigned()).await;
+            log::info!(
+                "Black team roster: {} players, captain: {:?}",
+                black.players.len(),
+                black.captain
+            );
+            let white = fetch_team_roster(&*portal_client, game.light.assigned()).await;
+            log::info!(
+                "White team roster: {} players, captain: {:?}",
+                white.players.len(),
+                white.captain
+            );
+            (black, white)
+        } else {
+            (
+                TeamRosterInfo {
+                    players: Vec::new(),
+                    captain: None,
+                },
+                TeamRosterInfo {
+                    players: Vec::new(),
+                    captain: None,
+                },
+            )
+        };
+
+        let html = match inputs.style {
+            SheetStyle::Detailed => render_html(
+                event,
+                num,
+                game,
+                csv_schedule.or(Some(&schedule)),
+                tr,
+                &white_suffix,
+                &white_name,
+                &black_suffix,
+                &black_name,
+                &officials,
+                left_logo_rel.as_deref(),
+                right_logo_rel.as_deref(),
+            ),
+            SheetStyle::Simple => render_html_simple(
+                event,
+                num,
+                game,
+                csv_schedule.or(Some(&schedule)),
+                tr,
+                &white_suffix,
+                &white_name,
+                &black_suffix,
+                &black_name,
+                &officials,
+            ),
+            SheetStyle::SimpleTeamRefs => render_html_simple_team_refs(
+                event,
+                num,
+                game,
+                Some(&schedule), // Use portal schedule directly for team ref data
+                tr,
+                &white_suffix,
+                &white_name,
+                &black_suffix,
+                &black_name,
+            ),
+            SheetStyle::Col3x3 => render_html_col3x3(
+                event,
+                num,
+                game,
+                csv_schedule.or(Some(&schedule)),
+                tr,
+                &white_suffix,
+                &white_name,
+                &black_suffix,
+                &black_name,
+                &officials,
+                &black_roster,
+                &white_roster,
+            ),
+        };
+
+        let html_path = inputs
+            .output_dir
+            .join(format!("game-{}.html", sanitize(num)));
+        fs::write(&html_path, html.as_bytes())?;
+
+        // Capture CSS from the first page and append this page fragment for combined output
+        if combined_css.is_none() {
+            if let (Some(s), Some(e)) = (html.find("<style>"), html.find("</style>")) {
+                let css_inner = &html[s + "<style>".len()..e];
+                combined_css = Some(css_inner.to_string());
+            }
+        }
+        if let Some(s) = html.find("<div class='page'>") {
+            // Prefer slicing up to the closing </div> immediately before </body>,
+            // so we include the full page wrapper regardless of how many nested divs are inside.
+            if let Some(body_idx) = html.rfind("</body>") {
+                if let Some(d) = html[..body_idx].rfind("</div>") {
+                    let frag = &html[s..d + "</div>".len()];
+                    combined_pages.push_str(frag);
+                } else {
+                    log::warn!(
+                        "Could not find closing </div> before </body> for game {}",
+                        num
+                    );
+                }
+            } else if let Some(e) = html.rfind("</div></div>") {
+                // Fallback for pages that end with two closing divs right before </body>
+                let frag = &html[s..e + "</div></div>".len()];
+                combined_pages.push_str(frag);
+            } else {
+                log::warn!("Could not extract page fragment for game {}", num);
+            }
+        } else {
+            log::warn!("Page wrapper not found for game {}", num);
+        }
+    }
+
+    // Build combined HTML and export a single PDF via Chrome headless
+    if !combined_pages.is_empty() {
+        let css = combined_css.unwrap_or_default();
+        let all_html = format!(
+            r#"<!doctype html><html><head><meta charset='utf-8'/><style>{css}</style></head><body>{pages}</body></html>"#,
+            css = css,
+            pages = combined_pages
+        );
+        let all_html_path = inputs.output_dir.join("scoresheets-all.html");
+        fs::write(&all_html_path, all_html.as_bytes())?;
+        let all_pdf_path = inputs.output_dir.join("scoresheets-all.pdf");
+
+        // Convert to file:/// URL for Chrome without introducing Windows \\?\ prefix
+        let html_abs = if all_html_path.is_absolute() {
+            all_html_path.clone()
+        } else {
+            std::env::current_dir()
+                .unwrap_or_else(|_| std::path::PathBuf::from("."))
+                .join(&all_html_path)
+        };
+        let html_url = format!("file:///{}", html_abs.to_string_lossy().replace('\\', "/"));
+
+        // Hardwire Chrome: prefer standard install paths, then PATH 'chrome'
+        let mut candidates: Vec<String> = vec![
+            r#"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe"#.into(),
+            r#"C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe"#.into(),
+        ];
+        if let Ok(local) = std::env::var("LOCALAPPDATA") {
+            let mut p = std::path::PathBuf::from(&local);
+            p.push("Google\\Chrome\\Application\\chrome.exe");
+            candidates.push(p.to_string_lossy().into_owned());
+        }
+        candidates.push("chrome".into());
+        let try_arg_sets: [&[&str]; 4] = [
+            &[
+                "--headless=new",
+                "--disable-gpu",
+                "--allow-file-access-from-files",
+                "--virtual-time-budget=8000",
+                "--no-sandbox",
+                "--disable-extensions",
+                "--disable-dev-shm-usage",
+            ],
+            &[
+                "--headless",
+                "--disable-gpu",
+                "--allow-file-access-from-files",
+                "--virtual-time-budget=8000",
+                "--no-sandbox",
+                "--disable-extensions",
+                "--disable-dev-shm-usage",
+            ],
+            &[
+                "--headless=new",
+                "--disable-gpu",
+                "--allow-file-access-from-files",
+                "--run-all-compositor-stages-before-draw",
+                "--no-sandbox",
+            ],
+            &[
+                "--headless",
+                "--disable-gpu",
+                "--allow-file-access-from-files",
+                "--run-all-compositor-stages-before-draw",
+                "--no-sandbox",
+            ],
+        ];
+        let mut printed = false;
+        'outer: for c in &candidates {
+            // If 'c' looks like a path, ensure it exists before trying
+            let is_path_like = c.contains('\\') || c.contains('/') || c.contains(':');
+            if is_path_like && !std::path::Path::new(c).exists() {
+                log::warn!("Chrome not found at: {}", c);
+                continue;
+            }
+            for args in &try_arg_sets {
+                let mut cmd = Command::new(c);
+                let print_arg = format!("--print-to-pdf={}", all_pdf_path.display());
+                cmd.args(*args)
+                    .arg("--no-first-run")
+                    .arg("--no-default-browser-check")
+                    .arg(print_arg)
+                    .arg(&html_url);
+                log::info!(
+                    "Attempting to print via '{}' url={} pdf={}",
+                    c,
+                    &html_url,
+                    all_pdf_path.display()
+                );
+                match cmd.output() {
+                    Ok(out) if out.status.success() => {
+                        log::info!("Wrote combined PDF to {}", all_pdf_path.display());
+                        printed = true;
+                        break 'outer;
+                    }
+                    Ok(out) => {
+                        let so = String::from_utf8_lossy(&out.stdout);
+                        let se = String::from_utf8_lossy(&out.stderr);
+                        log::error!(
+                            "Chrome run failed (status {}). stdout: {} stderr: {}",
+                            out.status,
+                            so,
+                            se
+                        );
+                    }
+                    Err(e) => {
+                        log::error!("Failed to run Chrome '{}': {}", c, e);
+                    }
+                }
+            }
+        }
+
+        if !printed {
+            log::error!(
+                "Could not find or run a browser to produce combined PDF. Saved combined HTML at {}",
+                all_html_path.display()
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn sanitize(s: &str) -> String {
+    s.chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect()
+}
+
+fn copy_logo(
+    output_dir: &Path,
+    src: Option<&Path>,
+    stem: &str,
+) -> Result<Option<String>, Box<dyn std::error::Error>> {
+    if let Some(src) = src {
+        let ext = src.extension().and_then(|e| e.to_str()).unwrap_or("png");
+        let dst = output_dir.join(format!("{}.{ext}", stem));
+        fs::copy(src, &dst)?;
+        return Ok(Some(
+            dst.file_name().unwrap().to_string_lossy().into_owned(),
+        ));
+    }
+    Ok(None)
+}
+
+fn placeholder_suffix_and_name(team: &ScheduledTeam, teams: &TeamList) -> (String, String) {
+    if let Some(id) = team.assigned() {
+        let name = teams
+            .get(id)
+            .cloned()
+            .unwrap_or_else(|| id.partial().to_string());
+        // Treat any assigned team whose name contains "Seed" (case-insensitive) as a placeholder suffix
+        if name.to_ascii_lowercase().contains("seed") {
+            (format!(" ({})", name), String::new())
+        } else {
+            (String::new(), name)
+        }
+    } else if let Some(r) = team.result_of() {
+        match r {
+            uwh_common::uwhportal::schedule::ResultOf::Winner { game_number } => {
+                (format!(" (Winner {})", game_number), String::new())
+            }
+            uwh_common::uwhportal::schedule::ResultOf::Loser { game_number } => {
+                (format!(" (Loser {})", game_number), String::new())
+            }
+        }
+    } else if let Some(s) = team.seeded_by() {
+        let group_name = s.group.as_deref().unwrap_or("Unknown");
+        (
+            format!(" (Seed {} {})", s.number, group_name),
+            String::new(),
+        )
+    } else if let Some(p) = team.pending() {
+        let up = p.to_ascii_uppercase();
+        if up.contains("SEED")
+            || up.starts_with("W_")
+            || up.starts_with("L_")
+            || up.contains("WINNER")
+            || up.contains("LOSER")
+        {
+            (format!(" ({})", p), String::new())
+        } else {
+            // Treat as a free-text team name if not a recognized placeholder pattern
+            (String::new(), p.to_string())
+        }
+    } else {
+        (String::new(), String::new())
+    }
+}
+
+fn derive_category(rule_name: &str) -> &'static str {
+    let up = rule_name.to_ascii_uppercase();
+    if up.contains("RR") {
+        "Round Robin"
+    } else if up.contains("XO") {
+        "Crossover"
+    } else if up.contains("PO") {
+        "Playoff"
+    } else if up.contains("MD") {
+        "Medal Game"
+    } else {
+        ""
+    }
+}
+
+fn div_pod_for_game(
+    csv_schedule: Option<&uwh_common::uwhportal::schedule::Schedule>,
+    game_number: &str,
+) -> Option<(String, String, String)> {
+    // Returns (div_short, div_long, pod_short)
+    let mut div_short: Option<String> = None;
+    let mut div_long: Option<String> = None;
+    let mut pod_short: Option<String> = None;
+    let sched = csv_schedule?;
+    // Normalize target by stripping a leading 'G' (common notation differences)
+    let target_norm = game_number.trim_start_matches(|c: char| ['G', 'g'].contains(&c));
+    for g in &sched.groups {
+        // Match if any group game number equals raw or normalized target (case-insensitive)
+        let matches_group = g.game_numbers.iter().any(|n| {
+            let n_str = n.as_str();
+            let n_norm = n_str.trim_start_matches(|c: char| ['G', 'g'].contains(&c));
+            n_str.eq_ignore_ascii_case(game_number) || n_norm.eq_ignore_ascii_case(target_norm)
+        });
+        if matches_group {
+            if let Some(t) = g.group_type {
+                match t {
+                    uwh_common::uwhportal::schedule::GroupType::Division => {
+                        if !g.short_name.is_empty() {
+                            div_short = Some(g.short_name.clone());
+                        }
+                        if !g.name.is_empty() {
+                            div_long = Some(g.name.clone());
+                        }
+                    }
+                    uwh_common::uwhportal::schedule::GroupType::Pod => {
+                        if !g.short_name.is_empty() {
+                            pod_short = Some(g.short_name.clone());
+                        }
+                    }
+                }
+            }
+        }
+    }
+    match (div_short, div_long, pod_short) {
+        (Some(ds), Some(dl), Some(ps)) => Some((ds, dl, ps)),
+        (Some(ds), Some(dl), None) => Some((ds, dl, String::new())),
+        (None, None, Some(ps)) => Some((String::new(), String::new(), ps)),
+        _ => None,
+    }
+}
+
+fn find_timing_rule<'a>(
+    game: &Game,
+    csv_sched: Option<&'a uwh_common::uwhportal::schedule::Schedule>,
+    portal_sched: &'a uwh_common::uwhportal::schedule::Schedule,
+) -> Result<&'a uwh_common::uwhportal::schedule::TimingRule, Box<dyn std::error::Error>> {
+    // Prefer CSV timing rules (last value wins) when available
+    if let Some(cs) = csv_sched {
+        if let Some(tr) = cs.get_game_timing(&game.number) {
+            return Ok(tr);
+        }
+        if let Some(tr) = cs
+            .timing_rules
+            .iter()
+            .find(|tr| tr.name == game.timing_rule)
+        {
+            return Ok(tr);
+        }
+    }
+    if let Some(tr) = portal_sched.get_game_timing(&game.number) {
+        return Ok(tr);
+    }
+    if let Some(tr) = portal_sched
+        .timing_rules
+        .iter()
+        .find(|tr| tr.name == game.timing_rule)
+    {
+        return Ok(tr);
+    }
+    Err(format!(
+        "Missing timing rule '{}'. Please ensure CSV has complete timing rules for this name.",
+        game.timing_rule
+    )
+    .into())
+}
+
+#[derive(Default, Clone)]
+struct OfficialNames {
+    chief: String,
+    water1: String,
+    water2: String,
+    water3: String,
+    ts_keeper: String,
+    ts_helper: String,
+}
+
+async fn resolve_officials(
+    portal_client: &UwhPortalClient,
+    event_id: &EventId,
+    game: &Game,
+    cache: &mut HashMap<String, String>,
+) -> OfficialNames {
+    let mut names = OfficialNames::default();
+    if let Some(list) = &game.referee_assignments {
+        let mut fetched_for_game = false;
+        for a in list {
+            // Skip if user_id is None (unassigned referee slot)
+            let user_id = match &a.user_id {
+                Some(uid) => uid,
+                None => continue,
+            };
+            let display = if let Some(n) = cache.get(user_id) {
+                n.clone()
+            } else {
+                // On first miss for this game, fetch all game refs in one call
+                if !fetched_for_game {
+                    if let Ok(per_game) = portal_client
+                        .get_game_referee_name_map(event_id, &game.number)
+                        .await
+                    {
+                        for (uid, name) in per_game {
+                            cache.entry(uid).or_insert(name);
+                        }
+                        log::debug!(
+                            "Filled official names from /admin/events/game-referees for game {}",
+                            game.number
+                        );
+                    }
+                    fetched_for_game = true;
+                }
+                // Fall back to the last segment of the user ID (e.g. "abc123")
+                cache.get(user_id).cloned().unwrap_or_else(|| {
+                    user_id
+                        .split('/')
+                        .next_back()
+                        .unwrap_or(user_id)
+                        .to_string()
+                })
+            };
+
+            match a.role.as_str() {
+                "Chief" => names.chief = display,
+                "Water1" => names.water1 = display,
+                "Water2" => names.water2 = display,
+                "Water3" => names.water3 = display,
+                "TimeOrScoreKeeper" => names.ts_keeper = display,
+                "TimeOrScoreHelper" => names.ts_helper = display,
+
+                other => {
+                    let low = other.to_ascii_lowercase();
+                    if low.contains("helper") {
+                        names.ts_helper = display;
+                    }
+                }
+            }
+        }
+    }
+    names
+}
+
+async fn fetch_team_roster(
+    portal_client: &UwhPortalClient,
+    team_id: Option<&TeamId>,
+) -> TeamRosterInfo {
+    if let Some(id) = team_id {
+        log::debug!("fetch_team_roster: Fetching roster for team {}", id);
+        match portal_client.get_team_roster(id).await {
+            Ok((players, captain)) => {
+                log::debug!(
+                    "fetch_team_roster: Got {} players and captain: {:?}",
+                    players.len(),
+                    captain
+                );
+                let player_infos = players
+                    .into_iter()
+                    .map(|(number, name)| PlayerInfo { number, name })
+                    .collect();
+                TeamRosterInfo {
+                    players: player_infos,
+                    captain,
+                }
+            }
+            Err(e) => {
+                log::warn!("Failed to fetch roster for team {}: {}", id, e);
+                TeamRosterInfo {
+                    players: Vec::new(),
+                    captain: None,
+                }
+            }
+        }
+    } else {
+        log::debug!("fetch_team_roster: No team_id provided");
+        TeamRosterInfo {
+            players: Vec::new(),
+            captain: None,
+        }
+    }
+}
+
+fn parse_referee_csv(
+    path: &Path,
+) -> Result<HashMap<String, OfficialNames>, Box<dyn std::error::Error>> {
+    let mut rdr = csv::ReaderBuilder::new()
+        .trim(csv::Trim::All)
+        .flexible(true)
+        .from_path(path)?;
+    let headers = rdr.headers()?.clone();
+    let find_idx = |name: &str| -> Result<usize, String> {
+        headers
+            .iter()
+            .position(|h| h.eq_ignore_ascii_case(name))
+            .ok_or_else(|| format!("Missing '{}' header in referee CSV", name))
+    };
+    let idx_game = find_idx("Game #")?;
+    let idx_w1 = find_idx("Water 1")?;
+    let idx_w2 = find_idx("Water 2")?;
+    let idx_w3 = find_idx("Water 3")?;
+    let idx_chief = find_idx("Chief")?;
+    let idx_keeper = find_idx("T/S Keeper")?;
+    let idx_helper = find_idx("T/S Helper")?;
+
+    let mut map: HashMap<String, OfficialNames> = HashMap::new();
+    for result in rdr.records() {
+        let rec = result?;
+        let game = rec.get(idx_game).unwrap_or("").trim().to_string();
+        if game.is_empty() {
+            continue;
+        }
+        let get = |i: usize| rec.get(i).unwrap_or("").trim().to_string();
+        let names = OfficialNames {
+            chief: get(idx_chief),
+            water1: get(idx_w1),
+            water2: get(idx_w2),
+            water3: get(idx_w3),
+            ts_keeper: get(idx_keeper),
+            ts_helper: get(idx_helper),
+        };
+        map.insert(game, names);
+    }
+    Ok(map)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn render_html(
+    event: &Event,
+    game_number: &str,
+    game: &Game,
+    csv_schedule: Option<&uwh_common::uwhportal::schedule::Schedule>,
+    tr: &uwh_common::uwhportal::schedule::TimingRule,
+    white_suffix: &str,
+    white_name: &str,
+    black_suffix: &str,
+    black_name: &str,
+    officials: &OfficialNames,
+    left_logo: Option<&str>,
+    right_logo: Option<&str>,
+) -> String {
+    // Date/time formatting in event timezone
+    let offset = event.date_range.start.offset();
+    let local_dt: OffsetDateTime = game.start_time.to_offset(offset);
+    // Example: Fri - Oct 17
+    const DATE_FMT: &[FormatItem<'static>] =
+        format_description!("[weekday repr:short] - [month repr:short] [day padding:none]");
+    // Example: 10:15 AM
+    const TIME_FMT: &[FormatItem<'static>] =
+        format_description!("[hour repr:12]:[minute] [period case:upper]");
+    let date_str = local_dt.format(&DATE_FMT).unwrap_or_default();
+    let time_str = local_dt.format(&TIME_FMT).unwrap_or_default();
+
+    // CSS ported from scoresheet-mock for pixel-match layout
+    let css = r#"
+      :root { --border:#888; --accent:#cc2b2b; }
+      * { box-sizing:border-box; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+      body { font-family: Arial, Helvetica, sans-serif; margin:18px; color:#000; }
+      .page { width: 11in; height: 8.5in; margin: 0 auto; border:1px solid #cfcfcf; padding:0.25in calc(0.25in - 10px); background:#fff; overflow:hidden; }
+      @media print {
+        @page { size: 11in 8.5in; margin: 0; }
+        html, body { width:11in; height:8.5in; margin:0; }
+        .page { width: 11in; height: 8.5in; margin: 0; padding:0.25in calc(0.25in - 10px); }
+      }
+      .inner { width:100%; transform: scale(0.95); transform-origin: top center; }
+
+
+      .top-pad { height:48px; border:0; margin-bottom:8px; }
+
+      .blue { display:grid; grid-template-columns: 120px 1fr 120px; gap:8px; align-items:stretch; border:1px solid var(--border); padding:6px; }
+      .logo-square { border:0; aspect-ratio:1 / 1; display:flex; align-items:center; justify-content:center; text-align:center; font-size:12px; }
+      .logo-square img { max-width:100%; max-height:100%; object-fit:contain; }
+      .center { display:grid; grid-template-rows: auto auto auto auto; gap:4px; }
+      .center .tname { text-align:center; font-weight:700; color:#000; font-size:22px; border:1px solid var(--border); padding:4px 8px; }
+      .fields { display:grid; gap:5px; }
+      .fields.meta { grid-template-columns: 0.69fr 0.9fr 1fr 0.75fr 0.9fr 0.9fr; }
+      .fields.off1, .fields.off2 { grid-template-columns: repeat(3, 1fr); }
+      .field { display:grid; grid-template-columns: auto 1fr; align-items:center; column-gap:6px; }
+      .field .lbl { font-size:10px; text-align:right; line-height:1.05; white-space:nowrap; }
+      .field .val { border:1px solid var(--border); height:22px; display:flex; align-items:center; justify-content:center; font-size:12px; }
+
+      .sides { display:grid; grid-template-columns:1fr 1fr; gap:9px; margin-top:5px; }
+      .block { border:0; }
+      .block > * + * { margin-top:6px; }
+      .block .hdr { display:none; }
+
+      table.sheet { width:100%; border-collapse:collapse; font-size:11px; }
+      table.sheet col.col-period { width:75px; }
+      table.sheet col.col-score { width:30px; }
+      table.sheet col.col-pgt { width:120px; }
+      table.sheet.score { table-layout: fixed; }
+      table.sheet.score col.col-score { width:17.4px; }
+      table.sheet.score col.col-pgt { width:70px; }
+      table.sheet.score col.col-sub { width:50px; }
+      table.sheet.score col.col-timeouts { width:60px; }
+      /* Uniform widths for faults and penalty numeric columns */
+      table.sheet.faults { table-layout: fixed; }
+      table.sheet.faults col.col-infra, table.sheet.faults col.col-warn { width:16.5px; }
+      table.sheet.penalty { table-layout: fixed; }
+      table.sheet.penalty col.col-pen { width:16.5px; }
+      table.sheet.faults th:not(.tl), table.sheet.faults td:not(.tl) { padding:1px 0; }
+      table.sheet.penalty th:not(.tl), table.sheet.penalty td:not(.tl) { padding:1px 0; }
+      table.sheet.score th, table.sheet.score td { padding:2px 1px; }
+      .sheet th, .sheet td { border:1px solid var(--border); padding:2px 2px; text-align:center; height:16px; }
+      .sheet tr.final td { border-top:2px solid #666; }
+      .sheet th.tl, .sheet td.tl { text-align:left; }
+      .sheet th.period, .sheet td.period { white-space:nowrap; width:75px; }
+      .sheet th.pgt, .sheet td.pgt { white-space:normal; }
+      .sheet td.final-score { padding:1px 1px; }
+      .sheet tr.sep-top td, .sheet tr.sep-top th { border-top-width:2px; }
+      .sheet tr.notes-final td, .sheet tr.notes-final th { border-top-width:2px; }
+
+      .sheet tr.score-numbers th { border-bottom:2px solid var(--border); }
+      table.sheet:not(.faults):not(.penalty) tr > th:nth-child(2),
+      table.sheet:not(.faults):not(.penalty) tr > td:nth-child(2) { border-left-width:2px; }
+      table.sheet.score tr:not(.notes-final) > th:nth-child(16),
+      table.sheet.score tr:not(.notes-final) > td:nth-child(16) { border-left-width:2px; border-right-width:2px; }
+      table.sheet.score tr:not(.notes-final) > th:nth-child(17),
+      table.sheet.score tr:not(.notes-final) > td:nth-child(17) { border-left-width:2px; border-right-width:2px; }
+      table.sheet.score tr:not(.notes-final) > th:nth-child(18),
+      table.sheet.score tr:not(.notes-final) > td:nth-child(18) { border-right-width:2px; }
+
+      table.sheet.score tr.cap-row > th:nth-child(3),
+      table.sheet.score tr.cap-row > th:nth-child(4) { border-left-width:2px; border-right-width:2px; }
+      table.sheet.score tr.score-numbers > th:nth-child(14) { border-right-width:2px; }
+      table.sheet.score tr.gold-goal > td:nth-child(3) { border-right-width:2px; }
+      table.sheet.score tr.gold-goal > td:nth-child(4),
+      table.sheet.score tr.gold-goal > td:nth-child(5) { border-left-width:2px; border-right-width:2px; }
+      table.sheet.score tr.notes-final > td.final-score { border-right-width:2px; border-bottom-width:2px; }
+      table.sheet.score tr.notes-final > td:nth-child(3) { border-left-width:2px; }
+      table.sheet:not(.faults):not(.penalty) tr.score-numbers > th:nth-child(1) { border-left-width:2px; }
+      table.sheet:not(.faults):not(.penalty) tr:not(.notes-final) > th:nth-child(16),
+      table.sheet:not(.faults):not(.penalty) tr:not(.notes-final) > td:nth-child(16),
+      table.sheet:not(.faults):not(.penalty) tr:not(.notes-final) > th:nth-child(17),
+      table.sheet:not(.faults):not(.penalty) tr:not(.notes-final) > td:nth-child(17),
+      table.sheet:not(.faults):not(.penalty) tr:not(.notes-final) > th:nth-child(18),
+      table.sheet:not(.faults):not(.penalty) tr:not(.notes-final) > td:nth-child(18) { border-left-width:2px; }
+      .sheet .final-score { font-weight:700; font-size:18px; text-align:left; white-space:nowrap; padding-left:6px; }
+      .faults .sep-left { border-left:2px solid var(--border); }
+      /* Disabled cells: white background with a small gray text 'X' centered */
+      td.speckled { position: relative; background:transparent; }
+      td.speckled::before {
+        content: "X";
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        transform: translate(-50%, -52%);
+        font-size: 10px;
+        line-height: 1;
+        color: #9b9b9b;
+        font-weight: 600;
+        pointer-events: none;
+      }
+      .side.black table.sheet tr.cap-row th, .side.black table.sheet tr.cap-row td { background:#D3D3D3; }
+      .side.black table.sheet tr.score-numbers th { background:#D3D3D3; }
+      .side.black table.sheet.faults tr:nth-child(2) th { background:#D3D3D3; }
+      .side.black .team-row { background:#D3D3D3; }
+      .side.black td.final-score, .side.black table.sheet.score tr.notes-final > td:nth-last-child(2) { background:#D3D3D3; }
+      .side.black table.sheet.score tr.notes-final > td:last-child { background:#D3D3D3; }
+      .sigline { margin-top:55px; display:grid; grid-template-columns: 1fr 1fr 1fr; gap:30px; color:#333; font-size:11px; }
+      .sigline .line { border-top:1px solid var(--border); text-align:center; padding-top:5px; height:32px; }
+      .team-row { display:grid; grid-template-columns: auto 1fr; align-items:center; column-gap:8px; border:1px solid var(--border); padding:5px; margin-top:6px; }
+      .team-label { font-weight:700; text-align:left; }
+      .team-label .suffix { font-weight:400; }
+      .team-name { text-align:center; }
+    "#;
+
+    // Render sections
+    let score_table = score_section_with_rules(tr);
+    let faults_table = faults_warnings_section();
+    let penalty_table = time_penalty_section_fixed();
+
+    // Category and division/pod
+    let cat = derive_category(&game.timing_rule);
+    // Per request: always display Division Long name (fallback to Division Short), even if there is a pod
+    let divpod = if let Some((div_short, div_long, _pod_short)) =
+        div_pod_for_game(csv_schedule, game_number)
+    {
+        if !div_long.is_empty() {
+            div_long
+        } else {
+            div_short
+        }
+    } else {
+        String::new()
+    };
+
+    // Logos inside squares
+    let left_square = if let Some(src) = left_logo {
+        format!("<img class='logo-in-square' src=\"{}\"/>", html_escape(src))
+    } else {
+        "SANCTIONING<br/>BODY LOGO".to_string()
+    };
+    let right_square = if let Some(src) = right_logo {
+        format!("<img class='logo-in-square' src=\"{}\"/>", html_escape(src))
+    } else {
+        "TOURNAMENT<br/>LOGO".to_string()
+    };
+
+    // Combined side blocks
+    let side_white = format!(
+        "<div class='block'>\
+           <div class='team-row'><div class='team-label'>WHITE TEAM<span class='suffix'>{}</span></div><div class='team-name'>{}</div></div>\
+           {}{}{}\
+         </div>",
+        html_escape(white_suffix),
+        html_escape(white_name),
+        faults_table,
+        penalty_table,
+        score_table
+    );
+    let side_black = format!(
+        "<div class='block'>\
+           <div class='team-row'><div class='team-label'>BLACK TEAM<span class='suffix'>{}</span></div><div class='team-name'>{}</div></div>\
+           {}{}{}\
+         </div>",
+        html_escape(black_suffix),
+        html_escape(black_name),
+        faults_table,
+        penalty_table,
+        score_table
+    );
+
+    format!(
+        r#"<!doctype html><html><head><meta charset='utf-8'/>
+  <title>Scoresheet G{game_number}</title>
+  <style>{css}</style>
+</head><body>
+<div class='page'><div class='inner'>
+  <div class='top-pad'></div>
+  <div class='blue'>
+    <div class='logo-square'>{left_square}</div>
+    <div class='center'>
+      <div class='tname'>{event_name}</div>
+      <div class='fields meta'>
+        <div class='field'><div class='lbl'>GAME #:</div><div class='val'>{game_number}</div></div>
+        <div class='field'><div class='lbl'>DIV. / POD:</div><div class='val'>{divpod}</div></div>
+        <div class='field'><div class='lbl'>CATEGORY:</div><div class='val'>{category}</div></div>
+        <div class='field'><div class='lbl'>DATE:</div><div class='val'>{date}</div></div>
+        <div class='field'><div class='lbl'>SCHEDULED<br>START TIME:</div><div class='val'>{time}</div></div>
+        <div class='field'><div class='lbl'>ACTUAL<br>START TIME:</div><div class='val'></div></div>
+      </div>
+      <div class='fields off1'>
+        <div class='field'><div class='lbl'>CHIEF REF:</div><div class='val'>{chief}</div></div>
+        <div class='field'><div class='lbl'>T/S KEEPER:</div><div class='val'>{ts_keeper}</div></div>
+        <div class='field'><div class='lbl'>T/S HELPER:</div><div class='val'>{ts_helper}</div></div>
+      </div>
+      <div class='fields off2'>
+        <div class='field'><div class='lbl'>WATER REF 1:</div><div class='val'>{water1}</div></div>
+        <div class='field'><div class='lbl'>WATER REF 2:</div><div class='val'>{water2}</div></div>
+        <div class='field'><div class='lbl'>WATER REF 3:</div><div class='val'>{water3}</div></div>
+      </div>
+    </div>
+    <div class='logo-square'>{right_square}</div>
+  </div>
+  <div class='sides'>
+    <div class='side white'>{side_white}</div>
+    <div class='side black'>{side_black}</div>
+  </div>
+  <div class='sigline'>
+    <div class='line'>WHITE CAPTAIN SIGNATURE</div>
+    <div class='line'>CHIEF REFEREE SIGNATURE</div>
+    <div class='line'>BLACK CAPTAIN SIGNATURE</div>
+  </div>
+</div></div>
+</body></html>
+        "#,
+        css = css,
+        event_name = html_escape(&event.name),
+        game_number = html_escape(game_number),
+        divpod = html_escape(&divpod),
+        category = html_escape(cat),
+        date = html_escape(&date_str),
+        time = html_escape(&time_str),
+        chief = html_escape(&officials.chief),
+        water1 = html_escape(&officials.water1),
+        water2 = html_escape(&officials.water2),
+        water3 = html_escape(&officials.water3),
+        ts_keeper = html_escape(&officials.ts_keeper),
+        ts_helper = html_escape(&officials.ts_helper),
+        left_square = left_square,
+        right_square = right_square,
+        side_white = side_white,
+        side_black = side_black,
+    )
+}
+
+// Simple scoresheet layout (portrait) - English format with halves as columns, gray shading on black team
+#[allow(clippy::too_many_arguments)]
+fn render_html_simple(
+    event: &Event,
+    game_number: &str,
+    game: &Game,
+    csv_schedule: Option<&uwh_common::uwhportal::schedule::Schedule>,
+    tr: &uwh_common::uwhportal::schedule::TimingRule,
+    white_suffix: &str,
+    white_name: &str,
+    black_suffix: &str,
+    black_name: &str,
+    officials: &OfficialNames,
+) -> String {
+    // Date/time formatting in event timezone - include day of week
+    let offset = event.date_range.start.offset();
+    let local_dt: OffsetDateTime = game.start_time.to_offset(offset);
+    const DATE_FMT: &[FormatItem<'static>] =
+        format_description!("[weekday repr:long] [month repr:long] [day padding:none]");
+    const TIME_FMT: &[FormatItem<'static>] =
+        format_description!("[hour repr:12]:[minute] [period case:upper]");
+    let date_str = local_dt.format(&DATE_FMT).unwrap_or_default();
+    let time_str = local_dt.format(&TIME_FMT).unwrap_or_default();
+
+    // Team labels with suffix
+    let white_label = if white_suffix.is_empty() {
+        white_name.to_string()
+    } else if white_name.is_empty() {
+        white_suffix
+            .trim_matches(|c| c == '(' || c == ')' || c == ' ')
+            .to_string()
+    } else {
+        format!("{} {}", white_name, white_suffix)
+    };
+    let black_label = if black_suffix.is_empty() {
+        black_name.to_string()
+    } else if black_name.is_empty() {
+        black_suffix
+            .trim_matches(|c| c == '(' || c == ')' || c == ' ')
+            .to_string()
+    } else {
+        format!("{} {}", black_name, black_suffix)
+    };
+
+    // Category (type)
+    let cat = derive_category(&game.timing_rule);
+
+    // Division/Pod for display (reserved for future use)
+    let _divpod = if let Some((div_short, div_long, _pod_short)) =
+        div_pod_for_game(csv_schedule, game_number)
+    {
+        if !div_long.is_empty() {
+            div_long
+        } else {
+            div_short
+        }
+    } else {
+        String::new()
+    };
+
+    // Water refs combined text with extra spacing
+    let mut water_refs = Vec::new();
+    if !officials.water1.is_empty() {
+        water_refs.push(html_escape(&officials.water1));
+    }
+    if !officials.water2.is_empty() {
+        water_refs.push(html_escape(&officials.water2));
+    }
+    if !officials.water3.is_empty() {
+        water_refs.push(html_escape(&officials.water3));
+    }
+    let water_refs_str = water_refs.join(",&nbsp;&nbsp;&nbsp; ");
+
+    // Timer/Scorer combined
+    let timer_scorer = if officials.ts_keeper.is_empty() && officials.ts_helper.is_empty() {
+        String::new()
+    } else if officials.ts_helper.is_empty() {
+        officials.ts_keeper.clone()
+    } else if officials.ts_keeper.is_empty() {
+        officials.ts_helper.clone()
+    } else {
+        format!("{} / {}", officials.ts_keeper, officials.ts_helper)
+    };
+
+    let css = r#"
+      * { box-sizing:border-box; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+      body { font-family: Arial, Helvetica, sans-serif; margin:0; padding:0; color:#000; }
+      .page { width: 8.5in; height: 11in; margin: 0 auto; border:1px solid #cfcfcf; padding:0.5in 0.94in; background:#fff; }
+      .page { break-after: page; page-break-after: always; }
+      @media print { @page { size: 8.5in 11in; margin: 0; } html, body { width:8.5in; height:11in; margin:0; } .page { padding:0.5in 0.94in; } }
+
+      .header { text-align:center; margin-bottom:16px; }
+      .header h1 { font-size:24px; margin:0 0 8px 0; font-weight:bold; }
+      .header .event-name { font-size:24px; font-weight:normal; margin:0 0 2px 0; }
+      .header .event-date { font-size:12px; margin:0; }
+
+      .info-line { font-size:12px; margin:28px 0; }
+      .info-line b { font-weight:bold; }
+
+      /* Unified table - 6 columns: 12.5%, 12.5%, 25%, 12.5%, 12.5%, 25% */
+      table.unified { width:100%; border-collapse:collapse; font-size:12px; table-layout:fixed; border:1px solid #000; }
+      table.unified th, table.unified td { border:1px solid #000; padding:4px; text-align:center; }
+      table.unified col.col-narrow { width:12.5%; }
+      table.unified col.col-wide { width:25%; }
+
+      /* Team headers */
+      table.unified th.white-header { background:#fff; font-weight:bold; font-size:12px; }
+      table.unified th.black-header { background:#d0d0d0; font-weight:bold; font-size:12px; }
+
+      /* Half headers */
+      table.unified th.white-half { background:#fff; font-weight:bold; font-size:11px; }
+      table.unified th.black-half { background:#d0d0d0; font-weight:bold; font-size:11px; }
+
+      /* Scoring cells - 25% taller (145 * 1.25 = 181) */
+      table.unified td.score-white { height:181px; background:#fff; vertical-align:top; }
+      table.unified td.score-black { height:181px; background:#d0d0d0; vertical-align:top; }
+
+      /* Section headers (Time Outs, Timed Penalties, Final Scores) */
+      table.unified th.section-header { background:#fff; font-weight:bold; }
+
+      /* Time Outs half headers */
+      table.unified th.to-white-half { background:#fff; font-weight:bold; font-size:11px; }
+      table.unified th.to-black-half { background:#d0d0d0; font-weight:bold; font-size:11px; }
+
+      /* Time Outs / Final Scores boxes */
+      table.unified td.white-box { height:45px; background:#fff; }
+      table.unified td.black-box { height:45px; background:#d0d0d0; }
+      table.unified td.final-white { height:55px; background:#fff; }
+      table.unified td.final-black { height:55px; background:#d0d0d0; }
+
+      /* Speckled/disabled cells for timeouts */
+      table.unified td.speckled-white { height:45px; background:#fff; position:relative; }
+      table.unified td.speckled-black { height:45px; background:#d0d0d0; position:relative; }
+      table.unified td.speckled-white::before,
+      table.unified td.speckled-black::before {
+        content: "X";
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        transform: translate(-50%, -50%);
+        font-size: 14px;
+        color: #9b9b9b;
+        font-weight: 600;
+      }
+
+      /* Penalty column headers */
+      table.unified th.pen-white { background:#fff; font-weight:bold; font-size:11px; }
+      table.unified th.pen-black { background:#d0d0d0; font-weight:bold; font-size:11px; }
+
+      /* Penalty data cells - merged cells (4 rows height = 192px) */
+      table.unified td.pen-data-white { height:192px; background:#fff; vertical-align:top; }
+      table.unified td.pen-data-black { height:192px; background:#d0d0d0; vertical-align:top; }
+
+      .signature { margin-top:36px; font-size:14px; text-align:center; font-weight:bold; }
+    "#;
+
+    // Generate timeout cells and headers based on timing rules
+    let (to_half_headers, to_white_cells, to_black_cells) = if tr.team_timeout_count == 0 {
+        // No timeouts allowed - show X in all cells, with half headers
+        (
+            "<th class='to-white-half' colspan='2'>1st Half</th><th class='to-white-half'>2nd Half</th><th class='to-black-half' colspan='2'>1st Half</th><th class='to-black-half'>2nd Half</th>".to_string(),
+            "<td class='speckled-white' colspan='2'></td><td class='speckled-white'></td>".to_string(),
+            "<td class='speckled-black' colspan='2'></td><td class='speckled-black'></td>".to_string(),
+        )
+    } else if tr.team_timeout_count >= 1 && !tr.team_timeouts_counted_per_half {
+        // Timeouts per game (not per half) - merge into single cell spanning all 3 columns
+        (
+            String::new(), // No half headers when merged
+            format!(
+                "<td class='white-box' colspan='3'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;of {}</td>",
+                tr.team_timeout_count
+            ),
+            format!(
+                "<td class='black-box' colspan='3'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;of {}</td>",
+                tr.team_timeout_count
+            ),
+        )
+    } else {
+        // Timeouts counted per half - show "of X" in each cell
+        (
+            "<th class='to-white-half' colspan='2'>1st Half</th><th class='to-white-half'>2nd Half</th><th class='to-black-half' colspan='2'>1st Half</th><th class='to-black-half'>2nd Half</th>".to_string(),
+            format!("<td class='white-box' colspan='2'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;of {}</td><td class='white-box'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;of {}</td>", tr.team_timeout_count, tr.team_timeout_count),
+            format!("<td class='black-box' colspan='2'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;of {}</td><td class='black-box'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;of {}</td>", tr.team_timeout_count, tr.team_timeout_count),
+        )
+    };
+
+    // Build the timeout half headers row (may be empty if merged)
+    let to_half_headers_row = if to_half_headers.is_empty() {
+        String::new()
+    } else {
+        format!("<tr>{}</tr>", to_half_headers)
+    };
+
+    let html = format!(
+        r#"<!doctype html><html><head><meta charset='utf-8'/>
+<title>Scoresheet G{game_number}</title>
+<style>{css}</style>
+</head><body>
+<div class='page'>
+  <div class='header'>
+    <h1>UNDERWATER HOCKEY SCORE SHEET</h1>
+    <p class='event-name'>{event_name}</p>
+    <p class='event-date'>{date}</p>
+  </div>
+
+  <!-- Game Info - inline text format with tab-like spacing -->
+  <div class='info-line'>
+    <b>Game #:</b> {game_number} &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+    <b>Court:</b> {court} &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+    <b>Scheduled Start:</b> {time} &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+    <b>Type:</b> {category}
+  </div>
+
+  <div class='info-line'>
+    <b>Water Refs:</b> {water_refs}
+  </div>
+
+  <div class='info-line'>
+    <b>Chief Ref:</b> {chief} &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+    <b>Timer:</b> {timer} &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+    <b>Actual Start:</b> ______
+  </div>
+
+  <!-- Unified Table - 6 columns: 12.5%, 12.5%, 25%, 12.5%, 12.5%, 25% -->
+  <table class='unified'>
+    <colgroup>
+      <col class='col-narrow'/>
+      <col class='col-narrow'/>
+      <col class='col-wide'/>
+      <col class='col-narrow'/>
+      <col class='col-narrow'/>
+      <col class='col-wide'/>
+    </colgroup>
+    <!-- Team Headers -->
+    <tr>
+      <th class='white-header' colspan='3'>White Team: {white_team}</th>
+      <th class='black-header' colspan='3'>Black Team: {black_team}</th>
+    </tr>
+    <!-- Half Headers -->
+    <tr>
+      <th class='white-half' colspan='2'>1st Half</th>
+      <th class='white-half'>2nd Half</th>
+      <th class='black-half' colspan='2'>1st Half</th>
+      <th class='black-half'>2nd Half</th>
+    </tr>
+    <!-- Scoring Cells -->
+    <tr>
+      <td class='score-white' colspan='2'></td>
+      <td class='score-white'></td>
+      <td class='score-black' colspan='2'></td>
+      <td class='score-black'></td>
+    </tr>
+    <!-- Time Outs Header -->
+    <tr>
+      <th class='section-header' colspan='6'>Time Outs</th>
+    </tr>
+    <!-- Time Outs Half Headers (may be empty if merged) -->
+    {to_half_headers_row}
+    <!-- Time Outs Boxes - dynamic based on timing rules -->
+    <tr>
+      {to_white_cells}{to_black_cells}
+    </tr>
+    <!-- Timed Penalties Header -->
+    <tr>
+      <th class='section-header' colspan='6'>Timed Penalties</th>
+    </tr>
+    <!-- Penalty Column Headers -->
+    <tr>
+      <th class='pen-white'>Time</th>
+      <th class='pen-white'>Cap #</th>
+      <th class='pen-white'>Infraction</th>
+      <th class='pen-black'>Time</th>
+      <th class='pen-black'>Cap #</th>
+      <th class='pen-black'>Infraction</th>
+    </tr>
+    <!-- Penalty Data Row (merged cells) -->
+    <tr>
+      <td class='pen-data-white'></td>
+      <td class='pen-data-white'></td>
+      <td class='pen-data-white'></td>
+      <td class='pen-data-black'></td>
+      <td class='pen-data-black'></td>
+      <td class='pen-data-black'></td>
+    </tr>
+    <!-- Final Scores Header -->
+    <tr>
+      <th class='section-header' colspan='6'>Final Scores</th>
+    </tr>
+    <!-- Final Scores Boxes -->
+    <tr>
+      <td class='final-white' colspan='3'></td>
+      <td class='final-black' colspan='3'></td>
+    </tr>
+  </table>
+
+  <!-- Signature with actual line -->
+  <div class='signature'>
+    Chief Referee Signature: ________________________________
+  </div>
+</div>
+</body></html>
+"#,
+        css = css,
+        event_name = html_escape(&event.name),
+        date = html_escape(&date_str),
+        game_number = html_escape(game_number),
+        court = html_escape(&game.court),
+        time = html_escape(&time_str),
+        category = html_escape(cat),
+        water_refs = water_refs_str, // Already escaped with &nbsp; separators
+        chief = html_escape(&officials.chief),
+        timer = html_escape(&timer_scorer),
+        white_team = html_escape(&white_label),
+        black_team = html_escape(&black_label),
+        to_half_headers_row = to_half_headers_row,
+        to_white_cells = to_white_cells,
+        to_black_cells = to_black_cells,
+    );
+
+    html
+}
+
+// Simple (Team Refs) scoresheet layout - similar to Simple but uses team-based referee assignments
+#[allow(clippy::too_many_arguments)]
+fn render_html_simple_team_refs(
+    event: &Event,
+    game_number: &str,
+    game: &Game,
+    schedule: Option<&uwh_common::uwhportal::schedule::Schedule>,
+    tr: &uwh_common::uwhportal::schedule::TimingRule,
+    white_suffix: &str,
+    white_name: &str,
+    black_suffix: &str,
+    black_name: &str,
+) -> String {
+    use time::OffsetDateTime;
+    use time::format_description::FormatItem;
+    use time::macros::format_description;
+
+    // Date/time formatting in event timezone - include day of week
+    let offset = event.date_range.start.offset();
+    let local_dt: OffsetDateTime = game.start_time.to_offset(offset);
+    const DATE_FMT: &[FormatItem<'static>] =
+        format_description!("[weekday repr:long] [month repr:long] [day padding:none]");
+    const TIME_FMT: &[FormatItem<'static>] =
+        format_description!("[hour repr:12]:[minute] [period case:upper]");
+    let date_str = local_dt.format(&DATE_FMT).unwrap_or_default();
+    let time_str = local_dt.format(&TIME_FMT).unwrap_or_default();
+
+    // Team labels with suffix
+    let white_label = if white_suffix.is_empty() {
+        white_name.to_string()
+    } else if white_name.is_empty() {
+        white_suffix
+            .trim_matches(|c| c == '(' || c == ')' || c == ' ')
+            .to_string()
+    } else {
+        format!("{} {}", white_name, white_suffix)
+    };
+    let black_label = if black_suffix.is_empty() {
+        black_name.to_string()
+    } else if black_name.is_empty() {
+        black_suffix
+            .trim_matches(|c| c == '(' || c == ')' || c == ' ')
+            .to_string()
+    } else {
+        format!("{} {}", black_name, black_suffix)
+    };
+
+    // Category (type)
+    let cat = derive_category(&game.timing_rule);
+
+    // Look up team referee assignments from schedule.referees_by_game_number
+    let (ref_team, ts_keeper_team) = if let Some(sched) = schedule {
+        if let Some(refs_by_game) = &sched.referees_by_game_number {
+            if let Some(game_refs) = refs_by_game.get(game_number) {
+                let ref_team = game_refs
+                    .referees
+                    .as_ref()
+                    .and_then(|r| r.team.as_ref())
+                    .and_then(|t| t.name.clone())
+                    .unwrap_or_default();
+                let ts_keeper = game_refs
+                    .time_or_score_keeper
+                    .as_ref()
+                    .and_then(|r| r.team.as_ref())
+                    .and_then(|t| t.name.clone())
+                    .unwrap_or_default();
+                (ref_team, ts_keeper)
+            } else {
+                (String::new(), String::new())
+            }
+        } else {
+            (String::new(), String::new())
+        }
+    } else {
+        (String::new(), String::new())
+    };
+
+    // Debug log the team refs found
+    log::info!(
+        "Game {}: Referees team = '{}', T/S Keeper team = '{}'",
+        game_number,
+        ref_team,
+        ts_keeper_team
+    );
+
+    // Timeout headers and cells (same logic as render_html_simple)
+    let to_per_half = tr.team_timeouts_counted_per_half;
+    let to_count = tr.team_timeout_count as usize;
+    let (to_half_headers_row, to_white_cells, to_black_cells) = if to_per_half {
+        let hdr = "<tr><th class='to-white-half' colspan='2'>1st Half</th><th class='to-white-half' colspan='2'>2nd Half</th><th class='to-black-half' colspan='2'>1st Half</th><th class='to-black-half' colspan='2'>2nd Half</th></tr>".to_string();
+        let mut w = String::new();
+        let mut b = String::new();
+        for _ in 0..to_count {
+            w.push_str("<td class='to-white'></td><td class='to-white'></td><td class='to-white'></td><td class='to-white'></td>");
+            b.push_str("<td class='to-black'></td><td class='to-black'></td><td class='to-black'></td><td class='to-black'></td>");
+        }
+        (hdr, w, b)
+    } else {
+        let hdr = String::new();
+        let mut w = String::new();
+        let mut b = String::new();
+        for i in 0..to_count {
+            let span = if to_count == 1 {
+                4
+            } else {
+                4 / to_count.max(1)
+            };
+            w.push_str(&format!(
+                "<td class='to-white' colspan='{}'>{}</td>",
+                span,
+                i + 1
+            ));
+            b.push_str(&format!(
+                "<td class='to-black' colspan='{}'>{}</td>",
+                span,
+                i + 1
+            ));
+        }
+        (hdr, w, b)
+    };
+
+    let css = r#"
+      * { box-sizing:border-box; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+      body { font-family: Arial, Helvetica, sans-serif; margin:0; padding:0; color:#000; }
+      .page { width: 8.5in; height: 11in; margin: 0 auto; border:1px solid #cfcfcf; padding:0.5in 0.94in; background:#fff; }
+      .page { break-after: page; page-break-after: always; }
+      @media print { @page { size: 8.5in 11in; margin: 0; } html, body { width:8.5in; height:11in; margin:0; } .page { padding:0.5in 0.94in; } }
+
+      .header { text-align:center; margin-bottom:16px; }
+      .header h1 { font-size:24px; margin:0 0 8px 0; font-weight:bold; }
+      .header .event-name { font-size:24px; font-weight:normal; margin:0 0 2px 0; }
+      .header .event-date { font-size:12px; margin:0; }
+
+      .info-line { font-size:12px; margin-bottom:4px; }
+
+      table.unified { width:100%; border-collapse:collapse; margin-top:16px; }
+      table.unified th, table.unified td { border:1px solid #000; text-align:center; padding:4px; font-size:11px; }
+      col.col-narrow { width:12.5%; }
+      col.col-wide { width:25%; }
+
+      /* Team headers */
+      table.unified th.white-team { background:#fff; font-weight:bold; font-size:14px; }
+      table.unified th.black-team { background:#d0d0d0; font-weight:bold; font-size:14px; }
+
+      /* Half headers */
+      table.unified th.white-half { background:#fff; font-weight:bold; font-size:11px; }
+      table.unified th.black-half { background:#d0d0d0; font-weight:bold; font-size:11px; }
+
+      /* Scoring cells - 25% taller (145 * 1.25 = 181) */
+      table.unified td.score-white { height:181px; background:#fff; vertical-align:top; }
+      table.unified td.score-black { height:181px; background:#d0d0d0; vertical-align:top; }
+
+      /* Section headers (Time Outs, Timed Penalties, Final Scores) */
+      table.unified th.section-header { background:#fff; font-weight:bold; }
+
+      /* Time Outs half headers */
+      table.unified th.to-white-half { background:#fff; font-weight:bold; font-size:11px; }
+      table.unified th.to-black-half { background:#d0d0d0; font-weight:bold; font-size:11px; }
+
+      /* Time Out cells */
+      table.unified td.to-white { height:32px; background:#fff; }
+      table.unified td.to-black { height:32px; background:#d0d0d0; }
+
+      /* Final score cells - 25% taller (50 * 1.25 = 62) */
+      table.unified td.final-white { height:62px; background:#fff; font-size:18px; font-weight:bold; }
+      table.unified td.final-black { height:62px; background:#d0d0d0; font-size:18px; font-weight:bold; }
+
+      /* Penalty column headers */
+      table.unified th.pen-white { background:#fff; font-weight:bold; font-size:11px; }
+      table.unified th.pen-black { background:#d0d0d0; font-weight:bold; font-size:11px; }
+
+      /* Penalty data cells - no horizontal borders, 25% taller (38 * 1.25 = 48) */
+      table.unified td.pen-data-white { height:48px; background:#fff; border-top:none; border-bottom:none; }
+      table.unified td.pen-data-black { height:48px; background:#d0d0d0; border-top:none; border-bottom:none; }
+      table.unified tr.pen-last td.pen-data-white,
+      table.unified tr.pen-last td.pen-data-black { border-bottom:1px solid #000; }
+
+      .signature { margin-top:36px; font-size:14px; text-align:center; font-weight:bold; }
+    "#;
+
+    let html = format!(
+        r#"<!doctype html><html><head><meta charset='utf-8'/>
+<title>Scoresheet G{game_number}</title>
+<style>{css}</style>
+</head><body>
+<div class='page'>
+  <div class='header'>
+    <h1>UNDERWATER HOCKEY SCORE SHEET</h1>
+    <p class='event-name'>{event_name}</p>
+    <p class='event-date'>{date}</p>
+  </div>
+
+  <!-- Game Info - inline text format with tab-like spacing -->
+  <div class='info-line'>
+    <b>Game #:</b> {game_number} &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+    <b>Court:</b> {court} &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+    <b>Scheduled Start:</b> {time} &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+    <b>Type:</b> {category}
+  </div>
+
+  <div class='info-line'>
+    <b>Referees:</b> {ref_team} &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+    <b>Timer:</b> {ts_keeper_team} &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+    <b>Actual Start:</b> ______
+  </div>
+
+  <!-- Unified Table - 6 columns: 12.5%, 12.5%, 25%, 12.5%, 12.5%, 25% -->
+  <table class='unified'>
+    <colgroup>
+      <col class='col-narrow'/>
+      <col class='col-narrow'/>
+      <col class='col-wide'/>
+      <col class='col-narrow'/>
+      <col class='col-narrow'/>
+      <col class='col-wide'/>
+    </colgroup>
+    <!-- Team Names row -->
+    <tr>
+      <th class='white-team' colspan='3'>{white_team}</th>
+      <th class='black-team' colspan='3'>{black_team}</th>
+    </tr>
+    <!-- Half headers row -->
+    <tr>
+      <th class='white-half'>1st Half</th>
+      <th class='white-half'>2nd Half</th>
+      <th class='white-half'>OT / SD</th>
+      <th class='black-half'>1st Half</th>
+      <th class='black-half'>2nd Half</th>
+      <th class='black-half'>OT / SD</th>
+    </tr>
+    <!-- Scoring row -->
+    <tr>
+      <td class='score-white'></td>
+      <td class='score-white'></td>
+      <td class='score-white'></td>
+      <td class='score-black'></td>
+      <td class='score-black'></td>
+      <td class='score-black'></td>
+    </tr>
+    <!-- Time Outs section header -->
+    <tr>
+      <th class='section-header' colspan='6'>Time Outs</th>
+    </tr>
+    <!-- Time Outs half headers (if per-half) -->
+    {to_half_headers_row}
+    <!-- Time Out cells row for white -->
+    <tr>
+      {to_white_cells}
+      {to_black_cells}
+    </tr>
+    <!-- Timed Penalties section header -->
+    <tr>
+      <th class='section-header' colspan='6'>Timed Penalties</th>
+    </tr>
+    <!-- Penalty column headers -->
+    <tr>
+      <th class='pen-white'>Cap #</th>
+      <th class='pen-white'>Time</th>
+      <th class='pen-white'>Reason</th>
+      <th class='pen-black'>Cap #</th>
+      <th class='pen-black'>Time</th>
+      <th class='pen-black'>Reason</th>
+    </tr>
+    <!-- Penalty rows (5 rows, last one has bottom border) -->
+    <tr><td class='pen-data-white'></td><td class='pen-data-white'></td><td class='pen-data-white'></td><td class='pen-data-black'></td><td class='pen-data-black'></td><td class='pen-data-black'></td></tr>
+    <tr><td class='pen-data-white'></td><td class='pen-data-white'></td><td class='pen-data-white'></td><td class='pen-data-black'></td><td class='pen-data-black'></td><td class='pen-data-black'></td></tr>
+    <tr><td class='pen-data-white'></td><td class='pen-data-white'></td><td class='pen-data-white'></td><td class='pen-data-black'></td><td class='pen-data-black'></td><td class='pen-data-black'></td></tr>
+    <tr><td class='pen-data-white'></td><td class='pen-data-white'></td><td class='pen-data-white'></td><td class='pen-data-black'></td><td class='pen-data-black'></td><td class='pen-data-black'></td></tr>
+    <tr class='pen-last'><td class='pen-data-white'></td><td class='pen-data-white'></td><td class='pen-data-white'></td><td class='pen-data-black'></td><td class='pen-data-black'></td><td class='pen-data-black'></td></tr>
+    <!-- Final Scores section header -->
+    <tr>
+      <th class='section-header' colspan='6'>Final Scores</th>
+    </tr>
+    <!-- Final score row -->
+    <tr>
+      <td class='final-white' colspan='3'></td>
+      <td class='final-black' colspan='3'></td>
+    </tr>
+  </table>
+
+  <!-- Signature with actual line -->
+  <div class='signature'>
+    Chief Referee Signature: ________________________________
+  </div>
+</div>
+</body></html>
+"#,
+        css = css,
+        event_name = html_escape(&event.name),
+        date = html_escape(&date_str),
+        game_number = html_escape(game_number),
+        court = html_escape(&game.court),
+        time = html_escape(&time_str),
+        category = html_escape(cat),
+        ref_team = html_escape(&ref_team),
+        ts_keeper_team = html_escape(&ts_keeper_team),
+        white_team = html_escape(&white_label),
+        black_team = html_escape(&black_label),
+        to_half_headers_row = to_half_headers_row,
+        to_white_cells = to_white_cells,
+        to_black_cells = to_black_cells,
+    );
+
+    html
+}
+
+// Col_3x3 scoresheet layout (landscape) based on provided mockup
+#[allow(clippy::too_many_arguments)]
+fn render_html_col3x3(
+    event: &Event,
+    game_number: &str,
+    game: &Game,
+    _csv_schedule: Option<&uwh_common::uwhportal::schedule::Schedule>,
+    _tr: &uwh_common::uwhportal::schedule::TimingRule,
+    white_suffix: &str,
+    white_name: &str,
+    black_suffix: &str,
+    black_name: &str,
+    officials: &OfficialNames,
+    black_roster: &TeamRosterInfo,
+    white_roster: &TeamRosterInfo,
+) -> String {
+    // Date/time formatting in event timezone
+    let offset = event.date_range.start.offset();
+    let local_dt: OffsetDateTime = game.start_time.to_offset(offset);
+    const DATE_FMT: &[FormatItem<'static>] =
+        format_description!("[weekday repr:short] [month repr:short] [day padding:none]");
+    const TIME_FMT: &[FormatItem<'static>] =
+        format_description!("[hour repr:12]:[minute] [period case:upper]");
+    let date_str = local_dt.format(&DATE_FMT).unwrap_or_default();
+    let time_str = local_dt.format(&TIME_FMT).unwrap_or_default();
+
+    // Category
+    let cat = derive_category(&game.timing_rule);
+
+    // Team names
+    let white_label = if white_suffix.is_empty() {
+        white_name.to_string()
+    } else {
+        format!("{} {}", white_name, white_suffix)
+    };
+    let black_label = if black_suffix.is_empty() {
+        black_name.to_string()
+    } else {
+        format!("{} {}", black_name, black_suffix)
+    };
+
+    let css = r#"
+      * { box-sizing:border-box; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+      body { font-family: Arial, Helvetica, sans-serif; margin:8px; color:#000; }
+      .page { width: 11in; height: 8.5in; margin: 0 auto; border:1px solid #cfcfcf; padding:1in 0.5in 0.5in 0.5in; background:#fff; display:flex; flex-direction:column; }
+      .page { break-after: page; page-break-after: always; }
+      @media print { @page { size: 11in 8.5in; margin: 0; } html, body { width:11in; height:8.5in; margin:0; } .page { padding:1in 0.5in 0.5in 0.5in; } }
+
+      /* Main unified table */
+      table.sheet { width:100%; border-collapse:collapse; table-layout: fixed; font-size:9px; line-height:1.1; flex:1; }
+      table.sheet th, table.sheet td { border:1px solid #000; padding:2px; text-align:center; vertical-align:middle; overflow:hidden; height:0.189in; max-height:0.189in; }
+      table.sheet th { font-weight:bold; background:#fff; }
+      table.sheet td.label { font-weight:bold; text-align:left; padding-left:3px; }
+      table.sheet td.label-center { font-weight:bold; text-align:center; }
+      table.sheet td.text-left { text-align:left; padding-left:3px; }
+      table.sheet tr:nth-child(-n+3) td:nth-child(-n+4) { text-align:left; padding-left:3px; }
+      table.sheet tr:nth-child(1) td:nth-child(5), table.sheet tr:nth-child(1) td:nth-child(6) { text-align:center; padding-left:2px; }
+      table.sheet tr:nth-child(2) td:nth-child(15), table.sheet tr:nth-child(2) td:nth-child(16) { text-align:center; }
+      table.sheet tr:nth-child(7) td { text-align:center; }
+      table.sheet tr:nth-child(33) td:nth-child(1), table.sheet tr:nth-child(36) td:nth-child(1) { text-align:center; }
+      table.sheet td:nth-child(n+5) { text-align:center; }
+      table.sheet { font-weight:bold; }
+      table.sheet tr { height:0.189in; max-height:0.189in; }
+      table.sheet tr.header-row th { padding:2px; }
+      table.sheet tr.header-row td { padding:2px; }
+      table.sheet tr.team-row td { font-weight:bold; }
+      table.sheet tr.judges-header td { font-weight:bold; text-align:center; }
+      table.sheet tr.judges-row td { }
+      table.sheet tr.totals-row td { font-weight:bold; }
+      table.sheet tr:nth-child(5) td:nth-child(-n+4) { font-size:18px; word-wrap:break-word; overflow:hidden; }
+      table.sheet td.no-border { border:none; }
+      .circle { font-size:6px; }
+    "#;
+
+    let html = format!(
+        r#"<!doctype html><html><head><meta charset='utf-8'/>
+  <title>Scoresheet G{game_number}</title>
+  <style>{css}</style>
+</head><body>
+<div class='page'>
+  <table class='sheet'>
+    <colgroup>
+      <col style='width:2.8%'/>
+      <col style='width:18.5%'/>
+      <col style='width:2.8%'/>
+      <col style='width:18.5%'/>
+      <col style='width:6.5%'/>
+      <col style='width:6.5%'/>
+      <col style='width:2.8%'/>
+      <col style='width:3.7%'/>
+      <col style='width:4.6%'/>
+      <col style='width:5.6%'/>
+      <col style='width:5.6%'/>
+      <col style='width:6.5%'/>
+      <col style='width:5.6%'/>
+      <col style='width:13%'/>
+      <col style='width:5.6%'/>
+      <col style='width:5.6%'/>
+    </colgroup>
+{table_rows}
+  </table>
+</div>
+</body></html>
+        "#,
+        css = css,
+        table_rows = {
+            let mut rows = String::new();
+
+            // Define grouped cells with their labels
+            let mut grouped: std::collections::HashMap<(usize, usize), Option<String>> =
+                std::collections::HashMap::new();
+
+            // Row 1-4: A1:B1, C1:D1, A2:B2, C2:D2, A3:B3, C3:D3, A4:B4, C4:D4
+            for row in 1..=4 {
+                grouped.insert((0, row), Some(format!("A{}:B{}", row, row)));
+                grouped.insert((1, row), None);
+                grouped.insert((2, row), Some(format!("C{}:D{}", row, row)));
+                grouped.insert((3, row), None);
+            }
+
+            // Row 5-6: A5:B6, C5:D6
+            for row in 5..=6 {
+                grouped.insert(
+                    (0, row),
+                    if row == 5 {
+                        Some("A5:B6".to_string())
+                    } else {
+                        None
+                    },
+                );
+                grouped.insert((1, row), None);
+                grouped.insert(
+                    (2, row),
+                    if row == 5 {
+                        Some("C5:D6".to_string())
+                    } else {
+                        None
+                    },
+                );
+                grouped.insert((3, row), None);
+            }
+
+            // Rows 1-2: E1:E2, F1:F2, G1:G2, H1:H2, I1:I2, J1:J2, K1:K2, L1:L2, M1:M2, N1:N2
+            for col in 4..=13 {
+                grouped.insert(
+                    (col, 1),
+                    Some(format!(
+                        "{}1:{}2",
+                        (b'A' + col as u8) as char,
+                        (b'A' + col as u8) as char
+                    )),
+                );
+                grouped.insert((col, 2), None);
+            }
+
+            // O1:P1
+            grouped.insert((14, 1), Some("O1:P1".to_string()));
+            grouped.insert((15, 1), None);
+
+            // Rows 8-9: A8:A9, B8:B9, C8:C9, D8:D9
+            for col in 0..=3 {
+                grouped.insert(
+                    (col, 8),
+                    Some(format!(
+                        "{}8:{}9",
+                        (b'A' + col as u8) as char,
+                        (b'A' + col as u8) as char
+                    )),
+                );
+                grouped.insert((col, 9), None);
+            }
+
+            // Rows 10-11: A10:A11, B10:B11, C10:C11, D10:D11
+            for col in 0..=3 {
+                grouped.insert(
+                    (col, 10),
+                    Some(format!(
+                        "{}10:{}11",
+                        (b'A' + col as u8) as char,
+                        (b'A' + col as u8) as char
+                    )),
+                );
+                grouped.insert((col, 11), None);
+            }
+
+            // Rows 12-13: A12:A13, B12:B13, C12:C13, D12:D13
+            for col in 0..=3 {
+                grouped.insert(
+                    (col, 12),
+                    Some(format!(
+                        "{}12:{}13",
+                        (b'A' + col as u8) as char,
+                        (b'A' + col as u8) as char
+                    )),
+                );
+                grouped.insert((col, 13), None);
+            }
+
+            // Rows 14-15: A14:A15, B14:B15, C14:C15, D14:D15
+            for col in 0..=3 {
+                grouped.insert(
+                    (col, 14),
+                    Some(format!(
+                        "{}14:{}15",
+                        (b'A' + col as u8) as char,
+                        (b'A' + col as u8) as char
+                    )),
+                );
+                grouped.insert((col, 15), None);
+            }
+
+            // Rows 16-17: A16:A17, B16:B17, C16:C17, D16:D17
+            for col in 0..=3 {
+                grouped.insert(
+                    (col, 16),
+                    Some(format!(
+                        "{}16:{}17",
+                        (b'A' + col as u8) as char,
+                        (b'A' + col as u8) as char
+                    )),
+                );
+                grouped.insert((col, 17), None);
+            }
+
+            // Rows 18-19: A18:A19, B18:B19, C18:C19, D18:D19
+            for col in 0..=3 {
+                grouped.insert(
+                    (col, 18),
+                    Some(format!(
+                        "{}18:{}19",
+                        (b'A' + col as u8) as char,
+                        (b'A' + col as u8) as char
+                    )),
+                );
+                grouped.insert((col, 19), None);
+            }
+
+            // Rows 20-21: A20:A21, B20:B21, C20:C21, D20:D21
+            for col in 0..=3 {
+                grouped.insert(
+                    (col, 20),
+                    Some(format!(
+                        "{}20:{}21",
+                        (b'A' + col as u8) as char,
+                        (b'A' + col as u8) as char
+                    )),
+                );
+                grouped.insert((col, 21), None);
+            }
+
+            // Row 22: A22:B22, C22:D22
+            grouped.insert((0, 22), Some("A22:B22".to_string()));
+            grouped.insert((1, 22), None);
+            grouped.insert((2, 22), Some("C22:D22".to_string()));
+            grouped.insert((3, 22), None);
+
+            // Row 23: A23:D23
+            grouped.insert((0, 23), Some("A23:D23".to_string()));
+            grouped.insert((1, 23), None);
+            grouped.insert((2, 23), None);
+            grouped.insert((3, 23), None);
+
+            // Rows 24-25: A24:B25, C24:D25
+            grouped.insert((0, 24), Some("A24:B25".to_string()));
+            grouped.insert((1, 24), None);
+            grouped.insert((0, 25), None);
+            grouped.insert((1, 25), None);
+            grouped.insert((2, 24), Some("C24:D25".to_string()));
+            grouped.insert((3, 24), None);
+            grouped.insert((2, 25), None);
+            grouped.insert((3, 25), None);
+
+            // Row 26: A26:D26
+            grouped.insert((0, 26), Some("A26:D26".to_string()));
+            grouped.insert((1, 26), None);
+            grouped.insert((2, 26), None);
+            grouped.insert((3, 26), None);
+
+            // Rows 27-28: A27:B28, C27:D28
+            grouped.insert((0, 27), Some("A27:B28".to_string()));
+            grouped.insert((1, 27), None);
+            grouped.insert((0, 28), None);
+            grouped.insert((1, 28), None);
+            grouped.insert((2, 27), Some("C27:D28".to_string()));
+            grouped.insert((3, 27), None);
+            grouped.insert((2, 28), None);
+            grouped.insert((3, 28), None);
+
+            // Row 29: A29:D29
+            grouped.insert((0, 29), Some("A29:D29".to_string()));
+            grouped.insert((1, 29), None);
+            grouped.insert((2, 29), None);
+            grouped.insert((3, 29), None);
+
+            // Rows 30-31: A30:B31, C30:D31
+            grouped.insert((0, 30), Some("A30:B31".to_string()));
+            grouped.insert((1, 30), None);
+            grouped.insert((0, 31), None);
+            grouped.insert((1, 31), None);
+            grouped.insert((2, 30), Some("C30:D31".to_string()));
+            grouped.insert((3, 30), None);
+            grouped.insert((2, 31), None);
+            grouped.insert((3, 31), None);
+
+            // Row 32: A32:D32
+            grouped.insert((0, 32), Some("A32:D32".to_string()));
+            grouped.insert((1, 32), None);
+            grouped.insert((2, 32), None);
+            grouped.insert((3, 32), None);
+
+            // Rows 33-34: A33:B34, C33:D34
+            grouped.insert((0, 33), Some("A33:B34".to_string()));
+            grouped.insert((1, 33), None);
+            grouped.insert((0, 34), None);
+            grouped.insert((1, 34), None);
+            grouped.insert((2, 33), Some("C33:D34".to_string()));
+            grouped.insert((3, 33), None);
+            grouped.insert((2, 34), None);
+            grouped.insert((3, 34), None);
+
+            // Row 35: A35:D35
+            grouped.insert((0, 35), Some("A35:D35".to_string()));
+            grouped.insert((1, 35), None);
+            grouped.insert((2, 35), None);
+            grouped.insert((3, 35), None);
+
+            // Rows 36-37: A36:B37, C36:D37
+            grouped.insert((0, 36), Some("A36:B37".to_string()));
+            grouped.insert((1, 36), None);
+            grouped.insert((0, 37), None);
+            grouped.insert((1, 37), None);
+            grouped.insert((2, 36), Some("C36:D37".to_string()));
+            grouped.insert((3, 36), None);
+            grouped.insert((2, 37), None);
+            grouped.insert((3, 37), None);
+
+            // Row 37: E37:G37
+            grouped.insert((4, 37), Some("E37:G37".to_string()));
+            grouped.insert((5, 37), None);
+            grouped.insert((6, 37), None);
+
+            // Define cell content
+            let mut content: std::collections::HashMap<(usize, usize), String> =
+                std::collections::HashMap::new();
+
+            // Row 1
+            content.insert((0, 1), format!("PARTIDO #: {}", html_escape(game_number)));
+            content.insert((2, 1), format!("CATEGORIA: {}", cat));
+            content.insert((4, 1), "MIN:SEG".to_string());
+            content.insert((5, 1), "ACCIÓN<br/>N/B".to_string());
+            content.insert((6, 1), "NR".to_string());
+            content.insert((7, 1), "GOL".to_string());
+            content.insert((8, 1), "FALTA".to_string());
+            content.insert((9, 1), "EXPUL<br/>-CIÓN".to_string());
+            content.insert((10, 1), "PENAL".to_string());
+            content.insert((11, 1), "AMONES<br/>-TACIÓN".to_string());
+            content.insert((12, 1), "TIEMPO<br/>FUERA".to_string());
+            content.insert((13, 1), "COMENTARIOS".to_string());
+            content.insert((14, 1), "MARCADOR".to_string());
+
+            // Row 2
+            content.insert((0, 2), "CIUDAD:".to_string());
+            content.insert((2, 2), format!("FECHA: {}", date_str));
+            content.insert((14, 2), "NEGRO".to_string());
+            content.insert((15, 2), "BLANCO".to_string());
+
+            // Row 3
+            content.insert((0, 3), format!("HORA: {}", time_str));
+            content.insert(
+                (2, 3),
+                format!("PLANILLERO: {}", html_escape(&officials.ts_keeper)),
+            );
+            for col in 7..=13 {
+                if col != 13 {
+                    content.insert((col, 3), "○".to_string());
+                }
+            }
+
+            // Row 4
+            content.insert((0, 4), "<b>EQUIPO NEGRO</b>".to_string());
+            content.insert((2, 4), "<b>EQUIPO BLANCO</b>".to_string());
+            for col in 7..=13 {
+                if col != 13 {
+                    content.insert((col, 4), "○".to_string());
+                }
+            }
+
+            // Row 5 - Team names
+            content.insert((0, 5), html_escape(&black_label));
+            content.insert((2, 5), html_escape(&white_label));
+            for col in 7..=13 {
+                if col != 13 {
+                    content.insert((col, 5), "○".to_string());
+                }
+            }
+
+            // Rows 6-7
+            for row in 6..=7 {
+                for col in 7..=13 {
+                    if col != 13 {
+                        content.insert((col, row), "○".to_string());
+                    }
+                }
+            }
+
+            // Row 7 - Player headers
+            content.insert((0, 7), "<b>NR</b>".to_string());
+            content.insert((1, 7), "<b>NOMBRE</b>".to_string());
+            content.insert((2, 7), "<b>NR</b>".to_string());
+            content.insert((3, 7), "<b>NOMBRE</b>".to_string());
+
+            // Rows 8-21 - Player data and scoring rows with circles
+            // Only insert player data into even rows (8, 10, 12, 14, 16, 18, 20) since odd rows are grouped
+            let player_rows = [8, 10, 12, 14, 16, 18, 20];
+            for (idx, &row) in player_rows.iter().enumerate() {
+                // Add player data for black team (columns 0-1)
+                if idx < black_roster.players.len() {
+                    let player = &black_roster.players[idx];
+                    if let Some(num) = player.number {
+                        content.insert((0, row), num.to_string());
+                    }
+                    content.insert((1, row), html_escape(&player.name));
+                }
+
+                // Add player data for white team (columns 2-3)
+                if idx < white_roster.players.len() {
+                    let player = &white_roster.players[idx];
+                    if let Some(num) = player.number {
+                        content.insert((2, row), num.to_string());
+                    }
+                    content.insert((3, row), html_escape(&player.name));
+                }
+            }
+
+            // Add scoring circles to all rows 8-21 (both player rows and grouped rows)
+            for row in 8..=21 {
+                for col in 7..=13 {
+                    if col != 13 {
+                        content.insert((col, row), "○".to_string());
+                    }
+                }
+            }
+
+            // Add captain names to A33 (black) and A36 (white)
+            if let Some(captain) = &black_roster.captain {
+                content.insert((0, 33), html_escape(captain));
+            }
+            if let Some(captain) = &white_roster.captain {
+                content.insert((0, 36), html_escape(captain));
+            }
+
+            // Row 22
+            content.insert((0, 22), "<b>NOMBRES</b>".to_string());
+            content.insert((2, 22), "<b>FIRMAS</b>".to_string());
+            for col in 7..=13 {
+                if col != 13 {
+                    content.insert((col, 22), "○".to_string());
+                }
+            }
+
+            // Row 23 - JUEZ1
+            content.insert((0, 23), "<b>JUEZ1:</b>".to_string());
+            for col in 7..=13 {
+                if col != 13 {
+                    content.insert((col, 23), "○".to_string());
+                }
+            }
+
+            // Rows 24-25
+            for row in 24..=25 {
+                for col in 7..=13 {
+                    if col != 13 {
+                        content.insert((col, row), "○".to_string());
+                    }
+                }
+            }
+
+            // Row 26 - JUEZ2
+            content.insert((0, 26), "<b>JUEZ2:</b>".to_string());
+            for col in 7..=13 {
+                if col != 13 {
+                    content.insert((col, 26), "○".to_string());
+                }
+            }
+
+            // Rows 27-28
+            for row in 27..=28 {
+                for col in 7..=13 {
+                    if col != 13 {
+                        content.insert((col, row), "○".to_string());
+                    }
+                }
+            }
+
+            // Row 29 - JUEZ3
+            content.insert((0, 29), "<b>JUEZ3:</b>".to_string());
+            for col in 7..=13 {
+                if col != 13 {
+                    content.insert((col, 29), "○".to_string());
+                }
+            }
+
+            // Rows 30-31
+            for row in 30..=31 {
+                for col in 7..=13 {
+                    if col != 13 {
+                        content.insert((col, row), "○".to_string());
+                    }
+                }
+            }
+
+            // Row 32 - CAPITAN BLANCO
+            content.insert((0, 32), "<b>CAPITAN BLANCO:</b>".to_string());
+            for col in 7..=13 {
+                if col != 13 {
+                    content.insert((col, 32), "○".to_string());
+                }
+            }
+
+            // Rows 33-34
+            for row in 33..=34 {
+                for col in 7..=13 {
+                    if col != 13 {
+                        content.insert((col, row), "○".to_string());
+                    }
+                }
+            }
+
+            // Row 35 - CAPITAN NEGRO
+            content.insert((0, 35), "<b>CAPITAN NEGRO:</b>".to_string());
+            for col in 7..=13 {
+                if col != 13 {
+                    content.insert((col, 35), "○".to_string());
+                }
+            }
+
+            // Row 36
+            for col in 7..=13 {
+                if col != 13 {
+                    content.insert((col, 36), "○".to_string());
+                }
+            }
+
+            // Row 37 - TOTALES
+            content.insert((4, 37), "<b>TOTALES</b>".to_string());
+            content.insert((13, 37), "<b>MARCADOR FINAL</b>".to_string());
+
+            // Generate table
+            for row in 1..=37 {
+                rows.push_str("    <tr>\n");
+                let mut col = 0;
+                while col < 16 {
+                    if let Some(label_opt) = grouped.get(&(col, row)) {
+                        if let Some(label) = label_opt {
+                            let label_str = label.as_str();
+
+                            let (colspan, rowspan) = if label_str.contains(':') {
+                                let parts: Vec<&str> = label_str.split(':').collect();
+                                let start_col =
+                                    (parts[0].chars().next().unwrap() as usize) - ('A' as usize);
+                                let start_row: usize = parts[0][1..].parse().unwrap_or(row);
+                                let end_col =
+                                    (parts[1].chars().next().unwrap() as usize) - ('A' as usize);
+                                let end_row: usize = parts[1][1..].parse().unwrap_or(row);
+
+                                let cs = end_col - start_col + 1;
+                                let rs = end_row - start_row + 1;
+                                (cs, rs)
+                            } else {
+                                (1, 1)
+                            };
+
+                            let cell_content =
+                                content.get(&(col, row)).map(|s| s.as_str()).unwrap_or("");
+
+                            if colspan > 1 || rowspan > 1 {
+                                rows.push_str(&format!(
+                                    "      <td colspan='{}' rowspan='{}'>{}</td>\n",
+                                    colspan, rowspan, cell_content
+                                ));
+                                col += colspan;
+                            } else {
+                                rows.push_str(&format!("      <td>{}</td>\n", cell_content));
+                                col += 1;
+                            }
+                        } else {
+                            col += 1;
+                        }
+                    } else {
+                        let cell_content =
+                            content.get(&(col, row)).map(|s| s.as_str()).unwrap_or("");
+                        rows.push_str(&format!("      <td>{}</td>\n", cell_content));
+                        col += 1;
+                    }
+                }
+                rows.push_str("    </tr>\n");
+            }
+            rows
+        },
+    );
+
+    html
+}
+
+fn empty_cells(n: usize) -> String {
+    let mut s = String::new();
+    for _ in 0..n {
+        s.push_str("<td></td>");
+    }
+    s
+}
+
+fn speckled_cells(n: usize) -> String {
+    let mut s = String::new();
+    for _ in 0..n {
+        s.push_str("<td class='speckled'></td>");
+    }
+    s
+}
+
+fn score_section_with_rules(tr: &uwh_common::uwhportal::schedule::TimingRule) -> String {
+    let mut cols = String::new();
+    for i in 1..=14 {
+        cols.push_str(&format!("<th>{}</th>", i));
+    }
+
+    let blank = empty_cells(14);
+    let blank_speckled = speckled_cells(14);
+
+    // Team timeouts for 1st/2nd half
+    let (to_first, to_second) = if tr.team_timeout_count == 0 {
+        (
+            "<td class='speckled'></td>".to_string(),
+            "<td class='speckled'></td>".to_string(),
+        )
+    } else if tr.team_timeout_count == 1 && !tr.team_timeouts_counted_per_half {
+        (
+            "<td rowspan='2'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;of 1</td>".to_string(),
+            String::new(),
+        )
+    } else if tr.team_timeout_count == 1 && tr.team_timeouts_counted_per_half {
+        (
+            "<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;of 1</td>".to_string(),
+            "<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;of 1</td>".to_string(),
+        )
+    } else {
+        ("<td></td>".to_string(), "<td></td>".to_string())
+    };
+
+    // OT rows
+    let (ot_cells, ot_pgt_attr, ot_sub_attr) = if !tr.overtime_allowed {
+        (
+            blank_speckled.as_str(),
+            " class='speckled'",
+            " class='speckled'",
+        )
+    } else {
+        (blank.as_str(), "", "")
+    };
+
+    // Gold goal row
+
+    // Gold goal row: col 1 separate; cols 2–14 merged (colspan=13) and always speckled
+    let gg_col1 = if !tr.sudden_death_allowed {
+        "<td class='speckled'></td>"
+    } else {
+        "<td></td>"
+    }
+    .to_string();
+    let gg_merged = speckled_cells(13);
+    let gg_nums = format!("{}{}", gg_col1, gg_merged);
+    let (gg_pgt, gg_sub) = if !tr.sudden_death_allowed {
+        (
+            "<td class='speckled'></td>".to_string(),
+            "<td class='speckled'></td>".to_string(),
+        )
+    } else {
+        ("<td></td>".to_string(), "<td></td>".to_string())
+    };
+
+    format!(
+        "<table class='sheet score'>\
+           <colgroup><col class='col-period'/><col class='col-score' span='14'/><col class='col-pgt'/><col class='col-sub'/><col class='col-timeouts'/></colgroup>\
+           <tr class='cap-row'><th class='tl period' rowspan='2'>TIME<br>PERIOD</th><th colspan='14'>SCORE COUNT</th><th class='pgt' rowspan='2'>PENALTY<br>GOAL&nbsp;TALLY</th><th rowspan='2'>SUB-TOTAL</th><th rowspan='2'>TEAM TIMEOUTS</th></tr>\
+           <tr class='score-numbers'>{}</tr>\
+           <tr class='sep-top'><td class='tl period'>1ST HALF</td>{}<td></td><td></td>{}</tr>\
+           <tr><td class='tl period'>2ND HALF</td>{}<td></td><td></td>{}</tr>\
+           <tr class='sep-top'><td class='tl period'>OT 1ST HALF</td>{}<td{}></td><td{}></td><td class='speckled'></td></tr>\
+           <tr><td class='tl period'>OT 2ND HALF</td>{}<td{}></td><td{}></td><td class='speckled'></td></tr>\
+           <tr class='sep-top gold-goal'><td class='tl period'>GOLD GOAL</td>{}{}{}<td class='speckled'></td></tr>\
+           <tr class='notes-final'><td class='tl period'>NOTES</td><td colspan='11'></td><td class='final-score' colspan='6'>FINAL SCORE</td></tr>\
+         </table>",
+        cols,
+        blank,
+        to_first,
+        blank,
+        to_second,
+        ot_cells,
+        ot_pgt_attr,
+        ot_sub_attr,
+        ot_cells,
+        ot_pgt_attr,
+        ot_sub_attr,
+        gg_nums,
+        gg_pgt,
+        gg_sub
+    )
+}
+
+pub fn generate_example_rule_sheets(
+    output_dir: &Path,
+    style: SheetStyle,
+) -> Result<(), Box<dyn std::error::Error>> {
+    fs::create_dir_all(output_dir)?;
+
+    // Minimal example event and times
+    let start = OffsetDateTime::from_unix_timestamp(1_700_000_000).unwrap();
+    let event = Event {
+        id: EventId::from_partial("EXAMPLE"),
+        name: "Example Event".to_string(),
+        slug: "example-event".to_string(),
+        date_range: DateRange {
+            start,
+            end: start + TimeDur::hours(8),
+        },
+        teams: None,
+        schedule: None,
+        courts: None,
+    };
+
+    // Helper to make a timing rule with the flags we want
+    let make_rule =
+        |name: &str, to_count: u16, per_half: bool, ot_allowed: bool, sd_allowed: bool| {
+            TimingRule {
+                name: name.to_string(),
+                team_timeout_count: to_count,
+                team_timeouts_counted_per_half: per_half,
+                overtime_allowed: ot_allowed,
+                sudden_death_allowed: sd_allowed,
+                last_2_min_stop_time: false,
+                half_play_duration: std::time::Duration::from_secs(15 * 60),
+                half_time_duration: std::time::Duration::from_secs(3 * 60),
+                team_timeout_duration: std::time::Duration::from_secs(60),
+                ot_half_play_duration: std::time::Duration::from_secs(5 * 60),
+                ot_half_time_duration: std::time::Duration::from_secs(60),
+                pre_overtime_break: std::time::Duration::from_secs(2 * 60),
+                pre_sudden_death_duration: std::time::Duration::from_secs(60),
+                minimum_break: std::time::Duration::from_secs(5 * 60),
+                game_block: None,
+            }
+        };
+
+    let examples: Vec<(&str, TimingRule)> = vec![
+        (
+            "ot_disallowed",
+            make_rule("RR - OT OFF", 1, false, false, true),
+        ),
+        (
+            "sudden_death_disallowed",
+            make_rule("RR - SD OFF", 1, false, true, false),
+        ),
+        (
+            "timeouts_none",
+            make_rule("RR - TO 0", 0, false, true, true),
+        ),
+        (
+            "timeouts_one_combined",
+            make_rule("RR - TO 1 combined", 1, false, true, true),
+        ),
+        (
+            "timeouts_one_per_half",
+            make_rule("RR - TO 1 per half", 1, true, true, true),
+        ),
+        (
+            "all_allowed",
+            make_rule("RR - All Allowed", 1, true, true, true),
+        ),
+    ];
+
+    for (i, (slug, tr)) in examples.iter().enumerate() {
+        let game = Game {
+            number: format!("EX{}", i + 1),
+            dark: ScheduledTeam::new_pending_assignment_name("Example Black"),
+            light: ScheduledTeam::new_pending_assignment_name("Example White"),
+            start_time: start,
+            court: "1".to_string(),
+            timing_rule: tr.name.clone(),
+            referee_assignments: None,
+            description: Some(format!("Example: {}", slug.replace('_', " "))),
+        };
+        let officials = OfficialNames::default();
+
+        // Generate the selected style
+        let (html, style_name) = match style {
+            SheetStyle::Detailed => {
+                let html = render_html(
+                    &event,
+                    &game.number,
+                    &game,
+                    None,
+                    tr,
+                    "",
+                    "Example White",
+                    "",
+                    "Example Black",
+                    &officials,
+                    None,
+                    None,
+                );
+                (html, "detailed")
+            }
+            SheetStyle::Simple => {
+                let html = render_html_simple(
+                    &event,
+                    &game.number,
+                    &game,
+                    None,
+                    tr,
+                    "",
+                    "Example White",
+                    "",
+                    "Example Black",
+                    &officials,
+                );
+                (html, "simple")
+            }
+            SheetStyle::SimpleTeamRefs => {
+                let html = render_html_simple_team_refs(
+                    &event,
+                    &game.number,
+                    &game,
+                    None,
+                    tr,
+                    "",
+                    "Example White",
+                    "",
+                    "Example Black",
+                );
+                (html, "simple_team_refs")
+            }
+            SheetStyle::Col3x3 => {
+                let empty_roster = TeamRosterInfo {
+                    players: Vec::new(),
+                    captain: None,
+                };
+                let html = render_html_col3x3(
+                    &event,
+                    &game.number,
+                    &game,
+                    None,
+                    tr,
+                    "",
+                    "Example White",
+                    "",
+                    "Example Black",
+                    &officials,
+                    &empty_roster,
+                    &empty_roster,
+                );
+                (html, "col3x3")
+            }
+        };
+
+        let path = output_dir.join(format!("scoresheet_example_{}_{}.html", slug, style_name));
+        fs::write(&path, html)?;
+    }
+
+    Ok(())
+}
+
+fn faults_warnings_section() -> String {
+    let mut counts12 = String::new();
+    for i in 1..=12 {
+        counts12.push_str(&format!("<th>{}</th>", i));
+    }
+    let mut counts8 = String::new();
+    for i in 1..=8 {
+        if i == 1 {
+            counts8.push_str(&format!("<th class='sep-left'>{}</th>", i));
+        } else {
+            counts8.push_str(&format!("<th>{}</th>", i));
+        }
+    }
+    let items = [
+        "STICK INFRINGEMENT",
+        "ILLEGAL ADVANCEMENT",
+        "OBSTR. / SCREEN / BARG.",
+        "ILLEGALLY STOP",
+        "FREE ARM",
+        "FALSE START / BREAKING",
+        "GRABBING BARRIER",
+        "ILLEGAL SUBSTITUTION",
+        "OUT OF BOUNDS",
+        "DELAY OF GAME",
+        "UNSPORTING CONDUCT",
+    ];
+    let mut rows = String::new();
+    for it in items {
+        let mut warn = String::new();
+        for j in 0..8 {
+            if j == 0 {
+                warn.push_str("<td class='sep-left'></td>");
+            } else {
+                warn.push_str("<td></td>");
+            }
+        }
+        rows.push_str(&format!(
+            "<tr><td class='tl'>{}</td>{}{}</tr>",
+            html_escape(it),
+            empty_cells(12),
+            warn
+        ));
+    }
+    format!(
+        "<table class='sheet faults'>\
+           <colgroup><col class='col-fault'/><col class='col-infra' span='12'/><col class='col-warn' span='8'/></colgroup>\
+           <tr class='cap-row'><th class='tl'>FAULTS AND WARNINGS</th><th colspan='12'>INFRACTION COUNT</th><th class='sep-left' colspan='8'>WARNING COUNT</th></tr>\
+           <tr><th class='tl'>FAULT LIST</th>{}{}</tr>\
+           {}\
+         </table>",
+        counts12, counts8, rows
+    )
+}
+
+fn time_penalty_section_fixed() -> String {
+    let mut hdr = String::new();
+    for i in 1..=20 {
+        hdr.push_str(&format!("<th>{}</th>", i));
+    }
+    format!(
+        "<table class='sheet penalty'>\
+           <colgroup><col class='col-label'/><col class='col-pen' span='20'/></colgroup>\
+           <tr class='cap-row'><th class='tl'>TIME PENALTY &darr;&nbsp;&nbsp;&nbsp;&nbsp;COUNT &rarr;</th>{}</tr>\
+           <tr><td class='tl'>1 min</td>{}</tr>\
+           <tr><td class='tl'>2 min</td>{}</tr>\
+           <tr><td class='tl'>5 min</td>{}</tr>\
+           <tr><td class='tl'>TOTAL DISMISSAL</td>{}{}</tr>\
+         </table>",
+        hdr,
+        empty_cells(20),
+        empty_cells(20),
+        empty_cells(20),
+        empty_cells(10),
+        speckled_cells(10)
+    )
+}
+
+fn html_escape(s: &str) -> String {
+    s.chars()
+        .flat_map(|c| match c {
+            '&' => "&amp;".chars().collect::<Vec<_>>(),
+            '<' => "&lt;".chars().collect(),
+            '>' => "&gt;".chars().collect(),
+            '"' => "&quot;".chars().collect(),
+            '\'' => "&#39;".chars().collect(),
+            _ => vec![c],
+        })
+        .collect()
+}

--- a/schedule-processor/src/scoresheets.rs
+++ b/schedule-processor/src/scoresheets.rs
@@ -253,9 +253,6 @@ pub async fn generate_scoresheets_for_event(
             ),
         };
 
-        // Per-game HTML is intermediate only (never read back); the PDF is built from the
-        // combined HTML below, so we don't write per-game files to the output folder.
-
         // Capture CSS from the first page and append this page fragment for combined output
         if combined_css.is_none() {
             if let (Some(s), Some(e)) = (html.find("<style>"), html.find("</style>")) {
@@ -291,10 +288,15 @@ pub async fn generate_scoresheets_for_event(
     // Build combined HTML and export a single PDF via Chrome headless
     if !combined_pages.is_empty() {
         let css = combined_css.unwrap_or_default();
+        // Auto-fit: size each header field value's font to fill its fixed-width box on
+        // one line, growing up to MAX and shrinking (down to MIN) when the text is too
+        // long. Runs in headless Chrome before print-to-pdf, and in the saved HTML.
+        const FIT_SCRIPT: &str = "(function(){var MIN=7,MAX=16;var vs=document.querySelectorAll('.fields .val');for(var i=0;i<vs.length;i++){var el=vs[i];el.style.whiteSpace='nowrap';el.style.overflow='hidden';if(!el.textContent.trim())continue;var s=MIN;el.style.fontSize=s+'px';while(s<MAX){el.style.fontSize=(s+0.5)+'px';if(el.scrollWidth>el.clientWidth){el.style.fontSize=s+'px';break;}s+=0.5;}}})();";
         let all_html = format!(
-            r#"<!doctype html><html><head><meta charset='utf-8'/><style>{css}</style></head><body>{pages}</body></html>"#,
+            r#"<!doctype html><html><head><meta charset='utf-8'/><style>{css}</style></head><body>{pages}<script>{fit}</script></body></html>"#,
             css = css,
-            pages = combined_pages
+            pages = combined_pages,
+            fit = FIT_SCRIPT
         );
         let all_html_path = inputs.output_dir.join("scoresheets-all.html");
         fs::write(&all_html_path, all_html.as_bytes())?;
@@ -310,17 +312,12 @@ pub async fn generate_scoresheets_for_event(
         };
         let html_url = format!("file:///{}", html_abs.to_string_lossy().replace('\\', "/"));
 
-        // Hardwire Chrome: prefer standard install paths, then PATH 'chrome'
-        let mut candidates: Vec<String> = vec![
-            r#"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe"#.into(),
-            r#"C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe"#.into(),
-        ];
-        if let Ok(local) = std::env::var("LOCALAPPDATA") {
-            let mut p = std::path::PathBuf::from(&local);
-            p.push("Google\\Chrome\\Application\\chrome.exe");
-            candidates.push(p.to_string_lossy().into_owned());
-        }
-        candidates.push("chrome".into());
+        // Browsers to try for HTML->PDF, across Linux/WSL, macOS and Windows.
+        // Override with the SCORESHEET_BROWSER env var (full path to a browser).
+        let candidates = browser_candidates(
+            std::env::var("SCORESHEET_BROWSER").ok().as_deref(),
+            std::env::var("LOCALAPPDATA").ok().as_deref(),
+        );
         let try_arg_sets: [&[&str]; 4] = [
             &[
                 "--headless=new",
@@ -360,7 +357,7 @@ pub async fn generate_scoresheets_for_event(
             // If 'c' looks like a path, ensure it exists before trying
             let is_path_like = c.contains('\\') || c.contains('/') || c.contains(':');
             if is_path_like && !std::path::Path::new(c).exists() {
-                log::warn!("Chrome not found at: {}", c);
+                log::debug!("Browser not found at: {}", c);
                 continue;
             }
             for args in &try_arg_sets {
@@ -371,7 +368,7 @@ pub async fn generate_scoresheets_for_event(
                     .arg("--no-default-browser-check")
                     .arg(print_arg)
                     .arg(&html_url);
-                log::info!(
+                log::debug!(
                     "Attempting to print via '{}' url={} pdf={}",
                     c,
                     &html_url,
@@ -386,15 +383,21 @@ pub async fn generate_scoresheets_for_event(
                     Ok(out) => {
                         let so = String::from_utf8_lossy(&out.stdout);
                         let se = String::from_utf8_lossy(&out.stderr);
-                        log::error!(
-                            "Chrome run failed (status {}). stdout: {} stderr: {}",
+                        log::debug!(
+                            "Browser '{}' run failed (status {}). stdout: {} stderr: {}",
+                            c,
                             out.status,
-                            so,
-                            se
+                            so.trim(),
+                            se.trim()
                         );
                     }
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                        // Browser isn't installed; skip its remaining arg sets.
+                        log::debug!("Browser '{}' is not installed", c);
+                        continue 'outer;
+                    }
                     Err(e) => {
-                        log::error!("Failed to run Chrome '{}': {}", c, e);
+                        log::debug!("Failed to run browser '{}': {}", c, e);
                     }
                 }
             }
@@ -413,13 +416,65 @@ pub async fn generate_scoresheets_for_event(
         } else {
             // Keep the combined HTML on failure so there's something to inspect/recover.
             log::error!(
-                "Could not find or run a browser to produce combined PDF. Saved combined HTML at {}",
+                "No web browser was found to create the PDF. The combined HTML was still saved \
+                 at {}. To also get scoresheets-all.pdf, install Google Chrome and run again. On \
+                 Linux/WSL: download google-chrome-stable_current_amd64.deb from google.com and \
+                 install it with `sudo apt-get install -y ./google-chrome-stable_current_amd64.deb` \
+                 (Ubuntu's `chromium-browser` apt package is a Snap stub that does not run under \
+                 WSL). You can also point the tool at a specific browser by setting the \
+                 SCORESHEET_BROWSER environment variable to its full path.",
                 all_html_path.display()
             );
         }
     }
 
     Ok(())
+}
+
+/// Build the ordered list of browser executables to try when converting the
+/// combined score-sheet HTML into a PDF via headless Chrome/Chromium.
+///
+/// Order: an explicit override (`SCORESHEET_BROWSER`) first, then common
+/// Linux/macOS names resolved via PATH, then the standard Windows Chrome
+/// install locations, then a bare `chrome` on PATH.
+///
+/// `explicit` is the value of the `SCORESHEET_BROWSER` env var (a full path to
+/// a browser executable); `localappdata` is the Windows `LOCALAPPDATA` env var.
+fn browser_candidates(explicit: Option<&str>, localappdata: Option<&str>) -> Vec<String> {
+    let mut candidates: Vec<String> = Vec::new();
+
+    // 1. Explicit override wins, when set and non-empty.
+    if let Some(path) = explicit {
+        if !path.is_empty() {
+            candidates.push(path.to_string());
+        }
+    }
+
+    // 2. Linux / macOS names, resolved via PATH.
+    for name in [
+        "chromium",
+        "chromium-browser",
+        "google-chrome",
+        "google-chrome-stable",
+        "microsoft-edge",
+    ] {
+        candidates.push(name.to_string());
+    }
+
+    // 3. Standard Windows Chrome install locations (kept for the Windows build).
+    candidates.push(r#"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe"#.to_string());
+    candidates
+        .push(r#"C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe"#.to_string());
+    if let Some(local) = localappdata {
+        let mut p = PathBuf::from(local);
+        p.push("Google\\Chrome\\Application\\chrome.exe");
+        candidates.push(p.to_string_lossy().into_owned());
+    }
+
+    // 4. Bare `chrome` on PATH.
+    candidates.push("chrome".to_string());
+
+    candidates
 }
 
 fn copy_logo(
@@ -784,11 +839,11 @@ fn render_html(
       .center { display:grid; grid-template-rows: auto auto auto auto; gap:4px; }
       .center .tname { text-align:center; font-weight:700; color:#000; font-size:22px; border:1px solid var(--border); padding:4px 8px; }
       .fields { display:grid; gap:5px; }
-      .fields.meta { grid-template-columns: 0.69fr 0.9fr 1fr 0.75fr 0.9fr 0.9fr; }
+      .fields.meta { grid-template-columns: 0.6fr 0.9fr 1.25fr 1.12fr 1.0fr 1.15fr 1.15fr; }
       .fields.off1, .fields.off2 { grid-template-columns: repeat(3, 1fr); }
-      .field { display:grid; grid-template-columns: auto 1fr; align-items:center; column-gap:6px; }
+      .field { display:grid; grid-template-columns: auto 1fr; align-items:center; column-gap:6px; min-width:0; }
       .field .lbl { font-size:10px; text-align:right; line-height:1.05; white-space:nowrap; }
-      .field .val { border:1px solid var(--border); height:22px; display:flex; align-items:center; justify-content:center; font-size:12px; }
+      .field .val { border:1px solid var(--border); height:22px; display:flex; align-items:center; justify-content:center; font-size:12px; min-width:0; }
 
       .sides { display:grid; grid-template-columns:1fr 1fr; gap:9px; margin-top:5px; }
       .block { border:0; }
@@ -944,9 +999,10 @@ fn render_html(
     <div class='center'>
       <div class='tname'>{event_name}</div>
       <div class='fields meta'>
+        <div class='field'><div class='lbl'>COURT:</div><div class='val'>{court}</div></div>
         <div class='field'><div class='lbl'>GAME #:</div><div class='val'>{game_number}</div></div>
-        <div class='field'><div class='lbl'>DIV. / POD:</div><div class='val'>{divpod}</div></div>
-        <div class='field'><div class='lbl'>CATEGORY:</div><div class='val'>{category}</div></div>
+        <div class='field'><div class='lbl'>DIV. /<br>POD:</div><div class='val'>{divpod}</div></div>
+        <div class='field'><div class='lbl'>TYPE:</div><div class='val'>{category}</div></div>
         <div class='field'><div class='lbl'>DATE:</div><div class='val'>{date}</div></div>
         <div class='field'><div class='lbl'>SCHEDULED<br>START TIME:</div><div class='val'>{time}</div></div>
         <div class='field'><div class='lbl'>ACTUAL<br>START TIME:</div><div class='val'></div></div>
@@ -978,6 +1034,7 @@ fn render_html(
         "#,
         css = css,
         event_name = html_escape(&event.name),
+        court = html_escape(&game.court),
         game_number = html_escape(game_number),
         divpod = html_escape(&divpod),
         category = html_escape(cat),
@@ -2582,4 +2639,45 @@ fn html_escape(s: &str) -> String {
             _ => vec![c],
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::browser_candidates;
+
+    #[test]
+    fn candidates_include_linux_names() {
+        let candidates = browser_candidates(None, None);
+        for name in [
+            "chromium",
+            "chromium-browser",
+            "google-chrome",
+            "google-chrome-stable",
+        ] {
+            assert!(
+                candidates.iter().any(|c| c == name),
+                "expected candidate list to include {name}, got {candidates:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn explicit_browser_is_tried_first() {
+        let candidates = browser_candidates(Some("/opt/custom/chrome"), None);
+        assert_eq!(
+            candidates.first().map(String::as_str),
+            Some("/opt/custom/chrome"),
+            "explicit SCORESHEET_BROWSER path should be first"
+        );
+    }
+
+    #[test]
+    fn empty_explicit_is_ignored() {
+        let candidates = browser_candidates(Some(""), None);
+        assert_eq!(
+            candidates.first().map(String::as_str),
+            Some("chromium"),
+            "empty override should be skipped, Linux names come first"
+        );
+    }
 }

--- a/schedule-processor/src/scoresheets.rs
+++ b/schedule-processor/src/scoresheets.rs
@@ -50,6 +50,10 @@ pub struct RenderInputs {
     pub output_dir: PathBuf,
     pub style: SheetStyle,
     pub prefer_portal_officials: bool,
+    /// When false, referee/official names are left blank on the sheet (the operator
+    /// fills them in by hand). Does not apply to the Simple (Team Refs) style, which
+    /// uses team-based assignments rather than individual official names.
+    pub include_referees: bool,
 }
 
 pub async fn generate_scoresheets_for_event(
@@ -138,8 +142,12 @@ pub async fn generate_scoresheets_for_event(
         let (white_suffix, white_name) = placeholder_suffix_and_name(&game.light, &teams);
         let (black_suffix, black_name) = placeholder_suffix_and_name(&game.dark, &teams);
 
-        // Decide official names based on preference: portal display names vs CSV
-        let officials = if inputs.prefer_portal_officials {
+        // Decide official names. When the operator declined referee names, leave them
+        // blank (skipping the portal/CSV lookups entirely). Otherwise choose by
+        // preference: portal display names vs CSV.
+        let officials = if !inputs.include_referees {
+            OfficialNames::default()
+        } else if inputs.prefer_portal_officials {
             let resolved =
                 resolve_officials(&*portal_client, &event.id, game, &mut name_cache).await;
             // Fallback to CSV for this game if portal provides nothing

--- a/uwh-common/src/uwhportal/mod.rs
+++ b/uwh-common/src/uwhportal/mod.rs
@@ -15,6 +15,66 @@ use std::{
 
 pub mod schedule;
 
+// --- Coin-flip portal types (used by scoresheet generation / coin-flip resolution) ---
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CoinFlipDetails {
+    #[serde(rename = "Groups", alias = "groups")]
+    pub groups: Vec<GroupCoinFlips>,
+    #[serde(rename = "Games", alias = "games")]
+    pub games: Vec<CoinFlip>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct GroupCoinFlips {
+    #[serde(rename = "Identifier", alias = "identifier")]
+    pub identifier: String,
+    #[serde(rename = "Name", alias = "name")]
+    pub name: String,
+    #[serde(rename = "ShortName", alias = "shortName")]
+    pub short_name: Option<String>,
+    #[serde(rename = "CoinFlips", alias = "coinFlips")]
+    pub coin_flips: Vec<CoinFlip>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CoinFlip {
+    #[serde(rename = "Identifier", alias = "identifier")]
+    pub identifier: String,
+    #[serde(rename = "TiedTeams", alias = "tiedTeams")]
+    pub tied_teams: Vec<CoinFlipTeam>,
+    #[serde(rename = "Result", alias = "result")]
+    pub result: Option<CoinFlipResult>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CoinFlipTeam {
+    #[serde(rename = "TeamId", alias = "teamId")]
+    pub team_id: Option<String>,
+    #[serde(rename = "PendingAssignmentName", alias = "pendingAssignmentName")]
+    pub pending_assignment_name: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CoinFlipResult {
+    #[serde(rename = "Kind", alias = "kind")]
+    pub kind: String,
+    #[serde(rename = "Team", alias = "team")]
+    pub team: CoinFlipTeam,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SetCoinFlipModel {
+    #[serde(rename = "GroupIdentifier")]
+    pub group_identifier: Option<String>,
+    #[serde(rename = "CoinFlipIdentifier")]
+    pub coin_flip_identifier: String,
+    #[serde(rename = "TeamIdOrPendingAssignmentName")]
+    pub team_id_or_pending_assignment_name: String,
+    #[serde(rename = "Kind")]
+    pub kind: String,
+}
+
 pub struct UwhPortalClient {
     base_url: String,
     access_token: Option<String>,
@@ -539,4 +599,55 @@ pub enum PortalTokenResponse {
     Success(String),
     NoPendingLink,
     InvalidCode,
+}
+
+#[cfg(test)]
+mod coin_flip_tests {
+    use super::*;
+
+    #[test]
+    fn coin_flip_details_deserializes_camel_case() {
+        // The portal sends camelCase (aliases); PascalCase is also accepted.
+        let json = r#"{
+            "groups": [{
+                "identifier": "g1",
+                "name": "Group A",
+                "shortName": "A",
+                "coinFlips": [{
+                    "identifier": "cf1",
+                    "tiedTeams": [
+                        {"teamId": "1-A", "pendingAssignmentName": null},
+                        {"teamId": "2-A", "pendingAssignmentName": null}
+                    ],
+                    "result": {"kind": "White", "team": {"teamId": "1-A", "pendingAssignmentName": null}}
+                }]
+            }],
+            "games": []
+        }"#;
+        let parsed: CoinFlipDetails = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.groups.len(), 1);
+        let g = &parsed.groups[0];
+        assert_eq!(g.identifier, "g1");
+        assert_eq!(g.coin_flips.len(), 1);
+        assert_eq!(g.coin_flips[0].tied_teams.len(), 2);
+        assert_eq!(
+            g.coin_flips[0].result.as_ref().unwrap().kind.as_str(),
+            "White"
+        );
+    }
+
+    #[test]
+    fn set_coin_flip_model_serializes_pascal_case() {
+        let model = SetCoinFlipModel {
+            group_identifier: Some("g1".to_string()),
+            coin_flip_identifier: "cf1".to_string(),
+            team_id_or_pending_assignment_name: "1-A".to_string(),
+            kind: "White".to_string(),
+        };
+        let v: serde_json::Value = serde_json::to_value(&model).unwrap();
+        assert_eq!(v["GroupIdentifier"], "g1");
+        assert_eq!(v["CoinFlipIdentifier"], "cf1");
+        assert_eq!(v["TeamIdOrPendingAssignmentName"], "1-A");
+        assert_eq!(v["Kind"], "White");
+    }
 }

--- a/uwh-common/src/uwhportal/mod.rs
+++ b/uwh-common/src/uwhportal/mod.rs
@@ -557,6 +557,247 @@ impl UwhPortalClient {
             }
         }
     }
+
+    // --- Scoresheet generation portal calls (schedule / roster / referees / coin-flip) ---
+
+    /// Public (unauthenticated) event schedule. NOTE: for some events the public
+    /// endpoint returns games as a JSON array rather than the object `GameList`
+    /// expects; if this fails to parse for real data, use
+    /// `get_event_schedule_privileged` instead.
+    pub fn get_event_schedule_public(
+        &self,
+        event_id: &EventId,
+    ) -> impl std::future::Future<Output = Result<schedule::Schedule, Box<dyn Error>>> + use<> {
+        let url = format!(
+            "{}/api/events/{}/schedule",
+            self.base_url,
+            event_id.partial()
+        );
+        let request = self.client.get(&url).send();
+        async move {
+            let response = request.await?;
+            if response.status() == StatusCode::OK {
+                let body = response.text().await?;
+                let schedule: schedule::Schedule = serde_json::from_str(&body)?;
+                Ok(schedule)
+            } else {
+                warn!("uwhportal get public event schedule failed, response: {response:?}");
+                let body = response.text().await?;
+                Err(Box::new(ApiError::new(body)))?
+            }
+        }
+    }
+
+    #[allow(clippy::type_complexity)]
+    pub fn get_team_roster(
+        &self,
+        team_id: &TeamId,
+    ) -> impl std::future::Future<
+        Output = Result<(Vec<(Option<u8>, String)>, Option<String>), Box<dyn Error>>,
+    > + use<> {
+        let url = format!("{}/api/admin/get-event-team", self.base_url);
+        let team_id_full = team_id.full().to_string();
+        let request = self
+            .client
+            .get(&url)
+            .query(&[("teamId", &team_id_full)])
+            .send();
+        async move {
+            let response = request.await?;
+            if response.status() == StatusCode::OK {
+                let body = response.json::<serde_json::Value>().await?;
+                let mut players = Vec::new();
+                let mut captain_name: Option<String> = None;
+
+                if let Some(roster) = body.get("roster").and_then(|v| v.as_array()) {
+                    for member in roster {
+                        let number = member
+                            .get("capNumber")
+                            .and_then(|v| v.as_u64())
+                            .map(|n| n as u8);
+                        let roster_name = member
+                            .get("rosterName")
+                            .and_then(|v| v.as_str())
+                            .map(|s| s.trim())
+                            .filter(|s| !s.is_empty());
+                        let username = member
+                            .get("username")
+                            .and_then(|v| v.as_str())
+                            .map(|s| s.trim())
+                            .filter(|s| !s.is_empty());
+                        let name = roster_name.or(username).unwrap_or("").to_string();
+
+                        if let Some(roles) = member.get("roles").and_then(|v| v.as_array()) {
+                            if roles.iter().any(|r| r.as_str() == Some("Captain")) {
+                                captain_name = Some(name.clone());
+                            }
+                        }
+
+                        if !name.is_empty() || number.is_some() {
+                            players.push((number, name));
+                        }
+                    }
+                }
+                players.sort_by(|a, b| match (a.0, b.0) {
+                    (Some(na), Some(nb)) => na.cmp(&nb),
+                    (Some(_), None) => std::cmp::Ordering::Less,
+                    (None, Some(_)) => std::cmp::Ordering::Greater,
+                    (None, None) => a.1.cmp(&b.1),
+                });
+                Ok((players, captain_name))
+            } else {
+                let body = response.text().await?;
+                Err(Box::new(ApiError::new(body)))?
+            }
+        }
+    }
+
+    pub fn get_coin_flips(
+        &self,
+        event_slug: &str,
+    ) -> impl std::future::Future<Output = Result<CoinFlipDetails, Box<dyn Error>>> + use<> {
+        let url = format!(
+            "{}/api/events/{event_slug}/schedule/coin-flips",
+            self.base_url
+        );
+        let request =
+            authenticated_request(&self.client, Method::GET, &url, &self.access_token).send();
+        async move {
+            let response = request.await?;
+            let status = response.status();
+            let body = response.text().await?;
+            if status == StatusCode::OK {
+                match serde_json::from_str::<CoinFlipDetails>(&body) {
+                    Ok(parsed) => Ok(parsed),
+                    Err(e) => {
+                        debug!("get_coin_flips: failed to decode body: {e}; body: {body}");
+                        Err(Box::new(ApiError::new(format!(
+                            "error decoding response body: {e}"
+                        ))))?
+                    }
+                }
+            } else {
+                Err(Box::new(ApiError::new(body)))?
+            }
+        }
+    }
+
+    /// Returns a map from user_id string to display name, populated from the
+    /// authenticated `/participants` endpoint for the event.
+    pub fn get_event_referee_name_map(
+        &self,
+        event_id: &EventId,
+    ) -> impl std::future::Future<Output = Result<HashMap<String, String>, Box<dyn Error>>> + use<>
+    {
+        let url = format!(
+            "{}/api/events/{}/participants",
+            self.base_url,
+            event_id.partial()
+        );
+        let request =
+            authenticated_request(&self.client, Method::GET, &url, &self.access_token).send();
+        async move {
+            let response = request.await?;
+            if response.status() != StatusCode::OK {
+                let body = response.text().await?;
+                return Err(Box::new(ApiError::new(body)) as Box<dyn Error>);
+            }
+            let body = response.json::<serde_json::Value>().await?;
+            let mut map = HashMap::new();
+            let items = body
+                .as_array()
+                .cloned()
+                .or_else(|| body["participants"].as_array().cloned())
+                .or_else(|| body["items"].as_array().cloned())
+                .unwrap_or_default();
+            // Same nested-user structure as /referees
+            for item in &items {
+                let uid = item["user"]["id"]
+                    .as_str()
+                    .or_else(|| item["userId"].as_str())
+                    .or_else(|| item["id"].as_str());
+                let name = item["rosterName"]
+                    .as_str()
+                    .or_else(|| item["user"]["name"].as_str())
+                    .or_else(|| item["user"]["username"].as_str());
+                if let (Some(uid), Some(name)) = (uid, name) {
+                    map.insert(uid.to_string(), name.to_string());
+                }
+            }
+            Ok(map)
+        }
+    }
+
+    /// Returns a map from user_id string to display name for all referees
+    /// assigned to the given game (authenticated admin endpoint, AllowAnonymous).
+    pub fn get_game_referee_name_map(
+        &self,
+        event_id: &EventId,
+        game_number: &GameNumber,
+    ) -> impl std::future::Future<Output = Result<HashMap<String, String>, Box<dyn Error>>> + use<>
+    {
+        let url = format!("{}/api/admin/events/game-referees", self.base_url);
+        let event_id_full = event_id.full().to_string();
+        let game_number = game_number.clone();
+        let request = authenticated_request(&self.client, Method::GET, &url, &self.access_token)
+            .query(&[("eventId", &event_id_full), ("gameNumber", &game_number)])
+            .send();
+        async move {
+            let response = request.await?;
+            if response.status() != StatusCode::OK {
+                let body = response.text().await?;
+                return Err(Box::new(ApiError::new(body)) as Box<dyn Error>);
+            }
+            let body = response.json::<serde_json::Value>().await?;
+            let mut map = HashMap::new();
+            // Response: { referees: [ { user: { id, name, username } } ] }
+            // name may be null; username is the fallback.
+            let items = body["referees"]
+                .as_array()
+                .cloned()
+                .or_else(|| body.as_array().cloned())
+                .unwrap_or_default();
+            for item in &items {
+                let uid = item["user"]["id"]
+                    .as_str()
+                    .or_else(|| item["userId"].as_str())
+                    .or_else(|| item["id"].as_str());
+                let name = item["user"]["name"]
+                    .as_str()
+                    .or_else(|| item["user"]["username"].as_str())
+                    .or_else(|| item["rosterName"].as_str());
+                if let (Some(uid), Some(name)) = (uid, name) {
+                    map.insert(uid.to_string(), name.to_string());
+                }
+            }
+            Ok(map)
+        }
+    }
+
+    pub fn set_coin_flip_result(
+        &self,
+        event_slug: &str,
+        model: &SetCoinFlipModel,
+        force: bool,
+    ) -> impl std::future::Future<Output = Result<(), Box<dyn Error>>> + use<> {
+        let url = format!(
+            "{}/api/events/{event_slug}/schedule/coin-flips",
+            self.base_url
+        );
+        let request = authenticated_request(&self.client, Method::POST, &url, &self.access_token)
+            .query(&[("force", force)])
+            .json(model)
+            .send();
+        async move {
+            let response = request.await?;
+            if response.status() == StatusCode::OK {
+                Ok(())
+            } else {
+                let body = response.text().await?;
+                Err(Box::new(ApiError::new(body)))?
+            }
+        }
+    }
 }
 
 fn authenticated_request(

--- a/uwh-common/src/uwhportal/schedule.rs
+++ b/uwh-common/src/uwhportal/schedule.rs
@@ -477,6 +477,37 @@ pub struct Group {
 
 pub type GameList = IndexMap<GameNumber, Game>;
 
+/// Basic team info for team referee assignments
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TeamRefInfo {
+    #[serde(default)]
+    pub id: Option<TeamId>,
+    #[serde(default)]
+    pub name: Option<String>,
+}
+
+/// Team referee assignment — which team provides referees for a role
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TeamRefAssignment {
+    #[serde(default)]
+    pub team: Option<TeamRefInfo>,
+}
+
+/// Per-game team referee assignments (used when teams fill referee roles)
+#[serde_with::skip_serializing_none]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GameReferees {
+    #[serde(default, rename = "timeOrScoreKeeper")]
+    pub time_or_score_keeper: Option<TeamRefAssignment>,
+    #[serde(default, rename = "timeOrScoreHelper")]
+    pub time_or_score_helper: Option<TeamRefAssignment>,
+    #[serde(default)]
+    pub referees: Option<TeamRefAssignment>,
+}
+
+pub type RefereesByGameNumber = IndexMap<GameNumber, GameReferees>;
+
 #[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Schedule {
@@ -492,6 +523,8 @@ pub struct Schedule {
     pub standings_order: Option<Vec<GroupReference>>,
     #[serde(rename = "finalResultsOrder")]
     pub final_results_order: Option<Vec<GroupReference>>,
+    #[serde(default, rename = "refereesByGameNumber")]
+    pub referees_by_game_number: Option<RefereesByGameNumber>,
 }
 
 impl Schedule {
@@ -774,6 +807,28 @@ mod tests {
         env!("CARGO_MANIFEST_DIR"),
         "/resources/uwhportal_postman_schedule_example.json"
     );
+
+    #[test]
+    fn referees_by_game_number_deserializes() {
+        // `id` left null so the test is independent of TeamId's "teams/…" full-id
+        // format (that format is exercised by TeamId's own tests and verified live).
+        let json = r#"{
+            "1": {
+                "timeOrScoreKeeper": {"team": {"id": null, "name": "Team Alpha"}},
+                "referees": {"team": {"id": null, "name": "Team Bravo"}}
+            }
+        }"#;
+        let map: RefereesByGameNumber = serde_json::from_str(json).unwrap();
+        let g1 = map.get("1").expect("game 1 present");
+        assert_eq!(
+            g1.time_or_score_keeper
+                .as_ref()
+                .and_then(|a| a.team.as_ref())
+                .and_then(|t| t.name.as_deref()),
+            Some("Team Alpha")
+        );
+        assert!(g1.time_or_score_helper.is_none());
+    }
 
     #[test]
     fn test_serialize_winner() {
@@ -1413,6 +1468,7 @@ mod tests {
             }],
             standings_order: None,
             final_results_order: None,
+            referees_by_game_number: None,
         };
         let serialized = serde_json::to_string(&schedule).unwrap();
         let deserialized: serde_json::Value = serde_json::from_str(&serialized).unwrap();


### PR DESCRIPTION
## What changed
Adds a **Generate Score Sheets** capability to the schedule processor. It builds each game's scoresheet as a web page and uses Google Chrome to turn them into a printable PDF. Included:
- Core scoresheets: game info, teams, and referee names
- A roster-filled **Col_3x3** style (players + captain, pulled from the portal)
- A **Resolve Coin Tosses** step
- Court number on the Detailed sheet, tidied header, and auto-fitting header text
- Cross-platform PDF generation — finds Chrome/Chromium/Edge on Windows, Linux/WSL, and macOS (with a `SCORESHEET_BROWSER` override)

It also improves the tool's flow:
- The schedule CSV is only requested when an action actually needs it (not at startup)
- The event picker is sorted soonest-first
- Answering "Include referee names? No" now truly leaves the referee lines blank
- The output folder is left containing only the PDF

## Why
The scoresheet feature previously lived only on an older branch and no longer worked against the current portal. This brings it forward onto current code so it reliably generates scoresheets from today's portal, and folds in this session's usability fixes.

## Scope
- **uwh-common**: new portal request/response types (coin-flip + team-referee) and 6 portal API calls (public schedule, team roster, coin-flips read/write, referee name maps). Additive only — no existing behaviour changed.
- **schedule-processor**: the scoresheet generator module, the new menu options, and the CSV/event-list/flow tweaks above.
- **refbox**: a one-line change to a test helper, compile-forced by the additive uwh-common type (no behaviour change).

## How to verify
1. Run the schedule processor, choose the Development portal + an event, and log in.
2. Choose **Generate Score Sheets** → pick an output folder → try **Detailed** and **Col_3x3**.
3. Confirm a PDF is produced with correct game info, **court number**, referee names, and (Col_3x3) player rosters. The folder should contain only the PDF.
4. Try **Resolve Coin Tosses** and confirm it lists the pending flips.
5. Confirm **Include referee names? No** produces blank referee lines.

## Note on CI (audit)
The `audit` check is red due to a **project-wide** advisory in `quick-xml` 0.37.5 (RUSTSEC-2026-0194 / 0195; fix = upgrade to ≥0.41.0). This is **also present on `master`** — this branch's `Cargo.lock` is byte-identical to master's and adds **zero** dependencies. `quick-xml` is a transitive library in the SVG/font-rendering stack, unrelated to this feature. All other checks (fmt, clippy, tests) pass. This PR will go green once `quick-xml` is bumped repo-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
