### PR TITLE
fix(refbox): stop resizing the window on view-mode change

### DIFF
--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use futures_lite::Stream;
 use iced::{
-    Element, Subscription, Task, Theme,
+    Element, Length, Subscription, Task, Theme,
     application::Appearance,
     event,
     keyboard::{self, Key, key::Named},
@@ -198,10 +198,6 @@ pub struct RefBoxApp {
     /// `Message::BeepTestCycleDisplayLayout`.
     beep_test_display_layout: crate::sim_frame::FrontDisplayLayout,
     list_all_events: bool,
-    /// `true` when started with `--fullscreen` (the Pi). Read by
-    /// `force_display_repaint` to decide whether a display-mode change needs a
-    /// full-screen repaint. See `should_force_repaint`.
-    fullscreen: bool,
     /// `true` when running on a Raspberry Pi (device-tree model check). Gates the
     /// power button's visibility together with `force_power_controls`, and
     /// whether the Pi power actions actually execute.
@@ -1933,7 +1929,6 @@ impl RefBoxApp {
             beep_test_has_run: false,
             beep_test_display_layout: crate::sim_frame::FrontDisplayLayout::Default,
             list_all_events,
-            fullscreen,
             is_pi: crate::app::power_control::detect_raspberry_pi(),
             force_power_controls,
             mouse_alarm_held: false,
@@ -2962,7 +2957,15 @@ impl RefBoxApp {
                 self.config.display_mode = next;
                 crate::app::theme::set_display_mode(next);
                 self.persist_config();
-                self.force_display_repaint()
+                // Deliberately no window work here: a display-mode change is a
+                // palette change and nothing else. Forcing a repaint by leaving
+                // and re-entering fullscreen used to live here, but that is a
+                // real surface resize — it re-laid-out the whole UI and left the
+                // window at the wrong height on the Pi, moving every element
+                // sized as a share of that height. The window background is now
+                // a drawn element (see `window_background_container`), so the
+                // repaint happens on its own.
+                Task::none()
             }
             Message::ChangeConfigPage(new_page) => {
                 if let AppState::EditGameConfig(ref mut page) = self.app_state {
@@ -5337,7 +5340,16 @@ impl RefBoxApp {
             }
         }
 
-        main_view.into()
+        // Paint the window background as a real element rather than relying on
+        // iced's background clear, whose colour its damage tracking remembers
+        // only once for all buffers (see `window_background_container`). Fill
+        // in both directions with no padding, border or text colour, so it
+        // cannot move anything.
+        iced::widget::container(main_view)
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .style(window_background_container)
+            .into()
     }
 
     pub(super) fn subscription(&self) -> Subscription<Message> {
@@ -5416,36 +5428,6 @@ impl RefBoxApp {
             text_color,
         }
     }
-
-    /// Force the whole window to repaint after a display-mode change.
-    ///
-    /// On the Pi (Linux/tiny-skia, fullscreen) a palette-only change otherwise
-    /// leaves stale background pixels in one of the double-buffered frames,
-    /// producing a persistent flicker. Briefly leaving and re-entering
-    /// fullscreen is a genuine surface resize, which makes iced clear its
-    /// per-buffer layer history so both buffers repaint in the new palette.
-    /// Gated off everywhere else (no bug there; would just blink for nothing).
-    /// Mirrors the startup fullscreen task at the top of `new()`.
-    fn force_display_repaint(&self) -> Task<Message> {
-        if !should_force_repaint(self.fullscreen) {
-            return Task::none();
-        }
-        window::get_latest().and_then(|w| {
-            window::change_mode(w, window::Mode::Windowed)
-                .chain(window::change_mode(w, window::Mode::Fullscreen))
-        })
-    }
-}
-
-/// Whether changing the display mode must force a full-screen repaint.
-///
-/// Only the Pi hits the flicker: Linux uses the tiny-skia software renderer
-/// with a double-buffered Wayland surface, and a palette-only change repaints
-/// just one of the two buffers (the other keeps stale background pixels). On
-/// Windows/Mac (wgpu) and on windowed/single-buffered setups there is no such
-/// bug, so we never force a repaint — avoiding a needless on-screen blink.
-const fn should_force_repaint(fullscreen: bool) -> bool {
-    cfg!(target_os = "linux") && fullscreen
 }
 
 /// Decide whether a remembered link note should be restored at startup:
@@ -5813,30 +5795,5 @@ mod submission_gate_tests {
     fn no_recorded_result_is_not_submitted() {
         // First game of the session, or a fresh restart.
         assert!(!recorded_result_matches_ended_game(None, &"18".to_string()));
-    }
-}
-
-#[cfg(test)]
-mod repaint_gate_tests {
-    use super::*;
-
-    #[test]
-    fn windowed_never_repaints() {
-        // A windowed window has no stale second buffer to clear, on any platform.
-        assert!(!should_force_repaint(false));
-    }
-
-    #[test]
-    #[cfg(target_os = "linux")]
-    fn linux_fullscreen_repaints() {
-        // The Pi (Linux/tiny-skia, fullscreen) is the one place the flicker occurs.
-        assert!(should_force_repaint(true));
-    }
-
-    #[test]
-    #[cfg(not(target_os = "linux"))]
-    fn non_linux_never_repaints() {
-        // Windows/Mac use wgpu and don't have the bug; never force a repaint.
-        assert!(!should_force_repaint(true));
     }
 }

--- a/refbox/src/app/theme/container.rs
+++ b/refbox/src/app/theme/container.rs
@@ -224,6 +224,32 @@ pub fn transparent_container(theme: &Theme) -> Style {
     }
 }
 
+/// Backing panel painted behind the whole window in the active palette's
+/// window colour.
+///
+/// This exists so the window background is something iced *draws*, not merely
+/// the background clear it applies first. tiny-skia's damage tracking compares
+/// the fill colours of drawn quads, but remembers the clear colour only once
+/// for all buffers — so a palette-only change repaints one buffer and leaves
+/// stale background pixels in the other (the High-Contrast flicker). A real
+/// quad makes the change visible to damage tracking, so both buffers repaint
+/// on their own, with no window resize needed to force it.
+///
+/// Carries no padding, border or text colour: it must be incapable of moving
+/// anything or altering inherited text colour.
+pub fn window_background_container(_theme: &Theme) -> Style {
+    Style {
+        background: Some(Background::Color(window_background())),
+        text_color: None,
+        border: Border {
+            width: 0.0,
+            color: Color::TRANSPARENT,
+            radius: BORDER_RADIUS_ZERO,
+        },
+        shadow: Default::default(),
+    }
+}
+
 #[cfg(test)]
 mod high_contrast_container_tests {
     use super::*;
@@ -295,5 +321,44 @@ mod high_contrast_container_tests {
         let s = gray_container(&Theme::default());
         assert_eq!(s.background, Some(Background::Color(gray())));
         assert_eq!(s.border.width, 0.0);
+    }
+}
+
+#[cfg(test)]
+mod window_background_container_tests {
+    use super::*;
+    use crate::app::theme::{DISPLAY_MODE_TEST_LOCK, DisplayMode, set_display_mode};
+    use iced::{Background, Theme};
+
+    #[test]
+    fn follows_the_active_palette() {
+        let _guard = DISPLAY_MODE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        for mode in [
+            DisplayMode::Light,
+            DisplayMode::Dark,
+            DisplayMode::HighContrast,
+        ] {
+            set_display_mode(mode);
+            let s = window_background_container(&Theme::default());
+            assert_eq!(
+                s.background,
+                Some(Background::Color(mode.palette().window_background)),
+                "{mode:?}"
+            );
+        }
+        set_display_mode(DisplayMode::Light);
+    }
+
+    /// This panel sits behind the entire UI, so any border width, corner radius
+    /// or inherited text colour would be visible on every screen. It must be a
+    /// pure fill, incapable of moving anything.
+    #[test]
+    fn is_layout_and_text_neutral() {
+        let s = window_background_container(&Theme::default());
+        assert_eq!(s.border.width, 0.0);
+        assert_eq!(s.border.radius, BORDER_RADIUS_ZERO);
+        assert_eq!(s.text_color, None);
     }
 }

--- a/refbox/src/app/theme/mod.rs
+++ b/refbox/src/app/theme/mod.rs
@@ -361,7 +361,7 @@ pub use container::{
     green_container, light_gray_container, red_container, red_pressed_container,
     scroll_bar_container, table_black_cell, table_grid_container, table_label_cell,
     table_label_cell_grayed, table_value_cell, table_value_cell_grayed, table_white_cell,
-    transparent_container, white_container, yellow_container,
+    transparent_container, white_container, window_background_container, yellow_container,
 };
 
 pub mod text;


### PR DESCRIPTION
## What changed

Changing the view mode (Light / Dark / High Contrast) no longer moves anything on screen. It now changes colours and nothing else.

Previously, every view-mode change quietly dropped the whole window out of fullscreen and immediately put it back. That is a genuine window resize, so the app re-calculated the position of every element on screen — twice. On the Pi the window never recovered its correct height, and everything sized as "a share of the available space" ended up in a different place. The operator saw this as elements shifting, spacing growing between rows, and the screen appearing not to fill properly.

That drop-and-restore existed to work around a separate problem: the High Contrast flicker. So it could be removed safely, this change also gives the app a real background panel of its own, instead of relying on the graphics library to wipe the screen to the background colour. The library tracks the colour of things it *draws*, but not that wipe — which is what caused the flicker in the first place. With the background drawn as a normal element, a palette change is detected properly and the screen repaints by itself, with no window resizing needed.

## Why

Two problems, one of which was causing the other:

1. **Elements moved between view modes.** Confirmed by the operator on the Pi: starting fresh in High Contrast renders correctly, but switching away and back returns it in the shifted state, and the shift persists. It also happened going Light to Dark, where the two palettes differ in colour alone — which is what ruled out the theme code entirely.

2. **The High Contrast flicker.** The original fix for this shipped explicitly "unproven on hardware". It cured the flicker by rebuilding the window, which is what introduced problem 1. This change addresses the flicker at its actual cause instead.

The layout system in the graphics library never sees the styling — it is given only widths, heights and padding — so a colour change physically cannot move anything. The window resize was the only remaining explanation, and measurement confirmed it.

## Scope

Changes are limited to the `refbox` crate:

- `refbox/src/app/theme/container.rs` — new `window_background_container` style, plus two tests
- `refbox/src/app/theme/mod.rs` — export it
- `refbox/src/app/mod.rs` — wrap the UI in that background; delete `force_display_repaint`, `should_force_repaint`, and the now-unread `fullscreen` field

No palette colours changed. The High Contrast outlines and the swapped "?" foul icon are deliberately untouched — they are a separate design question. The `--fullscreen` command-line flag and the fullscreen-at-startup behaviour are unchanged.

## How to verify

**Measured before/after already done on Linux/X11.** The window's exact size was polled four times a second while cycling view modes.

Before (window collapses to the configured 945x691 and back, four transitions):

```
01:22:02  1920x1200+0+0
01:26:57  945x691+38+59
01:26:57  1920x1200+0+0
01:29:22  945x691+488+255
01:29:23  945x691+38+59
01:29:24  1920x1200+0+0
```

After (same test, same presses):

```
01:29:51  1920x1200+0+0
```

The window never changes. Visible confirmation: on the old build a smaller window flashes on at every mode change; on the fixed build it does not.

**On the Pi (the outstanding gate):**

1. Put the Pi in Dark mode and restart the app. Note the gap between the DISPLAY OPTIONS row and the VIEW MODE row.
2. Press VIEW MODE three times, back around to Dark.
3. The gap must be **identical**. Before this change it grew.
4. Confirm there is no flicker in High Contrast, and no blink when changing mode.

Step 4 cannot be tested anywhere but the Pi: the flicker requires its double-buffered Wayland surface, and WSL's X11 path is single-buffered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
