### PR TITLE
fix(refbox): reset beep test at the end and apply edited levels

### DIFF
--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -4914,9 +4914,15 @@ impl RefBoxApp {
                 // The engine holds its own copy of the schedule — push the
                 // edited one in, or the next run counts down the old times.
                 let beep_test_config = self.config.beep_test.clone();
+                let now = Instant::now();
                 if let Some(ref mut bt_tm) = self.beep_test_tm {
-                    bt_tm.set_config(beep_test_config, Instant::now());
+                    bt_tm.set_config(beep_test_config, now);
                 }
+                // set_config() only resets the engine — bring the app-side
+                // has_run/snapshot state back to idle too, so this stays
+                // consistent if a future entry point (e.g. a court-length
+                // preset) reaches set_config() while has_run is true.
+                self.reset_beep_test_state(now);
                 self.app_state = AppState::BeepTestSettings(BeepTestConfigPage::Main);
                 trace!("AppState changed to {:?}", self.app_state);
                 Task::none()

--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -647,6 +647,18 @@ impl RefBoxApp {
         }
     }
 
+    /// Return the BeepTest page and engine to the idle (pre-START) state:
+    /// green START, greyed RESET, LEVEL and LAP at 0, table cleared. Shared
+    /// by the operator's RESET button and the automatic reset that fires
+    /// when the schedule completes.
+    fn reset_beep_test_state(&mut self, now: Instant) {
+        if let Some(ref mut bt_tm) = self.beep_test_tm {
+            bt_tm.reset_beep_test_now(now);
+        }
+        self.beep_test_snapshot = BeepTestSnapshot::default();
+        self.beep_test_has_run = false;
+    }
+
     fn request_event_list(&self) -> Task<Message> {
         if let Some(client) = &self.uwhportal_client {
             // why this cannot panic: the `UwhPortalClient` is only mutated by
@@ -4453,54 +4465,62 @@ impl RefBoxApp {
                 Task::none()
             }
             Message::BeepTestReset => {
-                if let Some(ref mut bt_tm) = self.beep_test_tm {
-                    bt_tm.reset_beep_test_now(Instant::now());
-                }
-                self.beep_test_snapshot = BeepTestSnapshot::default();
-                self.beep_test_has_run = false;
+                self.reset_beep_test_state(Instant::now());
                 Task::none()
             }
             Message::BeepTestTick => {
-                // Drives the cadence engine forward, ships the snapshot
-                // to the LED panel, and triggers any whistles/buzzers at
-                // the same boundaries the standalone beep-test would.
-                if let Some(ref mut bt_tm) = self.beep_test_tm {
-                    let now = Instant::now();
-                    if let Err(e) = bt_tm.update(now) {
-                        error!("Beep-test engine update failed: {e}");
+                // Drives the cadence engine forward, ships the snapshot to the
+                // LED panel, and triggers any whistles/buzzers at the same
+                // boundaries the standalone beep-test would.
+                let now = Instant::now();
+                let (completed, new_snapshot) = match self.beep_test_tm {
+                    Some(ref mut bt_tm) => {
+                        if let Err(e) = bt_tm.update(now) {
+                            error!("Beep-test engine update failed: {e}");
+                        }
+                        (bt_tm.take_completed(), bt_tm.generate_snapshot(now))
                     }
-                    let Some(new_snapshot) = bt_tm.generate_snapshot(now) else {
-                        // generate_snapshot returns None when the clock
-                        // time would be negative; nothing to ship this
-                        // tick. The next tick will recover.
-                        return Task::none();
-                    };
-                    self.maybe_play_beep_test_sound(&new_snapshot);
-                    // The LED panel pipeline accepts the full GameSnapshot;
-                    // synthesize one from the beep-test snapshot the same
-                    // way the existing `BeepTestSnapshot -> GameSnapshotNoHeap`
-                    // conversion does (BetweenGames + lap_count as white score).
-                    let game_snap = GameSnapshot {
-                        current_period: GamePeriod::BetweenGames,
-                        secs_in_period: new_snapshot.secs_in_period,
-                        scores: BlackWhiteBundle {
-                            black: 0,
-                            white: new_snapshot.lap_count,
-                        },
-                        ..Default::default()
-                    };
-                    if let Err(e) = self.update_sender.send_snapshot(
-                        game_snap,
-                        // Beep test has no sides control: lap count always on the left.
-                        false,
-                        self.config.hardware.brightness,
-                    ) {
-                        // Channel-full or closed: the next tick re-sends
-                        // a fresh snapshot, so dropping one is acceptable.
-                        warn!("Failed to send beep-test snapshot to LED panel: {e:?}");
-                    }
-                    self.beep_test_snapshot = new_snapshot;
+                    None => return Task::none(),
+                };
+
+                // The schedule ran off its end: return the page to idle so the
+                // next group can start without the operator pressing RESET.
+                if completed {
+                    info!("Beep test complete — resetting to idle");
+                    self.reset_beep_test_state(now);
+                    return Task::none();
                 }
+
+                // generate_snapshot returns None when the clock time would be
+                // negative; nothing to ship this tick. The next tick recovers.
+                let Some(new_snapshot) = new_snapshot else {
+                    return Task::none();
+                };
+                self.maybe_play_beep_test_sound(&new_snapshot);
+                // The LED panel pipeline accepts the full GameSnapshot;
+                // synthesize one from the beep-test snapshot the same way the
+                // existing `BeepTestSnapshot -> GameSnapshotNoHeap` conversion
+                // does (BetweenGames + lap_count as white score).
+                let game_snap = GameSnapshot {
+                    current_period: GamePeriod::BetweenGames,
+                    secs_in_period: new_snapshot.secs_in_period,
+                    scores: BlackWhiteBundle {
+                        black: 0,
+                        white: new_snapshot.lap_count,
+                    },
+                    ..Default::default()
+                };
+                if let Err(e) = self.update_sender.send_snapshot(
+                    game_snap,
+                    // Beep test has no sides control: lap count always on the left.
+                    false,
+                    self.config.hardware.brightness,
+                ) {
+                    // Channel-full or closed: the next tick re-sends a fresh
+                    // snapshot, so dropping one is acceptable.
+                    warn!("Failed to send beep-test snapshot to LED panel: {e:?}");
+                }
+                self.beep_test_snapshot = new_snapshot;
                 Task::none()
             }
             Message::BeepTestCycleDisplayLayout => {

--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -4911,6 +4911,12 @@ impl RefBoxApp {
                     }
                 }
                 self.persist_config();
+                // The engine holds its own copy of the schedule — push the
+                // edited one in, or the next run counts down the old times.
+                let beep_test_config = self.config.beep_test.clone();
+                if let Some(ref mut bt_tm) = self.beep_test_tm {
+                    bt_tm.set_config(beep_test_config, Instant::now());
+                }
                 self.app_state = AppState::BeepTestSettings(BeepTestConfigPage::Main);
                 trace!("AppState changed to {:?}", self.app_state);
                 Task::none()

--- a/refbox/src/beep_test/cadence.rs
+++ b/refbox/src/beep_test/cadence.rs
@@ -187,6 +187,19 @@ impl TournamentManager {
         Ok(())
     }
 
+    /// Replace the schedule and return to the idle state.
+    ///
+    /// The engine keeps its own copy of the config, so a config write in the
+    /// app (APPLY on Edit Levels, or a court-length preset) has no effect on a
+    /// running engine until this is called. Resetting is required as well as
+    /// swapping the config: the current period index and lap counters are only
+    /// meaningful against the schedule they were produced from.
+    pub fn set_config(&mut self, config: BeepTestConfig, now: Instant) {
+        info!("{} Replacing beep test schedule", self.status_string(now));
+        self.config = config;
+        self.reset_beep_test_now(now);
+    }
+
     pub fn reset_beep_test_now(&mut self, now: Instant) {
         info!("{} Resetting Beep Test", self.status_string(now));
 
@@ -633,5 +646,31 @@ mod tests {
         tm.update(t0 + Duration::from_secs(4)).unwrap();
         tm.reset_beep_test_now(t0 + Duration::from_secs(5));
         assert!(!tm.take_completed());
+    }
+
+    // The engine holds its own copy of the config. `set_config` must replace
+    // it AND return to idle, so an APPLY on the Edit Levels page actually
+    // changes what the next run counts down.
+    #[test]
+    fn set_config_replaces_schedule_and_resets() {
+        let mut tm = TournamentManager::new(test_config());
+        let t0 = Instant::now();
+        tm.start_beep_test_now(t0).unwrap();
+        assert!(tm.clock_is_running());
+
+        // tiny_config(): pre=1s, one level count=1 duration=1s.
+        tm.set_config(tiny_config(), t0 + Duration::from_millis(500));
+
+        assert!(
+            !tm.clock_is_running(),
+            "set_config returns the engine to idle"
+        );
+        assert_eq!(tm.current_period(), BeepTestPeriod::Level(0));
+        // The stopped clock now shows tiny_config's 1s warm-up, not 1s from
+        // test_config by coincidence — check the level durations too.
+        assert_eq!(
+            BeepTestPeriod::Level(1).duration(&tm.config),
+            Some(Duration::from_secs(1))
+        );
     }
 }

--- a/refbox/src/beep_test/cadence.rs
+++ b/refbox/src/beep_test/cadence.rs
@@ -618,9 +618,10 @@ mod tests {
     }
 
     // On completion the engine must also restore `time_in_next_lap` to the
-    // duration of the period that follows the warm-up. Without this the
-    // front display keeps advertising a stale "next lap" time after the
-    // test ends.
+    // duration of the period that follows the warm-up, so that its idle
+    // state after completion matches the state `reset_beep_test_now`
+    // produces. Without this the engine would be internally inconsistent
+    // even though nothing observable depends on this field today.
     #[test]
     fn completion_restores_time_in_next_lap() {
         let mut tm = TournamentManager::new(test_config());

--- a/refbox/src/beep_test/cadence.rs
+++ b/refbox/src/beep_test/cadence.rs
@@ -44,6 +44,11 @@ pub struct TournamentManager {
     count: u8,
     lap_count: u8,
     time_in_next_lap: Duration,
+    /// Set exactly when the schedule runs off its end — the final lap of the
+    /// final level completes, or the sprint's single lap completes. Consumed
+    /// by `take_completed`, which the app polls each tick to return the page
+    /// to its idle state without the operator pressing RESET.
+    completed: bool,
 }
 
 impl TournamentManager {
@@ -64,11 +69,19 @@ impl TournamentManager {
             start_stop_rx,
             count: 1,
             lap_count: 0,
+            completed: false,
         }
     }
 
     pub fn current_period(&self) -> BeepTestPeriod {
         self.current_period
+    }
+
+    /// Returns `true` exactly once after the schedule completes, then clears
+    /// the flag. The app polls this each tick and, when it fires, returns the
+    /// BeepTest page to its idle (pre-START) state.
+    pub fn take_completed(&mut self) -> bool {
+        std::mem::take(&mut self.completed)
     }
 
     pub fn send_clock_running(&self, running: bool) {
@@ -141,6 +154,7 @@ impl TournamentManager {
 
     pub fn start_beep_test_now(&mut self, now: Instant) -> Result<()> {
         self.count = 1;
+        self.completed = false;
         if self.time_state != TimeState::None {
             return Err(TournamentManagerError::AlreadyStopped(
                 self.time_state.as_snapshot(),
@@ -187,6 +201,7 @@ impl TournamentManager {
         };
         self.count = 1;
         self.lap_count = 0;
+        self.completed = false;
         self.time_in_next_lap = self
             .current_period
             .next_test_period_dur(&self.config)
@@ -295,17 +310,22 @@ impl TournamentManager {
                 self.current_period
             );
 
-            // Detect wrap: next_period wraps to Level(0) when all levels are done.
-            // In that case, stop the clock — the test is complete.
+            // Detect wrap: next_period wraps to Level(0) when the schedule is
+            // done. Stop the clock, restore the idle "next lap" duration, and
+            // raise `completed` so the app resets the page.
             if next == BeepTestPeriod::Level(0) {
-                // Test complete — reset to the initial stopped state at Level(0).
                 self.lap_count = 0;
+                self.time_in_next_lap = self
+                    .current_period
+                    .next_test_period_dur(&self.config)
+                    .unwrap_or_default();
                 self.clock_state = ClockState::Stopped {
                     clock_time: self
                         .current_period
                         .duration(&self.config)
                         .unwrap_or_default(),
                 };
+                self.completed = true;
                 self.send_clock_running(false);
                 return;
             }
@@ -562,5 +582,56 @@ mod tests {
         tm.reset_beep_test_now(now + Duration::from_millis(500));
         // After reset, time_in_next_lap should be levels[0].duration = 10s.
         assert_eq!(tm.time_in_next_lap, Duration::from_secs(10));
+    }
+
+    // Completing the schedule sets the one-shot completed flag, and taking
+    // it clears it. `tiny_config()` is pre=1s + one level of count=1
+    // duration=1s, so the whole run is over 2s after start.
+    #[test]
+    fn completion_sets_one_shot_flag() {
+        let mut tm = TournamentManager::new(tiny_config());
+        let t0 = Instant::now();
+        tm.start_beep_test_now(t0).unwrap();
+        assert!(!tm.take_completed(), "not complete while the warm-up runs");
+
+        tm.update(t0 + Duration::from_secs(2)).unwrap();
+        assert_eq!(tm.current_period(), BeepTestPeriod::Level(1));
+        assert!(!tm.take_completed(), "not complete part-way through");
+
+        tm.update(t0 + Duration::from_secs(4)).unwrap();
+        assert!(!tm.clock_is_running());
+        assert!(tm.take_completed(), "completed after the final lap");
+        assert!(!tm.take_completed(), "flag is one-shot");
+    }
+
+    // On completion the engine must also restore `time_in_next_lap` to the
+    // duration of the period that follows the warm-up. Without this the
+    // front display keeps advertising a stale "next lap" time after the
+    // test ends.
+    #[test]
+    fn completion_restores_time_in_next_lap() {
+        let mut tm = TournamentManager::new(test_config());
+        let t0 = Instant::now();
+        tm.start_beep_test_now(t0).unwrap();
+        // test_config(): pre=1s, L1 count=2 dur=10s, L2 count=2 dur=8s.
+        // Warm-up (1s) + 2x10s + 2x8s = 37s covers the whole run.
+        for secs in [2, 12, 22, 31, 40] {
+            tm.update(t0 + Duration::from_secs(secs)).unwrap();
+        }
+        assert!(tm.take_completed());
+        assert_eq!(tm.time_in_next_lap, Duration::from_secs(10));
+    }
+
+    // Reset clears a pending completed flag so a stale completion can't
+    // fire an auto-reset after the operator has already reset by hand.
+    #[test]
+    fn reset_clears_completed_flag() {
+        let mut tm = TournamentManager::new(tiny_config());
+        let t0 = Instant::now();
+        tm.start_beep_test_now(t0).unwrap();
+        tm.update(t0 + Duration::from_secs(2)).unwrap();
+        tm.update(t0 + Duration::from_secs(4)).unwrap();
+        tm.reset_beep_test_now(t0 + Duration::from_secs(5));
+        assert!(!tm.take_completed());
     }
 }


### PR DESCRIPTION
## What changed

Two fixes to the beep test.

**1. The test resets itself when it finishes.** Previously, when the last lap of the last level
ended, the timer stopped but the page stayed half-finished — the big button read RESUME instead of
START and RESET stayed lit, so the operator had to press RESET before the next group could go. Now
the page returns to its fresh state on its own the instant the last lap ends: green START, greyed
RESET, LEVEL and LAP back to 0, table cleared.

**2. Edited level times now actually take effect.** The timer kept its own copy of the schedule from
when the app started and nothing ever replaced it. So changing a level's time in Settings and
pressing APPLY updated the config file and the on-screen table while the timer went on counting the
old times — and if levels had been added, the test would stop early because the timer still had the
shorter schedule. APPLY now hands the edited schedule to the timer, and resets the page state along
with it so the two can never disagree.

## Why

Both were visible to the operator at poolside. The first cost a press between every group. The
second was worse: the screen and the timer disagreed silently, so a test could run the wrong times,
or end after one lap while the table showed four, with nothing to indicate anything was wrong.

## Scope

`refbox` only, and within it only two files: `refbox/src/beep_test/cadence.rs` and
`refbox/src/app/mod.rs`. No new dependencies. No translation strings added.

This is the first of two branches. Court-length presets (25m/23m/21m) and the sprint feature build
on these fixes and follow separately.

## How to verify

1. Put the app in beep test mode.
2. **Settings → EDIT LEVELS.** Set up a short schedule — e.g. two levels, 2 laps each, 4s and 6s.
   Press **APPLY**, then **BACK**.
3. Press **START**. Confirm the run follows the table you just applied: all four laps, at the times
   shown. (Before this change it would run whatever schedule the app started with.)
4. Let it run to the end. The moment the last lap finishes, the page should return to green START
   with RESET greyed out, LEVEL 0 and LAP 0 — with no press needed.

Verified live on 2026-08-05: three consecutive runs, all laps at the applied times, auto-reset on
all three. `just check` passes clean (formatting, linter, full workspace test suite, security audit).

Three new tests cover the engine side, each confirmed to fail before the fix.

## A measurement note (no action needed)

While verifying this branch, beep-test laps appeared to overrun by ~1s at a random boundary once per
run. That was investigated and is **not a defect** — it is an artifact of the development machine.
On WSL the system wall clock jumps ~0.85s ahead of the monotonic clock every ~30 seconds
(reproducible with a 10-line script, refbox not running). refbox times laps with the monotonic
clock while log timestamps use the wall clock, so a correctly-timed lap measures long.

Verified at trace verbosity across one such "late" boundary: `BeepTestTick` arrived every 100ms with
no gap, the countdown stepped cleanly to zero, and `start_time` advanced strictly nominally. The
engine was exact.

Recorded for future sessions: do not time refbox behaviour by diffing log timestamps on WSL.
