### PR TITLE
fix(refbox): don't submit a result for an abandoned game

### DIFF
--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -5047,7 +5047,11 @@ impl RefBoxApp {
                     self.config.sound.sound_enabled && self.config.sound.manual_alarm_enabled,
                     self.mouse_alarm_held || self.spacebar_held,
                     behind_schedule,
-                    self.tm.lock().unwrap().last_game_info().map(|i| i.scores),
+                    self.tm
+                        .lock()
+                        .unwrap()
+                        .last_game_info()
+                        .map(|i| (i.game_number.clone(), i.scores)),
                 )
             }
             AppState::TimeEdit(_, time, timeout_time) => build_time_edit_view(
@@ -5096,7 +5100,11 @@ impl RefBoxApp {
                 self.using_uwhportal,
                 is_refreshing,
                 self.schedule.as_ref(),
-                self.tm.lock().unwrap().last_game_info().map(|i| i.scores),
+                self.tm
+                    .lock()
+                    .unwrap()
+                    .last_game_info()
+                    .map(|i| (i.game_number.clone(), i.scores)),
             ),
             AppState::WarningsSummaryPage => build_warnings_summary_page(data),
             AppState::PowerPage => build_power_page(data),

--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -508,6 +508,22 @@ fn should_play_countdown_beep(
         && (1..=10).contains(&new_secs)
 }
 
+/// Whether the result the refbox has on file may be submitted for the game the clock just
+/// left. A recorded result belongs to exactly one game and carries that game's number
+/// (`LastGameInfo::game_number`).
+///
+/// Ending a game normally records a result for it, so the two agree and the result is sent.
+/// Abandoning a game — END CURRENT GAME AND APPLY, which resets the game instead of ending
+/// it — records nothing, so the newest result on file belongs to an EARLIER game. Sending
+/// that under the abandoned game's number would post the previous game's score against a
+/// game that was never played.
+fn recorded_result_matches_ended_game(
+    recorded_game: Option<&GameNumber>,
+    ended_game: &GameNumber,
+) -> bool {
+    recorded_game == Some(ended_game)
+}
+
 impl RefBoxApp {
     fn apply_snapshot(&mut self, mut new_snapshot: GameSnapshot) -> Task<Message> {
         let mut task = Task::none();
@@ -856,33 +872,50 @@ impl RefBoxApp {
     fn handle_game_end(&mut self, game_number: &GameNumber) -> Task<Message> {
         let mut tasks = vec![];
         if self.using_uwhportal {
-            if let Some(info) = self.tm.lock().unwrap().last_game_info() {
-                let stats = info.stats.as_json();
-                let black_score = info.scores.black;
-                let white_score = info.scores.white;
+            // Copy everything needed out from under the lock: the recorded result's own
+            // game number, its scores, and its stats JSON.
+            let recorded = {
+                // Safety: Mutex poison only occurs if another thread already panicked; the refbox treats that as fatal (matches the 20+ identical sites in this file).
+                let tm = self.tm.lock().unwrap();
+                tm.last_game_info()
+                    .map(|info| (info.game_number.clone(), info.scores, info.stats.as_json()))
+            };
 
-                info!(
-                    "Game ended, scores: {:?} stats were: {:?}",
-                    info.scores, stats
-                );
+            match recorded {
+                Some((recorded_game, scores, stats))
+                    if recorded_result_matches_ended_game(Some(&recorded_game), game_number) =>
+                {
+                    info!("Game ended, scores: {scores:?} stats were: {stats:?}");
 
-                if let Some(ref event_id) = self.current_event_id {
-                    let event_id_str = event_id.full().to_string();
-                    tasks.push(self.request_schedule(event_id.clone()));
-                    if let Err(e) = self.portal_manager.enqueue_game_end(
-                        event_id_str,
-                        game_number.to_string(),
-                        black_score,
-                        white_score,
-                        stats,
-                    ) {
-                        error!("portal_manager.enqueue_game_end failed: {e}");
+                    if let Some(ref event_id) = self.current_event_id {
+                        let event_id_str = event_id.full().to_string();
+                        tasks.push(self.request_schedule(event_id.clone()));
+                        if let Err(e) = self.portal_manager.enqueue_game_end(
+                            event_id_str,
+                            game_number.to_string(),
+                            scores.black,
+                            scores.white,
+                            stats,
+                        ) {
+                            error!("portal_manager.enqueue_game_end failed: {e}");
+                        }
+                    } else {
+                        error!("Missing current event id to handle game end");
                     }
-                } else {
-                    error!("Missing current event id to handle game end");
                 }
-            } else {
-                warn!("Game ended, but no last game info was available");
+                Some((recorded_game, _, _)) => {
+                    warn!(
+                        "Clock left game {game_number} without a result being recorded for it \
+                         (the newest recorded result belongs to game {recorded_game}); nothing \
+                         sent to the portal"
+                    );
+                }
+                None => {
+                    warn!(
+                        "Clock left game {game_number} with no recorded result available; \
+                         nothing sent to the portal"
+                    );
+                }
             }
         }
 
@@ -5709,6 +5742,37 @@ mod countdown_beep_tests {
         ] {
             assert!(!should_play_countdown_beep(p, 5, 6, true), "{p:?}");
         }
+    }
+}
+
+#[cfg(test)]
+mod submission_gate_tests {
+    use super::recorded_result_matches_ended_game;
+
+    #[test]
+    fn result_for_the_same_game_is_submitted() {
+        let recorded = "16".to_string();
+        assert!(recorded_result_matches_ended_game(
+            Some(&recorded),
+            &"16".to_string()
+        ));
+    }
+
+    #[test]
+    fn result_for_an_earlier_game_is_not_submitted() {
+        // The forfeit incident: game 18 was abandoned mid-play, so the newest recorded
+        // result belongs to game 16 and must not be posted against 18.
+        let recorded = "16".to_string();
+        assert!(!recorded_result_matches_ended_game(
+            Some(&recorded),
+            &"18".to_string()
+        ));
+    }
+
+    #[test]
+    fn no_recorded_result_is_not_submitted() {
+        // First game of the session, or a fresh restart.
+        assert!(!recorded_result_matches_ended_game(None, &"18".to_string()));
     }
 }
 

--- a/refbox/src/app/view_builders/game_info.rs
+++ b/refbox/src/app/view_builders/game_info.rs
@@ -14,7 +14,7 @@ pub(in super::super) fn build_game_info_page<'a>(
     using_uwhportal: bool,
     is_refreshing: bool,
     schedule: Option<&Schedule>,
-    last_game_scores: Option<BlackWhiteBundle<u8>>,
+    last_game: Option<(GameNumber, BlackWhiteBundle<u8>)>,
 ) -> Element<'a, Message> {
     let ViewData {
         snapshot,
@@ -56,7 +56,7 @@ pub(in super::super) fn build_game_info_page<'a>(
         using_uwhportal,
         schedule,
         teams,
-        last_game_scores,
+        last_game,
     ));
     // Pin the table to the top of the button via a transparent fill-height
     // wrapper, so the table's dark gridline backing only covers the grid and the

--- a/refbox/src/app/view_builders/game_info_table.rs
+++ b/refbox/src/app/view_builders/game_info_table.rs
@@ -78,7 +78,7 @@ pub(in super::super) fn game_info_rows(
     using_uwhportal: bool,
     schedule: Option<&Schedule>,
     teams: Option<&TeamList>,
-    last_game_scores: Option<BlackWhiteBundle<u8>>,
+    last_game: Option<(GameNumber, BlackWhiteBundle<u8>)>,
 ) -> Vec<Row> {
     let between = snapshot.current_period == GamePeriod::BetweenGames;
     // The "current" game whose config + settings are displayed: the in-progress
@@ -184,13 +184,21 @@ pub(in super::super) fn game_info_rows(
         ),
     });
 
-    // Context block BEFORE the current block, between games only: the just-finished game.
+    // Context block BEFORE the current block, between games only: the last game that
+    // actually finished. Number AND score both come from the recorded result — pairing the
+    // clock's game number with an earlier game's score is exactly the fault this fixes,
+    // because an abandoned game leaves the clock reporting a game that has no result.
+    // With no recorded result at all, keep the pre-existing appearance.
     if between {
+        let (last_number, last_scores) = match last_game.as_ref() {
+            Some((number, scores)) => (number, Some(*scores)),
+            None => (&snapshot.game_number, None),
+        };
         let last = game_block_row(
             GameRole::Last,
-            &snapshot.game_number,
+            last_number,
             None, // prior game's Game Block is intentionally not shown
-            last_game_scores,
+            last_scores,
             using_uwhportal,
             schedule,
             teams,
@@ -874,7 +882,7 @@ mod tests {
             false,
             None,
             None,
-            Some(scores),
+            Some(("16".to_string(), scores)),
         );
         let last = rows
             .iter()
@@ -890,6 +898,67 @@ mod tests {
             })
             .unwrap();
         assert_eq!(last, (None, Some(3), Some(5)));
+    }
+
+    #[test]
+    fn last_block_uses_the_recorded_results_own_game_number() {
+        // Game 18 was abandoned, so the clock still reports 18 while the recorded result
+        // belongs to game 16. The Prior Game block must show 16 with 16's score — never
+        // 18's number paired with 16's score, which was the reported fault.
+        let snapshot = GameSnapshot {
+            current_period: GamePeriod::BetweenGames,
+            game_number: "18".to_string(),
+            ..GameSnapshot::default()
+        };
+        let scores = BlackWhiteBundle { black: 5, white: 3 };
+        let rows = game_info_rows(
+            &snapshot,
+            &cfg_all_on(),
+            false,
+            None,
+            None,
+            Some(("16".to_string(), scores)),
+        );
+        let last = rows
+            .iter()
+            .find_map(|r| match r {
+                Row::GameBlock {
+                    role: GameRole::Last,
+                    number,
+                    white,
+                    black,
+                    ..
+                } => Some((number.clone(), white.score, black.score)),
+                _ => None,
+            })
+            .unwrap();
+        assert_eq!(last, ("16".to_string(), Some(3), Some(5)));
+    }
+
+    #[test]
+    fn last_block_without_a_recorded_result_keeps_todays_appearance() {
+        // No game has finished yet this session: the block keeps the clock's number and
+        // shows no score, exactly as before this change.
+        let snapshot = GameSnapshot {
+            current_period: GamePeriod::BetweenGames,
+            game_number: "18".to_string(),
+            ..GameSnapshot::default()
+        };
+        let rows = game_info_rows(&snapshot, &cfg_all_on(), false, None, None, None);
+        let last = rows
+            .iter()
+            .find_map(|r| match r {
+                Row::GameBlock {
+                    role: GameRole::Last,
+                    number,
+                    white,
+                    black,
+                    ..
+                } => Some((number.clone(), white.score, black.score)),
+                _ => None,
+            })
+            .unwrap();
+        assert_eq!(last, ("18".to_string(), None, None));
     }
 
     fn ref_labels(rows: &[Row]) -> Vec<String> {

--- a/refbox/src/app/view_builders/main_view.rs
+++ b/refbox/src/app/view_builders/main_view.rs
@@ -24,7 +24,7 @@ pub(in super::super) fn build_main_view<'a>(
     manual_alarm_enabled: bool,
     alarm_held: bool,
     behind_schedule: std::time::Duration,
-    last_game_scores: Option<BlackWhiteBundle<u8>>,
+    last_game: Option<(GameNumber, BlackWhiteBundle<u8>)>,
 ) -> Element<'a, Message> {
     let ViewData {
         snapshot,
@@ -261,7 +261,7 @@ pub(in super::super) fn build_main_view<'a>(
                         using_uwhportal,
                         schedule,
                         teams,
-                        last_game_scores,
+                        last_game,
                     )))
                     .align_y(Vertical::Top)
                     .height(Length::Fill)
@@ -288,7 +288,7 @@ pub(in super::super) fn build_main_view<'a>(
                     using_uwhportal,
                     schedule,
                     teams,
-                    last_game_scores,
+                    last_game,
                 )))
                 .align_y(Vertical::Top)
                 .height(Length::Fill)

