### PR TITLE
fix(refbox): auto-expire portal-queue items after 120h

### DIFF
--- a/refbox/src/portal_manager/mod.rs
+++ b/refbox/src/portal_manager/mod.rs
@@ -355,6 +355,20 @@ pub fn is_item_stuck(item: &QueuedItem, now: OffsetDateTime) -> bool {
     !item.score_sent && (now - item.queued_at) >= STUCK_THRESHOLD
 }
 
+/// How long an unresolved item may sit in the queue before it is
+/// auto-expired: removed from the active queue (and archived to
+/// `portal_queue.expired.json`) so a stale, undeliverable score can't hold
+/// the indicator red forever. Mirrors the link-restore freshness window
+/// (`link_session::FRESHNESS_WINDOW`, also 120h).
+pub const EXPIRY_THRESHOLD: TimeDuration = TimeDuration::hours(120);
+
+/// An item is expired once it has sat in the queue for `EXPIRY_THRESHOLD`,
+/// regardless of `score_sent` — a stale stats-pending item is swept too so
+/// the whole leftover queue clears.
+fn is_item_expired(item: &QueuedItem, now: OffsetDateTime) -> bool {
+    (now - item.queued_at) >= EXPIRY_THRESHOLD
+}
+
 pub struct PortalManager {
     queue: QueueFile,
     check_in_flight: bool,
@@ -421,7 +435,40 @@ impl PortalManager {
     ///   indicator picks up anything that might have changed between
     ///   frames.
     pub fn ui_tick(&mut self) {
+        if let Err(e) = self.sweep_expired() {
+            log::warn!("portal queue expiry sweep failed: {e}");
+        }
         self.recompute_indicator();
+    }
+
+    /// Remove items past `EXPIRY_THRESHOLD` from the active queue, archiving
+    /// them first so nothing is silently lost. Runs at startup (in `new`) and
+    /// on every `ui_tick`; only touches disk when an item actually expires.
+    /// IO is ordered archive-then-remove so a failed write can never drop a
+    /// score without a saved copy.
+    fn sweep_expired(&mut self) -> std::io::Result<()> {
+        let now = OffsetDateTime::now_utc();
+        let (expired, kept): (Vec<QueuedItem>, Vec<QueuedItem>) = self
+            .queue
+            .items
+            .iter()
+            .cloned()
+            .partition(|it| is_item_expired(it, now));
+        if expired.is_empty() {
+            return Ok(());
+        }
+        // Archive BEFORE removing so a failed write never loses a score.
+        queue::append_to_archive(&self.config_dir, &expired)?;
+        let n = expired.len();
+        self.queue.items = kept;
+        queue::save(&self.config_dir, &self.queue)?;
+        self.recompute_indicator();
+        self.push_queue_snapshot();
+        log::info!(
+            "Expired {n} stale portal-queue item(s) (>{}h); archived to portal_queue.expired.json",
+            EXPIRY_THRESHOLD.whole_hours()
+        );
+        Ok(())
     }
 
     fn has_stuck_items(&self) -> bool {
@@ -500,6 +547,11 @@ impl PortalManager {
             config_dir: config_dir.to_path_buf(),
             recent_successes: VecDeque::new(),
         };
+        // Clear any items that already exceeded the expiry limit before this
+        // launch (e.g. leftovers carried across a portal switch or reboot).
+        if let Err(e) = m.sweep_expired() {
+            log::warn!("portal queue expiry sweep at startup failed: {e}");
+        }
         m.recompute_indicator();
         m.push_queue_snapshot();
         Ok((m, handle.event_rx))
@@ -1093,6 +1145,101 @@ mod tests {
 
         assert_eq!(m.indicator_state().health, HealthState::Green);
         assert!(m.queue.items.is_empty());
+    }
+
+    #[test]
+    fn item_under_120h_is_not_expired() {
+        let now = OffsetDateTime::now_utc();
+        let mut it = mk_young_item();
+        it.queued_at = now - TimeDuration::hours(119);
+        assert!(!is_item_expired(&it, now));
+    }
+
+    #[test]
+    fn item_over_120h_is_expired() {
+        let now = OffsetDateTime::now_utc();
+        let mut it = mk_young_item();
+        it.queued_at = now - TimeDuration::hours(121);
+        assert!(is_item_expired(&it, now));
+    }
+
+    #[test]
+    fn stats_pending_item_over_120h_is_expired() {
+        // A stats-pending item (score already accepted) doesn't drive the
+        // indicator, but a 5-day-old one should still be swept so the stale
+        // queue clears entirely.
+        let now = OffsetDateTime::now_utc();
+        let mut it = mk_young_item();
+        it.score_sent = true;
+        it.queued_at = now - TimeDuration::hours(121);
+        assert!(is_item_expired(&it, now));
+    }
+
+    #[tokio::test]
+    async fn sweep_removes_expired_item_archives_it_and_returns_to_green() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (mut m, _rx) = PortalManager::new(tmp.path(), NullIo).unwrap();
+        m.enqueue_game_end("e1".into(), "G1".into(), 3, 2, "{}".into())
+            .unwrap();
+        // Backdate past the 120h limit.
+        m.queue.items[0].queued_at = OffsetDateTime::now_utc() - TimeDuration::hours(121);
+
+        m.sweep_expired().unwrap();
+
+        assert!(m.queue.items.is_empty(), "expired item should be removed");
+        let archive = crate::portal_manager::queue::load_archive_or_empty(tmp.path()).unwrap();
+        assert_eq!(archive.items.len(), 1);
+        assert_eq!(archive.items[0].id.game_number, "G1");
+        assert_eq!(m.indicator_state().health, HealthState::Green);
+    }
+
+    #[tokio::test]
+    async fn sweep_keeps_a_fresh_item() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (mut m, _rx) = PortalManager::new(tmp.path(), NullIo).unwrap();
+        m.enqueue_game_end("e1".into(), "G1".into(), 0, 0, "{}".into())
+            .unwrap();
+
+        m.sweep_expired().unwrap();
+
+        assert_eq!(m.queue.items.len(), 1, "a fresh item must not be swept");
+        assert!(
+            crate::portal_manager::queue::load_archive_or_empty(tmp.path())
+                .unwrap()
+                .items
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn startup_sweep_clears_a_stale_queue_file() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        // Pre-populate a queue file with an item older than 120h.
+        let mut old = mk_young_item();
+        old.queued_at = OffsetDateTime::now_utc() - TimeDuration::hours(200);
+        crate::portal_manager::queue::save(
+            tmp.path(),
+            &QueueFile {
+                version: 1,
+                items: vec![old],
+            },
+        )
+        .unwrap();
+
+        let (m, _rx) = PortalManager::new(tmp.path(), NullIo).unwrap();
+
+        assert!(
+            m.queue.items.is_empty(),
+            "startup should sweep the stale queue item"
+        );
+        assert_eq!(
+            crate::portal_manager::queue::load_archive_or_empty(tmp.path())
+                .unwrap()
+                .items
+                .len(),
+            1
+        );
+        assert_eq!(m.indicator_state().health, HealthState::Green);
     }
 
     #[tokio::test]

--- a/refbox/src/portal_manager/queue.rs
+++ b/refbox/src/portal_manager/queue.rs
@@ -118,18 +118,68 @@ fn rename_corrupt(path: &Path) -> std::io::Result<()> {
     fs::rename(path, &new_path)
 }
 
-/// Atomically write the queue file to `dir/portal_queue.json`.
-/// Writes to a temp file, fsyncs, then renames over the target.
-pub fn save(dir: &Path, q: &QueueFile) -> std::io::Result<()> {
-    let tmp = tmp_path(dir);
+/// Atomically write a queue-file envelope to `target`: write to `tmp`,
+/// fsync, then rename over the target.
+fn write_atomic(target: &Path, tmp: &Path, q: &QueueFile) -> std::io::Result<()> {
     {
-        let mut f = fs::File::create(&tmp)?;
+        let mut f = fs::File::create(tmp)?;
         serde_json::to_writer(&f, q).map_err(std::io::Error::other)?;
         f.flush()?;
         f.sync_all()?;
     }
-    fs::rename(&tmp, queue_path(dir))?;
+    fs::rename(tmp, target)?;
     Ok(())
+}
+
+/// Atomically write the queue file to `dir/portal_queue.json`.
+pub fn save(dir: &Path, q: &QueueFile) -> std::io::Result<()> {
+    write_atomic(&queue_path(dir), &tmp_path(dir), q)
+}
+
+// --- Expired-item archive (Bug 2: portal_queue.expired.json) ---
+//
+// When a queued score passes the 120h expiry limit it is removed from the
+// active queue, but copied here first so nothing is ever silently lost. This
+// is a behind-the-scenes safety net, not surfaced in the UI.
+
+const ARCHIVE_FILE_NAME: &str = "portal_queue.expired.json";
+const ARCHIVE_TMP_FILE_NAME: &str = "portal_queue.expired.json.tmp";
+
+fn archive_path(dir: &Path) -> PathBuf {
+    dir.join(ARCHIVE_FILE_NAME)
+}
+
+fn archive_tmp_path(dir: &Path) -> PathBuf {
+    dir.join(ARCHIVE_TMP_FILE_NAME)
+}
+
+/// Load the archive of expired queue items. Missing → empty. Unparseable or
+/// unknown-version → logged and treated as empty (the archive is a
+/// best-effort safety net, so a corrupt archive must never block a sweep).
+pub fn load_archive_or_empty(dir: &Path) -> std::io::Result<QueueFile> {
+    let path = archive_path(dir);
+    if !path.exists() {
+        return Ok(QueueFile::empty());
+    }
+    let bytes = fs::read(&path)?;
+    match serde_json::from_slice::<QueueFile>(&bytes) {
+        Ok(q) if q.version == QueueFile::CURRENT_VERSION => Ok(q),
+        _ => {
+            log::error!("portal_queue.expired.json unreadable; starting a fresh archive");
+            Ok(QueueFile::empty())
+        }
+    }
+}
+
+/// Append expired items to the archive, atomically. No-op on empty input.
+/// Additive: items archived by earlier sweeps are preserved.
+pub fn append_to_archive(dir: &Path, items: &[QueuedItem]) -> std::io::Result<()> {
+    if items.is_empty() {
+        return Ok(());
+    }
+    let mut archive = load_archive_or_empty(dir)?;
+    archive.items.extend_from_slice(items);
+    write_atomic(&archive_path(dir), &archive_tmp_path(dir), &archive)
 }
 
 #[cfg(test)]
@@ -286,5 +336,64 @@ mod tests {
             !back.score_sent,
             "an item with no score_sent field must load as score-pending (false)"
         );
+    }
+}
+
+#[cfg(test)]
+mod archive_tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn sample_item(game: &str) -> QueuedItem {
+        QueuedItem {
+            id: ItemId {
+                event_id: "e1".into(),
+                game_number: game.into(),
+            },
+            black_score: 1,
+            white_score: 0,
+            stats: "{}".into(),
+            queued_at: OffsetDateTime::now_utc(),
+            attempts: 0,
+            last_attempt_at: None,
+            force: false,
+            score_sent: false,
+        }
+    }
+
+    #[test]
+    fn load_archive_missing_is_empty() {
+        let tmp = TempDir::new().unwrap();
+        assert_eq!(
+            load_archive_or_empty(tmp.path()).unwrap(),
+            QueueFile::empty()
+        );
+    }
+
+    #[test]
+    fn append_then_load_round_trips() {
+        let tmp = TempDir::new().unwrap();
+        let item = sample_item("G1");
+        append_to_archive(tmp.path(), std::slice::from_ref(&item)).unwrap();
+        let back = load_archive_or_empty(tmp.path()).unwrap();
+        assert_eq!(back.items, vec![item]);
+    }
+
+    #[test]
+    fn append_accumulates_across_calls() {
+        let tmp = TempDir::new().unwrap();
+        let a = sample_item("G1");
+        let b = sample_item("G2");
+        append_to_archive(tmp.path(), std::slice::from_ref(&a)).unwrap();
+        append_to_archive(tmp.path(), std::slice::from_ref(&b)).unwrap();
+        let back = load_archive_or_empty(tmp.path()).unwrap();
+        assert_eq!(back.items, vec![a, b]);
+    }
+
+    #[test]
+    fn append_empty_writes_no_file() {
+        let tmp = TempDir::new().unwrap();
+        append_to_archive(tmp.path(), &[]).unwrap();
+        assert!(!tmp.path().join("portal_queue.expired.json").exists());
     }
 }


