### PR TITLE
fix(refbox): make the infraction optional when saving a penalty

### DIFF
--- a/docs/superpowers/specs/2026-08-07-optional-penalty-infraction-design.md
+++ b/docs/superpowers/specs/2026-08-07-optional-penalty-infraction-design.md
@@ -1,0 +1,99 @@
+# Penalties: make the infraction optional
+
+**Date:** 2026-08-07
+**Branch:** `fix/refbox/optional-penalty-infraction` (off `origin/master` `1900f4ad`)
+**Crate:** `refbox` only
+
+## Problem
+
+On the penalty page, the DONE button required a player number *and* — whenever "track fouls
+and warnings" was on — an infraction. Poolside the operator may need the exclusion clock
+running before the reason has been settled, and the gate blocked that.
+
+## Decision
+
+DONE requires **only a player number**. The infraction picker is unchanged and still shown
+whenever tracking is on; choosing an infraction is simply no longer a precondition for saving.
+
+Applies to both adding a new penalty and editing an existing one — the same page serves both.
+
+## The asymmetry, and why it is correct
+
+Fouls and warnings still **require** an infraction (`foul_add_can_commit`,
+`warning_add_can_commit`). A foul or warning is nothing but its infraction, so a blank one
+records no information at all. A penalty's essential content is the player and the duration;
+the reason is useful but secondary.
+
+This pairs with the sibling change on `fix/refbox/infraction-picker-prompt-label`, which makes
+the foul/warning picker bar read "Infraction: Make selection" precisely because it *is*
+required there. The penalty page never displayed that bar
+(`make_penalty_dropdown(infraction, false)`), so the two changes do not interact visually.
+
+## Why this is low-risk
+
+An infraction-less penalty is not a new state:
+
+- It is exactly what this page has always produced with tracking **off**.
+- Tracking is a settings toggle that can be flipped at any time, so "penalty with no
+  infraction, tracking on" was already reachable before this change.
+- `Infraction::Unknown` is the enum's `#[derivative(Default)]` variant and is handled
+  everywhere downstream — scoresheets print "Unknown", the LED panel and portal serialize it
+  like any other variant. Nothing special-cases it as impossible.
+- The penalty list rows do not render the infraction at all (they show player number, time,
+  and kind), so there is no new display case.
+
+## Implementation
+
+`penalty_edit_can_commit` in `refbox/src/app/view_builders/keypad_pages/penalty_edit.rs`
+narrows its rule to `player_num > 0`.
+
+It keeps — and ignores — the team, infraction, and tracking flag:
+
+```rust
+fn penalty_edit_can_commit(
+    _color: GameColor,
+    _infraction: Infraction,
+    _track_fouls_and_warnings: bool,
+    player_num: u32,
+) -> bool {
+    player_num > 0
+}
+```
+
+Taking the whole of the page state that could plausibly gate saving, rather than only what
+the current rule reads, is what makes the *irrelevance* of the other three assertable. Without
+them the guarantee "an infraction never blocks saving" would be untestable, and a future
+change could quietly re-block the operator.
+
+`make_penalty_edit_page` still uses `track_fouls_and_warnings` to decide whether the picker is
+drawn and `infraction` to drive its selected tile.
+
+No translation changes.
+
+## Note on the button's name
+
+The button gated here is the penalty page's **DONE** button. The **APPLY** button on the
+penalties *overview* page is a different control — it commits the whole list of pending
+changes and is not affected.
+
+## Acceptance criteria
+
+1. Tracking **on**: pick a team, enter a player number, pick a duration, leave the infraction
+   grid untouched → DONE is enabled and the penalty saves.
+2. Tracking **on**, no player number → DONE stays greyed out.
+3. Tracking **off** → behaviour unchanged.
+4. Add Foul / Add Warning with no infraction → still refuse to save.
+5. `just check` clean.
+
+## Testing
+
+`penalty_gate_depends_only_on_the_player_number` sweeps the full cross-product of team
+(Black/White) × every `Infraction` variant × tracking on/off, asserting that a player number
+is sufficient in all 48 combinations and that its absence blocks in all 48. It replaces the
+three narrower tests that encoded the old rule.
+
+Mutation-checked: restoring the old condition fails the test with
+`a player number must be enough: Black, Unknown, tracking=true`.
+
+A team cannot be deselected on this page, so "team is required" is an invariant rather than a
+gate; the sweep covers both teams to pin that either one suffices.

