### PR TITLE
fix(refbox): prompt for an infraction instead of showing "Unknown"

### DIFF
--- a/docs/superpowers/specs/2026-08-07-infraction-picker-prompt-label-design.md
+++ b/docs/superpowers/specs/2026-08-07-infraction-picker-prompt-label-design.md
@@ -1,0 +1,102 @@
+# Infraction picker: prompt instead of "Unknown"
+
+**Date:** 2026-08-07
+**Branch:** `fix/refbox/infraction-picker-prompt-label`
+**Crate:** `refbox` only
+
+## Problem
+
+On the **Add Foul** and **Add Warning** pages, the blue bar above the infraction icon grid
+reads `Infraction: Unknown` before the operator has picked anything.
+
+"Unknown" reads as a legitimate choice, but it is not one. Both pages refuse to save until a
+real infraction is selected — the save button stays greyed out
+(`foul_add_can_commit`, `warning_add_can_commit`). The bar is showing an empty state as if it
+were a value.
+
+## Decision
+
+The bar reads **`Infraction: Make selection`** while nothing is selected. As soon as any icon
+is tapped it shows that infraction's name, exactly as today. Tapping `?` returns it to
+`Infraction: Make selection`.
+
+The `Infraction:` prefix is retained (rather than showing a bare "Make selection") so the bar
+always identifies which field it belongs to and the text does not shift position as the
+operator picks.
+
+## Scope boundary
+
+Explicitly unchanged:
+
+- **The `?` icon itself** and the icon grid layout.
+- **The penalty editor.** It renders the same grid via `make_penalty_dropdown(infraction,
+  false)` — the `false` suppresses the name bar — so it never displayed this text.
+- **Saved list rows.** The existing `unknown = Unknown` string stays as-is. A penalty can
+  legitimately be saved with no infraction when "track fouls and warnings" is off, and a row
+  in the list is reporting a recorded fact, not prompting for input. Renaming the shared key
+  would have made those rows read "Make selection", which is wrong.
+- **Enforcement.** No change to when saving is allowed; this is a label change only.
+
+## Implementation
+
+New Fluent key `select-infraction`, added to all 15 locales next to the existing `unknown`
+key.
+
+`shared_elements.rs` gains a small helper:
+
+```rust
+fn infraction_bar_label(infraction: Infraction) -> String {
+    let value = if infraction == Infraction::Unknown {
+        fl!("select-infraction")
+    } else {
+        inf_short_name(infraction)
+    };
+    fl!("infraction", infraction = value)
+}
+```
+
+`make_penalty_dropdown` calls it in place of the inline `fl!("infraction", ...)`.
+
+The prompt is substituted into the **existing** `infraction = Infraction: {$infraction}`
+template rather than being a new full-sentence string. All 15 locales already translate that
+template, so each language's prefix (`Verstoß:`, `反則:`, `犯规类型：`, …) stays automatically
+in sync between the empty and populated states, and translators only see one short phrase.
+
+### Translations
+
+| Locale | Value |
+|---|---|
+| de-DE | Bitte auswählen |
+| en-US | Make selection |
+| es | Seleccione una opción |
+| fr | Faire une sélection |
+| id-ID | Pilih salah satu |
+| it-IT | Effettua una scelta |
+| ja-JP | 選択してください |
+| ko-KR | 선택하세요 |
+| ms-MY | Sila pilih |
+| nl-NL | Maak een keuze |
+| pt-PT | Selecione uma opção |
+| th-TH | กรุณาเลือก |
+| tl-PH | Pumili |
+| tr-TR | Seçim yapın |
+| zh-CN | 请选择 |
+
+## Acceptance criteria
+
+1. Add Foul with nothing selected → bar reads `Infraction: Make selection`.
+2. Add Warning with nothing selected → same.
+3. Pick any infraction → bar reads that infraction's name.
+4. Tap `?` again → bar returns to `Infraction: Make selection`.
+5. With "track fouls and warnings" off, save a penalty with no infraction → its list row
+   still reads "Unknown".
+6. `just check` clean.
+
+## Tests
+
+`infraction_bar_prompts_until_a_selection_is_made` and
+`infraction_bar_names_a_chosen_infraction` in `shared_elements.rs`. Both compare against
+`fl!` keys rather than literal English so they hold in any locale.
+
+Mutation-checked: reverting the helper to the old behaviour fails the first test with
+`left: "Infraction: Unknown"` / `right: "Infraction: Make selection"`.

