### PR TITLE
fix(refbox): show selection and press feedback in high contrast

### DIFF
--- a/refbox/src/app/theme/button.rs
+++ b/refbox/src/app/theme/button.rs
@@ -10,9 +10,15 @@ use iced::{
 };
 
 /// In High Contrast only, restyle a filled button as an outline: dark `hc_fill`,
-/// the `accent` colour on the border + text, an always-visible `BORDER_WIDTH`
-/// border, and no hover/pressed darkening. Disabled buttons are left untouched.
-/// In Light/Dark the style is returned unchanged.
+/// the `accent` colour on the border + text, and an always-visible `BORDER_WIDTH`
+/// border. Light/Dark darken the fill while a button is held down, which a dark
+/// fill cannot show, so a pressed button takes the blue marker on its border
+/// instead. Disabled buttons are left untouched. In Light/Dark the style is
+/// returned unchanged.
+///
+/// No button passes `blue()` as its accent in this mode — blue is reserved for
+/// the selected/pressed marker, so it can never be mistaken for a button's own
+/// colour. `high_contrast_blue_button_uses_white_accent` pins that.
 fn outline_in_high_contrast(
     mut style: Style,
     accent: Color,
@@ -22,8 +28,27 @@ fn outline_in_high_contrast(
     if display_mode() == DisplayMode::HighContrast && !matches!(status, Status::Disabled) {
         style.background = Some(Background::Color(hc_fill));
         style.text_color = accent;
-        style.border.color = accent;
+        style.border.color = if matches!(status, Status::Pressed) {
+            blue()
+        } else {
+            accent
+        };
         style.border.width = BORDER_WIDTH;
+    }
+    style
+}
+
+/// In High Contrast only, mark a button as selected by recolouring its border to
+/// blue. `outline_in_high_contrast` has already given every non-disabled button a
+/// `BORDER_WIDTH` border in its own accent colour, so switching the border on —
+/// how Light and Dark signal selection — is a no-op here; the colour has to carry
+/// the signal instead.
+///
+/// A pressed button is already blue, so re-applying is harmless. Disabled buttons
+/// are left untouched. In Light/Dark the style is returned unchanged.
+fn select_in_high_contrast(mut style: Style, status: Status) -> Style {
+    if display_mode() == DisplayMode::HighContrast && !matches!(status, Status::Disabled) {
+        style.border.color = blue();
     }
     style
 }
@@ -83,7 +108,7 @@ pub fn light_gray_button(theme: &Theme, status: Status) -> Style {
 pub fn light_gray_selected_button(theme: &Theme, status: Status) -> Style {
     let mut style = light_gray_button(theme, status);
     style.border.width = BORDER_WIDTH;
-    style
+    select_in_high_contrast(style, status)
 }
 
 pub fn white_button(theme: &Theme, status: Status) -> Style {
@@ -109,7 +134,7 @@ pub fn white_button(theme: &Theme, status: Status) -> Style {
 pub fn white_selected_button(theme: &Theme, status: Status) -> Style {
     let mut style = white_button(theme, status);
     style.border.width = BORDER_WIDTH;
-    style
+    select_in_high_contrast(style, status)
 }
 
 pub fn black_button(theme: &Theme, status: Status) -> Style {
@@ -136,7 +161,7 @@ pub fn black_button(theme: &Theme, status: Status) -> Style {
 pub fn black_selected_button(theme: &Theme, status: Status) -> Style {
     let mut style = black_button(theme, status);
     style.border.width = BORDER_WIDTH;
-    style
+    select_in_high_contrast(style, status)
 }
 
 pub fn red_button(theme: &Theme, status: Status) -> Style {
@@ -164,7 +189,7 @@ pub fn red_button_armed(theme: &Theme, _status: Status) -> Style {
 pub fn red_selected_button(theme: &Theme, status: Status) -> Style {
     let mut style = red_button(theme, status);
     style.border.width = BORDER_WIDTH;
-    style
+    select_in_high_contrast(style, status)
 }
 
 pub fn orange_button(theme: &Theme, status: Status) -> Style {
@@ -184,7 +209,7 @@ pub fn orange_button(theme: &Theme, status: Status) -> Style {
 pub fn orange_selected_button(theme: &Theme, status: Status) -> Style {
     let mut style = orange_button(theme, status);
     style.border.width = BORDER_WIDTH;
-    style
+    select_in_high_contrast(style, status)
 }
 
 pub fn yellow_button(theme: &Theme, status: Status) -> Style {
@@ -212,7 +237,7 @@ pub fn yellow_button_armed(theme: &Theme, _status: Status) -> Style {
 pub fn yellow_selected_button(theme: &Theme, status: Status) -> Style {
     let mut style = yellow_button(theme, status);
     style.border.width = BORDER_WIDTH;
-    style
+    select_in_high_contrast(style, status)
 }
 
 pub fn green_button(theme: &Theme, status: Status) -> Style {
@@ -232,7 +257,7 @@ pub fn green_button(theme: &Theme, status: Status) -> Style {
 pub fn green_selected_button(theme: &Theme, status: Status) -> Style {
     let mut style = green_button(theme, status);
     style.border.width = BORDER_WIDTH;
-    style
+    select_in_high_contrast(style, status)
 }
 
 pub fn blue_button(theme: &Theme, status: Status) -> Style {
@@ -253,13 +278,15 @@ pub fn blue_button(theme: &Theme, status: Status) -> Style {
         text_color,
         ..gray_button(theme, status)
     };
-    outline_in_high_contrast(style, blue(), black(), status)
+    // White, not blue: in High Contrast blue is reserved for the selected/pressed
+    // marker, so no button may wear it as its own colour.
+    outline_in_high_contrast(style, white(), black(), status)
 }
 
 pub fn blue_selected_button(theme: &Theme, status: Status) -> Style {
     let mut style = blue_button(theme, status);
     style.border.width = BORDER_WIDTH;
-    style
+    select_in_high_contrast(style, status)
 }
 
 pub fn blue_with_border_button(theme: &Theme, status: Status) -> Style {
@@ -273,8 +300,8 @@ pub fn blue_with_border_button(theme: &Theme, status: Status) -> Style {
 mod high_contrast_tests {
     use super::*;
     use crate::app::theme::{
-        BORDER_WIDTH, DisplayMode, HC_DARK_GREY, HC_WHITE_DISABLED, black, light_gray_button, red,
-        set_display_mode, white, window_background,
+        BORDER_COLOR, BORDER_WIDTH, DisplayMode, HC_DARK_GREY, HC_WHITE_DISABLED, black,
+        light_gray_button, red, set_display_mode, white, window_background,
     };
     use iced::widget::button::Status;
     use iced::{Background, Theme};
@@ -350,5 +377,146 @@ mod high_contrast_tests {
         let s = white_button(&Theme::default(), Status::Disabled);
         assert_eq!(s.background, Some(Background::Color(HC_WHITE_DISABLED)));
         set_display_mode(DisplayMode::Light);
+    }
+
+    #[test]
+    fn high_contrast_selected_button_ring_is_blue() {
+        let _guard = crate::app::theme::DISPLAY_MODE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        set_display_mode(DisplayMode::HighContrast);
+        let selected = white_selected_button(&Theme::default(), Status::Active);
+        let plain = white_button(&Theme::default(), Status::Active);
+        assert_eq!(selected.border.color, blue());
+        assert_ne!(selected.border.color, plain.border.color);
+        assert_eq!(selected.border.width, BORDER_WIDTH);
+        set_display_mode(DisplayMode::Light);
+    }
+
+    #[test]
+    fn high_contrast_yellow_selected_button_ring_is_blue() {
+        let _guard = crate::app::theme::DISPLAY_MODE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        set_display_mode(DisplayMode::HighContrast);
+        let selected = yellow_selected_button(&Theme::default(), Status::Active);
+        let plain = yellow_button(&Theme::default(), Status::Active);
+        assert_eq!(selected.border.color, blue());
+        assert_ne!(selected.border.color, plain.border.color);
+        set_display_mode(DisplayMode::Light);
+    }
+
+    #[test]
+    fn high_contrast_blue_selected_button_ring_is_blue() {
+        let _guard = crate::app::theme::DISPLAY_MODE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        set_display_mode(DisplayMode::HighContrast);
+        let selected = blue_selected_button(&Theme::default(), Status::Active);
+        let plain = blue_button(&Theme::default(), Status::Active);
+        assert_eq!(selected.border.color, blue());
+        assert_ne!(selected.border.color, plain.border.color);
+        set_display_mode(DisplayMode::Light);
+    }
+
+    /// Blue is reserved for the selected/pressed marker, so a blue button must
+    /// render with a white accent in High Contrast — otherwise an idle blue
+    /// button would be indistinguishable from a selected one.
+    #[test]
+    fn high_contrast_blue_button_uses_white_accent() {
+        let _guard = crate::app::theme::DISPLAY_MODE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        set_display_mode(DisplayMode::HighContrast);
+        let s = blue_button(&Theme::default(), Status::Active);
+        assert_eq!(s.border.color, white());
+        assert_eq!(s.text_color, white());
+        assert_ne!(s.border.color, blue());
+        set_display_mode(DisplayMode::Light);
+    }
+
+    #[test]
+    fn light_mode_blue_button_unchanged() {
+        let _guard = crate::app::theme::DISPLAY_MODE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        set_display_mode(DisplayMode::Light);
+        let s = blue_button(&Theme::default(), Status::Active);
+        assert_eq!(s.background, Some(Background::Color(blue())));
+        assert_eq!(s.border.width, 0.0);
+    }
+
+    #[test]
+    fn high_contrast_disabled_selected_button_is_not_recoloured() {
+        let _guard = crate::app::theme::DISPLAY_MODE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        set_display_mode(DisplayMode::HighContrast);
+        let selected = blue_selected_button(&Theme::default(), Status::Disabled);
+        let plain = blue_button(&Theme::default(), Status::Disabled);
+        assert_eq!(selected.border.color, plain.border.color);
+        set_display_mode(DisplayMode::Light);
+    }
+
+    #[test]
+    fn high_contrast_pressed_button_ring_is_blue() {
+        let _guard = crate::app::theme::DISPLAY_MODE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        set_display_mode(DisplayMode::HighContrast);
+        let pressed = white_button(&Theme::default(), Status::Pressed);
+        let idle = white_button(&Theme::default(), Status::Active);
+        assert_eq!(pressed.border.color, blue());
+        assert_ne!(pressed.border.color, idle.border.color);
+        set_display_mode(DisplayMode::Light);
+    }
+
+    #[test]
+    fn high_contrast_pressed_blue_button_ring_is_blue() {
+        let _guard = crate::app::theme::DISPLAY_MODE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        set_display_mode(DisplayMode::HighContrast);
+        let pressed = blue_button(&Theme::default(), Status::Pressed);
+        let idle = blue_button(&Theme::default(), Status::Active);
+        assert_eq!(pressed.border.color, blue());
+        assert_ne!(pressed.border.color, idle.border.color);
+        set_display_mode(DisplayMode::Light);
+    }
+
+    /// A selected button that is also held down must not have the marker applied
+    /// twice — the second pass would read the blue border as "this is a blue
+    /// button" and flip it to yellow.
+    #[test]
+    fn high_contrast_pressed_selected_button_is_not_marked_twice() {
+        let _guard = crate::app::theme::DISPLAY_MODE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        set_display_mode(DisplayMode::HighContrast);
+        let pressed = white_selected_button(&Theme::default(), Status::Pressed);
+        assert_eq!(pressed.border.color, blue());
+        set_display_mode(DisplayMode::Light);
+    }
+
+    #[test]
+    fn light_mode_pressed_button_ring_unchanged() {
+        let _guard = crate::app::theme::DISPLAY_MODE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        set_display_mode(DisplayMode::Light);
+        let pressed = white_button(&Theme::default(), Status::Pressed);
+        assert_eq!(pressed.border.color, BORDER_COLOR);
+        assert_eq!(pressed.border.width, 0.0);
+    }
+
+    #[test]
+    fn light_mode_selected_button_ring_unchanged() {
+        let _guard = crate::app::theme::DISPLAY_MODE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        set_display_mode(DisplayMode::Light);
+        let selected = white_selected_button(&Theme::default(), Status::Active);
+        assert_eq!(selected.border.color, BORDER_COLOR);
+        assert_eq!(selected.border.width, BORDER_WIDTH);
     }
 }

--- a/refbox/src/app/theme/container.rs
+++ b/refbox/src/app/theme/container.rs
@@ -109,21 +109,31 @@ pub fn red_container(theme: &Theme) -> Style {
     outline_container_in_high_contrast(style, red(), Some(Background::Color(black())))
 }
 
+/// The buzzer face while it is held, during active play. In High Contrast the
+/// darkened fill that shows a press in Light/Dark is invisible against a dark
+/// panel, so the outline turns yellow instead. Yellow rather than the usual blue
+/// marker because the buzzer keeps its own red/blue identity — see
+/// `blue_pressed_container`.
 pub fn red_pressed_container(theme: &Theme) -> Style {
     let style = Style {
         background: Some(Background::Color(red_pressed())),
         ..gray_container_base(theme)
     };
-    outline_container_in_high_contrast(style, red(), Some(Background::Color(black())))
+    outline_container_in_high_contrast(style, yellow(), Some(Background::Color(black())))
 }
 
+/// The buzzer face while it is held, outside active play. The buzzer is the one
+/// control that keeps blue as its own colour in High Contrast, so the blue
+/// selected/pressed marker used everywhere else would be invisible on it; its
+/// held state is yellow instead. Used only by the buzzer, as is
+/// `red_pressed_container`.
 pub fn blue_pressed_container(theme: &Theme) -> Style {
     let style = Style {
         background: Some(Background::Color(blue_pressed())),
         text_color: Some(white()),
         ..gray_container_base(theme)
     };
-    outline_container_in_high_contrast(style, blue(), Some(Background::Color(black())))
+    outline_container_in_high_contrast(style, yellow(), Some(Background::Color(black())))
 }
 
 // ── Game-info table cells ───────────────────────────────────────────────────
@@ -258,6 +268,42 @@ mod high_contrast_container_tests {
         window_background, yellow,
     };
     use iced::{Background, Theme};
+
+    /// The buzzer is the one control that keeps blue in High Contrast, so its
+    /// held state must not use the blue marker — it would be invisible.
+    #[test]
+    fn high_contrast_held_buzzer_is_outlined_yellow() {
+        let _guard = crate::app::theme::DISPLAY_MODE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        set_display_mode(DisplayMode::HighContrast);
+
+        let held = blue_pressed_container(&Theme::default());
+        let idle = blue_container(&Theme::default());
+        assert_eq!(held.border.color, yellow());
+        assert_ne!(held.border.color, idle.border.color);
+
+        let held_in_play = red_pressed_container(&Theme::default());
+        let idle_in_play = red_container(&Theme::default());
+        assert_eq!(held_in_play.border.color, yellow());
+        assert_ne!(held_in_play.border.color, idle_in_play.border.color);
+
+        set_display_mode(DisplayMode::Light);
+    }
+
+    #[test]
+    fn light_mode_held_buzzer_unchanged() {
+        let _guard = crate::app::theme::DISPLAY_MODE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        set_display_mode(DisplayMode::Light);
+        let held = blue_pressed_container(&Theme::default());
+        assert_eq!(
+            held.background,
+            Some(Background::Color(crate::app::theme::blue_pressed()))
+        );
+        assert_eq!(held.border.width, 0.0);
+    }
 
     #[test]
     fn high_contrast_red_container_is_outlined() {


### PR DESCRIPTION
## What changed

In **High Contrast mode**, you can now see which button is selected and which button you are pressing.

- **Selected** — a selected button's outline turns **blue**. Previously selected and unselected buttons were pixel-identical.
- **Pressed** — a held-down button's outline turns **blue** too. Previously pressing a button in this mode produced **no visible feedback at all**.
- **Blue buttons render white** in this mode, so blue only ever means "selected or pressed" and can never be mistaken for a button's own colour.
- **The buzzer** on the main view keeps its blue-when-idle / red-during-play colours, and turns **yellow** while held. Holding the buzzer was also completely invisible in this mode before.

Light and Dark modes are unchanged — blue buttons and the buzzer included.

The resulting scheme:

| In High Contrast | Meaning |
|---|---|
| Red / orange / yellow / green outline | status and severity — penalties, danger, warnings |
| White outline | an ordinary button |
| Blue outline | selected, or being pressed |
| Yellow outline on the buzzer | the buzzer is being held |

## Why

High Contrast draws every button as a dark fill with a bright outline. The other two modes signal selection by switching an otherwise-invisible outline **on** — which does nothing here, because the outline is already on. So the operator could not tell which team, penalty length, or setting was currently selected.

Pressing was worse. Light and Dark show a press by darkening the button's fill, and a dark fill cannot darken. Every button in High Contrast — and the buzzer, the most physical control in the app — gave no feedback when pressed.

## Scope

Changes are limited to `refbox/src/app/theme/`: `button.rs` and `container.rs`.

**Note the branch name under-describes this.** It says "selection indicator", but the change also adds press feedback and repaints every blue button in the app in High Contrast (via the single `blue_button` style function). That is intentional and was agreed during review — flagging it so the diff isn't a surprise.

No new dependencies. No `unwrap()`/`expect()` added. Nothing outside High Contrast changes behaviour.

## How to verify

Switch to High Contrast with the VIEW MODE button, then:

1. **Press feedback** — hold any button. Its outline turns blue, and returns on release.
2. **Score keypad** — the selected team (BLACK / WHITE) has a blue outline; the other is white.
3. **Penalty lengths** — the selected length has a blue outline, whichever one you pick.
4. **Settings → game length** — the active one of TWO HALVES / ONE PERIOD has a blue outline.
5. **Buzzer** — hold the buzzer face on the main view: yellow outline while held, in both its blue (idle) and red (active play) states.
6. **Light and Dark** — switch to each and confirm nothing looks different from before.

All six were walked through on screen during development and confirmed.

Automated: 27 tests in the theme modules, 12 of them new. Two are worth calling out — `high_contrast_blue_button_uses_white_accent` fails if anyone reintroduces a blue-accented button and breaks the "nothing else is blue" rule, and `high_contrast_pressed_selected_button_is_not_marked_twice` guards a bug found during development where a button that was both selected and pressed had the marker colour applied twice.

`just check` (formatting, clippy with `-D warnings`, full test suite, security audit) passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
