### PR TITLE
chore(ci): sync Justfile audit ignores with CI workflow

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -41,8 +41,14 @@ test:
 # RUSTSEC-2024-0388: derivative - unmaintained (no fix available)
 # RUSTSEC-2026-0009: time - fix (>=0.3.47) requires Rust 1.88+, above our MSRV of 1.85
 #                    tracked in docs/decisions/002-time-cve-msrv.md
+# RUSTSEC-2026-0194: quick-xml - reached only via build-time wayland-scanner XML parse (not exposed)
+# RUSTSEC-2026-0195: quick-xml - same DoS vector, not exposed here
+# RUSTSEC-2025-0052: async-std - unmaintained, transitively via iced_futures
+#                    all three locked behind an out-of-scope iced/winit upgrade;
+#                    tracked in docs/decisions/024-cargo-audit-iced-transitive-advisories.md
+# Keep this ignore list in sync with the audit step in .github/workflows/rust.yml.
 audit:
-    cargo audit --ignore RUSTSEC-2024-0384 --ignore RUSTSEC-2024-0388 --ignore RUSTSEC-2026-0009
+    cargo audit --ignore RUSTSEC-2024-0384 --ignore RUSTSEC-2024-0388 --ignore RUSTSEC-2026-0009 --ignore RUSTSEC-2026-0194 --ignore RUSTSEC-2026-0195 --ignore RUSTSEC-2025-0052
 
 # ── Building ──────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## What changed
Syncs the local `just audit` command's ignore list with the one CI already uses in `.github/workflows/rust.yml` — adding three advisories CI accepts (two `quick-xml`, one `async-std`), each with a justification comment.

## Why
The CI audit step and the local `just audit` / `just check` had drifted apart. CI ignores these three transitive advisories (documented in decision 024 — they're reached only via a build-time Wayland-XML parser / are unmaintained-warnings), but the `Justfile` was never updated to match. The result: `just check` and `just audit` **failed locally for everyone**, even though CI was green. This restores parity so a local check reflects what CI does.

## Scope
- `Justfile` only (the `audit` recipe + its comments). No code, no dependency, and no CI-behaviour changes.

## How to verify
Run `just audit` (or `just check`): it now passes with no errors. Before this change it failed with the two `quick-xml` vulnerabilities. CI is unaffected — it already ignored these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