--- a/refbox/src/tournament_manager/mod.rs
+++ b/refbox/src/tournament_manager/mod.rs
@@ -1111,6 +1111,7 @@ impl TournamentManager {
 
         self.current_game_stats.add_end_time(now);
         self.last_game_info = Some(LastGameInfo {
+            game_number: self.game_number.clone(),
             scores: self.scores,
             stats: self.current_game_stats.clone(),
         });
@@ -2552,6 +2553,11 @@ pub struct NextGameInfo {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct LastGameInfo {
+    /// The game that produced this result. A recorded result belongs to exactly one game,
+    /// and only `end_game` writes one — abandoning a game (`reset_game`) records nothing.
+    /// Consumers compare this against the game they are reporting on, so a result can never
+    /// be submitted or displayed under another game's number.
+    pub game_number: GameNumber,
     pub scores: BlackWhiteBundle<u8>,
     pub stats: GameStats,
 }
@@ -2704,6 +2710,77 @@ mod test {
         assert_eq!(fouls[0]["side"], "light");
         assert_eq!(fouls[0]["playerCapNumber"], 7);
         assert_eq!(fouls[0]["called"], "Obstruction");
+    }
+
+    #[test]
+    fn end_game_labels_the_result_with_the_game_that_ended() {
+        initialize();
+        let config = GameConfig {
+            half_play_duration: Duration::from_secs(900),
+            ..Default::default()
+        };
+        let mut tm = TournamentManager::new(config);
+        let g = Instant::now();
+        tm.set_next_game(NextGameInfo {
+            number: "16".to_string(),
+            timing: None,
+            start_time: None,
+        });
+        tm.start_play_now(g).unwrap();
+        assert_eq!(tm.game_number(), "16");
+
+        tm.add_score(Color::Black, 5, g);
+        tm.stop_clock(g).unwrap();
+        tm.set_period_and_game_clock_time(GamePeriod::SecondHalf, Duration::from_secs(0));
+        tm.end_game(g);
+
+        let info = tm.last_game_info().unwrap();
+        assert_eq!(info.game_number, "16");
+        assert_eq!(info.scores.black, 1);
+    }
+
+    #[test]
+    fn abandoning_a_game_leaves_the_result_labelled_with_the_earlier_game() {
+        // The forfeit incident: game 16 finishes normally, game 18 starts and is abandoned
+        // in the first half via END CURRENT GAME AND APPLY, which calls reset_game rather
+        // than end_game. No result is recorded for 18, so the newest recorded result must
+        // still belong to 16 — while the engine still reports 18 as the current game. That
+        // mismatch is what the app-side guard detects.
+        initialize();
+        let config = GameConfig {
+            half_play_duration: Duration::from_secs(900),
+            ..Default::default()
+        };
+        let mut tm = TournamentManager::new(config);
+
+        let g16 = Instant::now();
+        tm.set_next_game(NextGameInfo {
+            number: "16".to_string(),
+            timing: None,
+            start_time: None,
+        });
+        tm.start_play_now(g16).unwrap();
+        tm.add_score(Color::White, 3, g16);
+        tm.stop_clock(g16).unwrap();
+        tm.set_period_and_game_clock_time(GamePeriod::SecondHalf, Duration::from_secs(0));
+        tm.end_game(g16);
+        assert_eq!(tm.last_game_info().unwrap().game_number, "16");
+
+        let g18 = g16 + Duration::from_secs(600);
+        tm.set_next_game(NextGameInfo {
+            number: "18".to_string(),
+            timing: None,
+            start_time: None,
+        });
+        tm.start_play_now(g18).unwrap();
+        assert_eq!(tm.game_number(), "18");
+
+        tm.reset_game(g18 + Duration::from_secs(60));
+
+        let info = tm.last_game_info().unwrap();
+        assert_eq!(info.game_number, "16", "no result was recorded for game 18");
+        assert_eq!(info.scores.white, 1, "game 16's score is untouched");
+        assert_eq!(tm.game_number(), "18", "the clock still reports game 18");
     }
 
     // TODO: test correct sending of time start/stop signals

--- a/refbox/tests/features/portal-health.feature
+++ b/refbox/tests/features/portal-health.feature
@@ -200,3 +200,23 @@ Feature: Portal health indicator
     # Operator confirmed tile visible at left of time banner with UWH Portal
     # compact logo above a green dot. B7.C2 (tile render) + B7.D1 (logo asset)
     # both live-confirmed.
+
+  # Added 2026-08-06 for branch fix/refbox/abandoned-game-portal-submission.
+  # Oracle: docs/superpowers/specs/2026-08-05-abandoned-game-portal-submission-design.md
+  # Reported from a live event: a team forfeited, the game had already started, and
+  # switching to the next game posted the PREVIOUS game's score against the forfeited
+  # game instead of leaving it unplayed.
+  Scenario: Abandoning an in-progress game submits nothing for it
+    Given a portal event is linked and a court is selected
+    And a game has already been played to a normal finish and its score has landed on the portal
+    And the next game is in progress in its first half
+    When the operator changes the game number in Settings and taps APPLY
+    And the operator chooses END CURRENT GAME AND APPLY CHANGE
+    Then the newly chosen game is selected and the correct time to its start is shown
+    And no score and no statistics are submitted for the abandoned game
+    And no new item appears in the portal queue or on the portal detail page
+    And the portal still shows the abandoned game as unplayed
+    And the Prior Game block shows the game that finished normally, with its own final score
+    And the log records that the clock left the abandoned game without a recorded result
+    When the newly chosen game is played to a normal finish
+    Then its result is submitted under its own game number


### PR DESCRIPTION
## What changed

Ending an in-progress game with the red **END CURRENT GAME AND APPLY CHANGE** button no longer
sends anything to the UWH Portal for that game. The game is left exactly as the portal already had
it — unplayed. No score, no statistics, no new item in the portal queue, so no new yellow or red row
on the portal tile.

The game-info table is corrected in the same way. The **Prior Game** block now shows the last game
that *actually finished* — its number, its teams and its real final score. Previously it took the
game number from the clock and the score from wherever the last stored result happened to be, which
could pair one game's number with another game's score.

A game that ends normally submits exactly as it does today, including a score corrected at the
confirm-score step. There is no new page, button, wording or translation key.

## Why

Reported from a live event. A team forfeited, but nobody told the operator, so the game had already
started. Part-way through the first half the operator selected the next game and applied it. The
next game was selected and the correct start time appeared — but the portal received a **final score
for the forfeited game equal to the score of the game before it**.

The cause: that button resets the game rather than ending it, so no result is ever recorded for the
abandoned game. The refbox nevertheless treated "the clock moved to between-games" as "a game just
finished" and submitted whatever result it was still holding, keyed to the game the clock had just
left. Nothing tied a stored result to the game that produced it. The Prior Game block had the same
flaw, so the mismatch was visible on the operator's own screen too.

A recorded result now carries the number of the game that produced it. The portal submission and the
Prior Game block both check that number, so a result can never be sent or shown under another game's
number.

## Scope

`refbox` only:

- `refbox/src/tournament_manager/mod.rs` — the recorded result gains the game number it belongs to,
  stamped when a game genuinely ends.
- `refbox/src/app/mod.rs` — the portal submission happens only when that number matches the game the
  clock just left; otherwise it logs why nothing was sent.
- `refbox/src/app/view_builders/game_info_table.rs`, `main_view.rs`, `game_info.rs` — the Prior Game
  block takes number and score from the same recorded result.
- `refbox/tests/features/portal-health.feature` — a written walkthrough scenario for this case.

No changes to `uwh-common`, no wire-format change, no portal API change, no new dependencies.

Deliberately out of scope: any "forfeit" or "game not played" feature, and correcting the data
already written to the affected event's portal (a manual portal task).

## How to verify

Automated — `just check` passes clean (formatting, clippy with warnings-as-errors, all tests,
security audit). Seven new tests, each of which fails without this change:

- A game that ends normally records its result labelled with that game's number.
- Game 16 finishes, game 18 starts and is abandoned mid-first-half → the recorded result still
  belongs to game 16, while the clock still reports game 18.
- A result for the same game is submitted; a result for an earlier game is not; no result on file
  means nothing is sent.
- The Prior Game block shows the recorded result's own game number and score; with no recorded
  result it keeps its previous appearance.

The 43 stored golden-trace timing scenarios are unaffected — that guard records clock and period
timing and ignores game numbers.

Live — verified against `https://api.dev.uwhportal.com`:

1. Run a game to a normal finish. Its score reaches the portal as before, and a green success row
   appears on the portal detail page.
2. Start the next game, and part-way through the first half change the game number in Settings, tap
   APPLY, and choose END CURRENT GAME AND APPLY CHANGE.
3. The newly chosen game is selected and a break countdown appears. The portal shows **nothing** for
   the abandoned game and no new row appears on the portal detail page.
4. The Prior Game block shows the game from step 1, with its own final score.
5. Play the newly chosen game to a normal finish — its result submits under its own game number, so
   legitimate submissions are unaffected.

The log during step 2 read:

```
Clock left game 3 without a result being recorded for it
(the newest recorded result belongs to game 1); nothing sent to the portal
```

Before this change, game 1's result would have been posted against game 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