--- a/refbox/src/app/view_builders/shared_elements.rs
+++ b/refbox/src/app/view_builders/shared_elements.rs
@@ -1264,12 +1264,9 @@ pub(super) fn make_penalty_dropdown<'a>(
     });
 
     let name: Container<'_, Message> = container(
-        row![text(fl!(
-            "infraction",
-            infraction = inf_short_name(infraction)
-        ))]
-        .spacing(0)
-        .align_y(Alignment::Center),
+        row![text(infraction_bar_label(infraction))]
+            .spacing(0)
+            .align_y(Alignment::Center),
     )
     .style(blue_container)
     .width(Length::Fill);
@@ -1358,6 +1355,24 @@ pub fn inf_short_name(inf: Infraction) -> String {
     }
 }
 
+/// Text for the infraction picker's header bar. Until an infraction is chosen
+/// the bar prompts for one rather than naming `Unknown`, which would read as a
+/// real choice — the Add Foul and Add Warning pages are the only callers that
+/// show this bar, and both refuse to save without a selection (see
+/// `foul_add_can_commit` / `warning_add_can_commit`). `unknown` stays the
+/// wording for saved list rows, where a penalty legitimately can carry no
+/// infraction (fouls-and-warnings tracking off). The prompt is substituted into
+/// the same `infraction` template as a real name so the localized prefix always
+/// matches the populated state.
+fn infraction_bar_label(infraction: Infraction) -> String {
+    let value = if infraction == Infraction::Unknown {
+        fl!("select-infraction")
+    } else {
+        inf_short_name(infraction)
+    };
+    fl!("infraction", infraction = value)
+}
+
 /// Returns true when any of the given format hints represents a pending change
 /// (anything other than `NoChange`). Used to gray the Apply button on the
 /// penalty / warning / foul overview pages until a row is added, edited, or
@@ -1416,6 +1431,32 @@ mod tests {
         assert_eq!(cancel_or_back_label(true), fl!("cancel"));
         assert_eq!(cancel_or_back_label(false), fl!("back"));
         assert_ne!(cancel_or_back_label(true), cancel_or_back_label(false));
+    }
+
+    #[test]
+    fn infraction_bar_prompts_until_a_selection_is_made() {
+        // Nothing picked yet → the bar prompts for a choice instead of naming
+        // "Unknown" as though it were one. Compared against the same fl! keys so
+        // the assertion holds regardless of which locale the loader resolves to.
+        assert_eq!(
+            infraction_bar_label(Infraction::Unknown),
+            fl!("infraction", infraction = fl!("select-infraction"))
+        );
+        // Would have passed before this fix, and must not again.
+        assert_ne!(
+            infraction_bar_label(Infraction::Unknown),
+            fl!("infraction", infraction = fl!("unknown"))
+        );
+    }
+
+    #[test]
+    fn infraction_bar_names_a_chosen_infraction() {
+        for inf in all::<Infraction>().filter(|i| *i != Infraction::Unknown) {
+            assert_eq!(
+                infraction_bar_label(inf),
+                fl!("infraction", infraction = inf_short_name(inf))
+            );
+        }
     }
 
     #[test]

--- a/refbox/translations/de-DE/refbox.ftl
+++ b/refbox/translations/de-DE/refbox.ftl
@@ -326,6 +326,7 @@ ref-list = Hauptschiedsrichter: { $chief_ref }
 team-ref-list = Schiedsrichter: { $ref_team }
     Zeitnehmer/Anschreiber: { $ts_keeper_team }
 unknown = Unbekannt
+select-infraction = Bitte auswählen
 ## Spielzeit-Schaltfläche
 next-game = NÄCHSTES SPIEL
 first-half = ERSTE HALBZEIT

--- a/refbox/translations/en-US/refbox.ftl
+++ b/refbox/translations/en-US/refbox.ftl
@@ -363,6 +363,7 @@ ref-list = Chief Ref: { $chief_ref }
 team-ref-list = Referees: { $ref_team }
     T/S Keeper: { $ts_keeper_team }
 unknown = Unknown
+select-infraction = Make selection
 ## Game time button
 next-game = NEXT GAME
 first-half = FIRST HALF