### PR DESCRIPTION
## What changed

The referee box now automatically clears out old, undelivered score-upload
records. If a game's score has been waiting in the upload queue for more than
5 days (120 hours), the box files it away in a saved backup file and removes it
from the active queue — so the portal status light can return to green on its
own instead of staying stuck red.

## Why

Previously an undelivered score stayed in the queue forever. After 30 minutes
the status light turned red, but nothing ever removed the item. In practice a
box that had leftover scores from a previous event (or from before switching
portals) showed a permanently red portal indicator with no way to clear it
except discarding each item by hand. A field box hit exactly this: a red
indicator on the pre-game screen caused by 5-day-old leftover scores that
should have "timed out" long ago.

## Scope

Limited to `refbox/src/portal_manager/` (`queue.rs` + `mod.rs`). No shared
types, no wire-format changes, no UI-flow changes, and no new dependencies.

## How to verify

- **Automated:** `just test` — 10 new unit tests cover the 120h boundary, the
  archive save/reload and accumulation across sweeps, the sweep removing an
  expired item (indicator returns to green), the startup sweep clearing a
  stale queue file, and the guard that a fresh item is never swept.
- **Observable:** on a box whose portal queue holds an item older than 5 days,
  launch the refbox — the stale item clears automatically and the portal
  indicator no longer stays red because of it. The removed score is preserved
  in `portal_queue.expired.json` next to the live queue (a behind-the-scenes
  safety net, not shown in the UI).

Note: the ~120h figure mirrors the existing portal-link restore window. Items
younger than 5 days behave exactly as before, so normal in-tournament use is
unchanged.