--- a/refbox/src/app/view_builders/keypad_pages/penalty_edit.rs
+++ b/refbox/src/app/view_builders/keypad_pages/penalty_edit.rs
@@ -107,7 +107,7 @@ pub(super) fn make_penalty_edit_page<'a>(
             .style(green_button)
             .width(Length::Fill)
             .on_press_maybe(
-                penalty_edit_can_commit(infraction, track_fouls_and_warnings, player_num)
+                penalty_edit_can_commit(color, infraction, track_fouls_and_warnings, player_num)
                     .then_some(Message::PenaltyEditComplete {
                         canceled: false,
                         deleted: false,
@@ -163,45 +163,60 @@ pub(super) fn make_penalty_edit_page<'a>(
     content.into()
 }
 
-/// Returns true when the penalty entry can be saved: a player number is always
-/// required (penalties are always individual). The infraction is required only
-/// when "track fouls & warnings" is on — that is exactly when the infraction
-/// picker is shown on this screen.
+/// Returns true when the penalty entry can be saved. A player number is the
+/// only requirement — penalties are always individual, and a team is always
+/// selected on this page (`KeypadPage::Penalty` carries a plain `GameColor`,
+/// so one of Black/White is highlighted from the moment the page opens).
+///
+/// The infraction is deliberately optional, even with "track fouls & warnings"
+/// on and the picker visible. A penalty's essential content is the player and
+/// the duration — poolside the exclusion clock may need to start before the
+/// reason is settled — whereas a foul or warning is nothing but its infraction,
+/// so those pages do still require one (`foul_add_can_commit`,
+/// `warning_add_can_commit`). An infraction-less penalty is not a new state
+/// either: it is what this page has always produced with tracking off, and
+/// `Infraction::Unknown` is the enum's default, handled throughout.
+///
+/// The team, infraction, and tracking flag stay in the signature — the whole of
+/// the page's state that could plausibly gate saving — even though the rule
+/// ignores them. That is what lets `penalty_gate_depends_only_on_the_player_number`
+/// pin their irrelevance, so reintroducing any of them fails a test rather than
+/// silently re-blocking the operator.
 fn penalty_edit_can_commit(
-    infraction: Infraction,
-    track_fouls_and_warnings: bool,
+    _color: GameColor,
+    _infraction: Infraction,
+    _track_fouls_and_warnings: bool,
     player_num: u32,
 ) -> bool {
-    player_num > 0 && (!track_fouls_and_warnings || !matches!(infraction, Infraction::Unknown))
+    player_num > 0
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use enum_iterator::all;
 
     #[test]
-    fn penalty_needs_number() {
-        // Tracking off: only a number is required.
-        assert!(!penalty_edit_can_commit(Infraction::Unknown, false, 0));
-        assert!(penalty_edit_can_commit(Infraction::Unknown, false, 5));
-    }
-
-    #[test]
-    fn penalty_needs_infraction_when_tracking_on() {
-        assert!(!penalty_edit_can_commit(Infraction::Unknown, true, 5));
-        assert!(penalty_edit_can_commit(
-            Infraction::StickInfringement,
-            true,
-            5
-        ));
-    }
-
-    #[test]
-    fn penalty_tracking_on_still_needs_number() {
-        assert!(!penalty_edit_can_commit(
-            Infraction::StickInfringement,
-            true,
-            0
-        ));
+    fn penalty_gate_depends_only_on_the_player_number() {
+        // Across every combination of team, infraction (including one already
+        // picked, and every real infraction — not just Unknown), and the
+        // fouls-and-warnings toggle: a player number is sufficient on its own,
+        // and its absence is the only thing that blocks saving.
+        for color in [GameColor::Black, GameColor::White] {
+            for infraction in all::<Infraction>() {
+                for tracking in [false, true] {
+                    assert!(
+                        penalty_edit_can_commit(color, infraction, tracking, 5),
+                        "a player number must be enough: \
+                         {color:?}, {infraction:?}, tracking={tracking}"
+                    );
+                    assert!(
+                        !penalty_edit_can_commit(color, infraction, tracking, 0),
+                        "no player number must block saving: \
+                         {color:?}, {infraction:?}, tracking={tracking}"
+                    );
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## What changed

On the penalty page, the **DONE** button used to require a player number *and* — whenever "track fouls and warnings" was on — an infraction. It now requires only the player number. The infraction picker is unchanged and still shown; choosing one is simply no longer a precondition for saving.

Applies to adding a new penalty and editing an existing one, since both use the same page.

## Why

Poolside the operator may need the exclusion clock running before the reason has been settled, and the old gate blocked that.

Fouls and warnings still require an infraction, and that asymmetry is deliberate: a foul or warning is nothing but its infraction, so a blank one records no information at all, whereas a penalty's essential content is the player and the duration.

## Scope

Changes are limited to `refbox/src/app/view_builders/keypad_pages/penalty_edit.rs` — the `penalty_edit_can_commit` gate, its call site, and its tests. No translation changes, no changes to how penalties are stored, displayed, printed, or sent to the portal.

**Why this is low-risk:** a penalty with no infraction is not a new state. It is what this page has always produced with tracking off; tracking is a settings toggle that can be flipped at any time, so "no infraction, tracking on" was already reachable. `Infraction::Unknown` is the enum's default variant and is handled everywhere downstream. The penalty list rows do not render the infraction at all.

**Note on naming:** the button gated here is the penalty page's DONE button. The APPLY button on the penalties *overview* commits the whole pending list and is not affected.

## How to verify

1. Turn "track fouls and warnings" **on**.
2. Open the penalty page: pick a team, enter a player number, pick a duration, and leave the infraction grid untouched — DONE should be enabled, and the penalty should save.
3. Clear the player number — DONE should grey out again.
4. Turn tracking **off** — behaviour should be unchanged.
5. Confirm **Add Foul** and **Add Warning** with no infraction still refuse to save.

`just check` passes locally. `penalty_gate_depends_only_on_the_player_number` sweeps all 48 combinations of team x infraction x tracking, asserting a player number is sufficient in every one and that its absence is the only blocker. The gate keeps the team, infraction, and tracking flag as deliberately-ignored parameters precisely so that irrelevance is assertable — restoring the old condition fails the test with `a player number must be enough: Black, Unknown, tracking=true`.