--- a/refbox/translations/es/refbox.ftl
+++ b/refbox/translations/es/refbox.ftl
@@ -337,6 +337,7 @@ ref-list = Árbitro principal: { $chief_ref }
 team-ref-list = Árbitros: { $ref_team }
     Cronometrador/Marcador: { $ts_keeper_team }
 unknown = Desconocido
+select-infraction = Seleccione una opción
 ## Game time button
 next-game = PRÓXIMO JUEGO
 first-half = 1a MITAD

--- a/refbox/translations/fr/refbox.ftl
+++ b/refbox/translations/fr/refbox.ftl
@@ -328,6 +328,7 @@ ref-list = Arbitre en Chef: { $chief_ref }
 team-ref-list = Arbitres: { $ref_team }
     Chronométreur/Marqueur: { $ts_keeper_team }
 unknown = Inconnu
+select-infraction = Faire une sélection
 ## Game time button
 next-game = MATCH SUIVANT
 first-half = 1ere PÉRIODE

--- a/refbox/translations/id-ID/refbox.ftl
+++ b/refbox/translations/id-ID/refbox.ftl
@@ -326,6 +326,7 @@ ref-list = Wasit Kepala: { $chief_ref }
 team-ref-list = Wasit: { $ref_team }
     Pencatat Waktu/Skor: { $ts_keeper_team }
 unknown = Tidak Diketahui
+select-infraction = Pilih salah satu
 ## Tombol waktu pertandingan
 next-game = PERTANDINGAN BERIKUTNYA
 first-half = BABAK PERTAMA

--- a/refbox/translations/it-IT/refbox.ftl
+++ b/refbox/translations/it-IT/refbox.ftl
@@ -326,6 +326,7 @@ ref-list = Capo Arbitro: { $chief_ref }
 team-ref-list = Arbitri: { $ref_team }
     Cronometrista/Segnapunti: { $ts_keeper_team }
 unknown = Sconosciuto
+select-infraction = Effettua una scelta
 ## Pulsante tempo di gioco
 next-game = PROSSIMA PARTITA
 first-half = PRIMO TEMPO

--- a/refbox/translations/ja-JP/refbox.ftl
+++ b/refbox/translations/ja-JP/refbox.ftl
@@ -326,6 +326,7 @@ ref-list = 主審: { $chief_ref }
 team-ref-list = 審判員: { $ref_team }
     記録員: { $ts_keeper_team }
 unknown = 不明
+select-infraction = 選択してください
 ## 試合時間ボタン
 next-game = 次の試合
 first-half = 前半

--- a/refbox/translations/ko-KR/refbox.ftl
+++ b/refbox/translations/ko-KR/refbox.ftl
@@ -328,6 +328,7 @@ ref-list = 주심: { $chief_ref }
 team-ref-list = 심판: { $ref_team }
     기록원/계시원: { $ts_keeper_team }
 unknown = 알 수 없음
+select-infraction = 선택하세요
 ## 경기 시간 버튼
 next-game = 다음 경기
 first-half = 전반

--- a/refbox/translations/ms-MY/refbox.ftl
+++ b/refbox/translations/ms-MY/refbox.ftl
@@ -326,6 +326,7 @@ ref-list = Ketua Pengadil: { $chief_ref }
 team-ref-list = Pengadil: { $ref_team }
     Pencatat Masa/Markah: { $ts_keeper_team }
 unknown = Tidak Diketahui
+select-infraction = Sila pilih
 ## Butang masa perlawanan
 next-game = PERLAWANAN SETERUSNYA
 first-half = SEPARUH PERTAMA

--- a/refbox/translations/nl-NL/refbox.ftl
+++ b/refbox/translations/nl-NL/refbox.ftl
@@ -326,6 +326,7 @@ ref-list = Hoofdscheidsrechter: { $chief_ref }
 team-ref-list = Scheidsrechters: { $ref_team }
     Tijdwaarnemer/Scorer: { $ts_keeper_team }
 unknown = Onbekend
+select-infraction = Maak een keuze
 ## Wedstrijdtijdknop
 next-game = VOLGENDE WEDSTRIJD
 first-half = EERSTE HELFT

--- a/refbox/translations/pt-PT/refbox.ftl
+++ b/refbox/translations/pt-PT/refbox.ftl
@@ -326,6 +326,7 @@ ref-list = Árbitro Principal: { $chief_ref }
 team-ref-list = Árbitros: { $ref_team }
     Controlador de Tempo/Pontuação: { $ts_keeper_team }
 unknown = Desconhecido
+select-infraction = Selecione uma opção
 ## Botão de tempo de jogo
 next-game = PRÓXIMO JOGO
 first-half = PRIMEIRO TEMPO

--- a/refbox/translations/th-TH/refbox.ftl
+++ b/refbox/translations/th-TH/refbox.ftl
@@ -325,6 +325,7 @@ ref-list = หัวหน้าผู้ตัดสิน: { $chief_ref }
 team-ref-list = ผู้ตัดสิน: { $ref_team }
     กรรมการจับเวลา/บันทึกคะแนน: { $ts_keeper_team }
 unknown = ไม่ทราบ
+select-infraction = กรุณาเลือก
 ## ปุ่มเวลาเกม
 next-game = เกมถัดไป
 first-half = ครึ่งแรก

--- a/refbox/translations/tl-PH/refbox.ftl
+++ b/refbox/translations/tl-PH/refbox.ftl
@@ -326,6 +326,7 @@ ref-list = Punong Ref: { $chief_ref }
 team-ref-list = Mga Referee: { $ref_team }
     Tagapanatili ng Puntos: { $ts_keeper_team }
 unknown = Hindi Alam
+select-infraction = Pumili
 ## Pindutan ng oras ng laro
 next-game = SUSUNOD NA LARO
 first-half = UNANG KALAHATI

--- a/refbox/translations/tr-TR/refbox.ftl
+++ b/refbox/translations/tr-TR/refbox.ftl
@@ -326,6 +326,7 @@ ref-list = Başhakem: { $chief_ref }
 team-ref-list = Hakemler: { $ref_team }
     Zaman/Skor Tutanlar: { $ts_keeper_team }
 unknown = Bilinmiyor
+select-infraction = Seçim yapın
 ## Oyun zamanı düğmesi
 next-game = SONRAKİ OYUN
 first-half = İLK DEVRE

--- a/refbox/translations/zh-CN/refbox.ftl
+++ b/refbox/translations/zh-CN/refbox.ftl
@@ -325,6 +325,7 @@ ref-list = 主裁判：{ $chief_ref }
 team-ref-list = 裁判员：{ $ref_team }
     计时/记分员：{ $ts_keeper_team }
 unknown = 未知
+select-infraction = 请选择
 ## 比赛时间按钮
 next-game = 下一场
 first-half = 上半场


### PR DESCRIPTION
## What changed

On the **Add Foul** and **Add Warning** pages, the blue bar above the infraction icon grid used to read `Infraction: Unknown` before anything was picked. It now reads `Infraction: Make selection` until the operator chooses one, then shows the chosen infraction as before. Tapping the `?` tile returns it to the prompt.

## Why

Both pages already refuse to save until a real infraction is selected — the save button stays greyed out. "Unknown" read like a legitimate choice when it is really just the empty state, so the bar was presenting a missing value as if it were a value.

## Scope

Changes are limited to `refbox`: one helper and one call site in `refbox/src/app/view_builders/shared_elements.rs`, plus a new `select-infraction` key in all 15 files under `refbox/translations/`.

Deliberately unchanged:

- **The penalty editor.** It renders the same icon grid with the name bar switched off, so it never displayed this text.
- **Saved list rows.** The existing `unknown = Unknown` string is untouched. A penalty can legitimately be saved with no infraction when "track fouls and warnings" is off, and a list row reports a recorded fact rather than prompting for input — renaming the shared key would have made those rows read "Make selection".
- **Enforcement.** No change to when saving is allowed; this is wording only.

The prompt is substituted into the existing `infraction = Infraction: {$infraction}` template rather than being a new full sentence, so each language keeps its own prefix automatically and translators see one short phrase.

## How to verify

1. Open **Add Foul** with nothing selected — the bar reads `Infraction: Make selection`.
2. Tap any infraction — the bar shows that infraction's name.
3. Tap the `?` tile — the bar returns to `Infraction: Make selection`.
4. Repeat on **Add Warning**.
5. Turn "track fouls and warnings" **off**, add a penalty with no infraction, and confirm its row in the penalties list still reads "Unknown".

`just check` passes locally. Two new tests in `shared_elements.rs` compare against `fl!` keys rather than literal English, so they hold in any locale; reverting the helper fails them with `left: "Infraction: Unknown"` / `right: "Infraction: Make selection"`.