### PR TITLE
feat(refbox): add court-length presets to the beep test

### DIFF
--- a/refbox/src/app/message.rs
+++ b/refbox/src/app/message.rs
@@ -1,5 +1,6 @@
 use super::{fl, languages::Language};
 use crate::{
+    config::BeepTestPreset,
     portal_manager::{ItemId, PortalEvent},
     sound_controller::{BuzzerSound, RemoteId},
     tournament_manager::{TournamentManager, penalty::PenaltyKind},
@@ -247,6 +248,10 @@ pub enum Message {
     /// Operator pressed `[REMOVE LEVEL]` on the Edit Levels page; removes
     /// the currently-selected level. No-op when only one level remains.
     BeepTestEditRemoveLevel,
+    /// Operator tapped a court-length preset on the BeepTest Edit Levels
+    /// sub-page. Replaces the staged levels with that preset's schedule; the
+    /// page's existing Apply footer commits it.
+    BeepTestEditSelectPreset(BeepTestPreset),
     /// Operator pressed Save on the Edit Levels page. Commits the staged
     /// level list to live config, persists to disk, and returns to the
     /// BeepTest Settings landing.
@@ -415,6 +420,7 @@ impl Message {
             | Self::BeepTestEditDurationDec
             | Self::BeepTestEditAddLevel
             | Self::BeepTestEditRemoveLevel
+            | Self::BeepTestEditSelectPreset(_)
             | Self::BeepTestEditLevelsSave
             | Self::BeepTestEditLevelsCancel
             | Self::BeepTestEditOpenBuzzer
@@ -646,6 +652,7 @@ impl PartialEq for Message {
             (Self::ConfirmationSelected(a), Self::ConfirmationSelected(b)) => a == b,
             (Self::PowerAction(a), Self::PowerAction(b)) => a == b,
             (Self::BeepTestEditSelectLevel(a), Self::BeepTestEditSelectLevel(b)) => a == b,
+            (Self::BeepTestEditSelectPreset(a), Self::BeepTestEditSelectPreset(b)) => a == b,
             (Self::TeamTimeout(a, b), Self::TeamTimeout(c, d)) => a == c && b == d,
             (Self::RefTimeout(a), Self::RefTimeout(b)) => a == b,
             (Self::PenaltyShot(a), Self::PenaltyShot(b)) => a == b,
@@ -759,6 +766,7 @@ impl PartialEq for Message {
             | (Self::BeepTestEditDurationDec, _)
             | (Self::BeepTestEditAddLevel, _)
             | (Self::BeepTestEditRemoveLevel, _)
+            | (Self::BeepTestEditSelectPreset(_), _)
             | (Self::BeepTestEditLevelsSave, _)
             | (Self::BeepTestEditLevelsCancel, _)
             | (Self::BeepTestEditOpenBuzzer, _)

--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -4945,6 +4945,9 @@ impl RefBoxApp {
                 // like any other on this page — the Apply footer commits it and
                 // Cancel discards it. Selection returns to the first level
                 // because the previously-selected index may no longer exist.
+                // preset.config() also returns `pre` (the warm-up), which is
+                // discarded here: `pre` isn't operator-editable anywhere and is
+                // 10 seconds for all three presets, so only `levels` is staged.
                 if let Some(ref mut edited) = self.edited_settings {
                     if edited.beep_test_levels.is_some() {
                         edited.beep_test_levels = Some(preset.config().levels);

--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -4912,7 +4912,7 @@ impl RefBoxApp {
             Message::BeepTestEditAddLevel => {
                 if let Some(ref mut edited) = self.edited_settings {
                     if let Some(ref mut levels) = edited.beep_test_levels {
-                        if levels.len() < 15 {
+                        if levels.len() < MAX_LEVELS {
                             let new_level = levels
                                 .get(edited.selected_level)
                                 .cloned()
@@ -4936,6 +4936,19 @@ impl RefBoxApp {
                             levels.remove(sel);
                             edited.selected_level = sel.saturating_sub(1);
                         }
+                    }
+                }
+                Task::none()
+            }
+            Message::BeepTestEditSelectPreset(preset) => {
+                // Replace the staged levels wholesale. This is a staged edit
+                // like any other on this page — the Apply footer commits it and
+                // Cancel discards it. Selection returns to the first level
+                // because the previously-selected index may no longer exist.
+                if let Some(ref mut edited) = self.edited_settings {
+                    if edited.beep_test_levels.is_some() {
+                        edited.beep_test_levels = Some(preset.config().levels);
+                        edited.selected_level = 0;
                     }
                 }
                 Task::none()

--- a/refbox/src/app/view_builders/beep_test.rs
+++ b/refbox/src/app/view_builders/beep_test.rs
@@ -199,7 +199,7 @@ fn build_levels_table(
             column_states[col_idx],
         ));
     }
-    for _ in levels.len()..15 {
+    for _ in levels.len()..MAX_LEVELS {
         header_row = header_row.push(filler_cell());
     }
     rows = rows.push(header_row);
@@ -232,7 +232,7 @@ fn build_levels_table(
                 cell_row = cell_row.push(filler_cell());
             }
         }
-        for _ in levels.len()..15 {
+        for _ in levels.len()..MAX_LEVELS {
             cell_row = cell_row.push(filler_cell());
         }
         rows = rows.push(cell_row);

--- a/refbox/src/app/view_builders/beep_test_settings.rs
+++ b/refbox/src/app/view_builders/beep_test_settings.rs
@@ -320,8 +320,9 @@ const EDIT_TABLE_CELL_HEIGHT: f32 = (MIN_BUTTON_SIZE - SPACING) / 2.0;
 /// selected column is highlighted with a distinct (blue) style to
 /// distinguish it from the main view's yellow "active lap" highlight. The
 /// table reserves `MAX_LEVELS` columns but the presets use only 7, so a
-/// fixed strip to its right holds the three preset buttons — the one whose
-/// schedule matches the staged levels renders highlighted; see
+/// fixed strip to its right holds the six preset buttons (a referee and a
+/// full schedule per court length, in a 2-column by 3-row grid) — the one
+/// whose schedule matches the staged levels renders highlighted; see
 /// `build_preset_panel`.
 ///
 /// Bottom middle: a per-level edit panel showing the selected level's
@@ -376,8 +377,10 @@ pub(in super::super) fn build_beep_test_edit_levels_page<'a>(
     .into()
 }
 
-/// The court-length preset buttons, stacked in the strip to the right of the
-/// levels table.
+/// The court-length preset buttons, arranged in a 2-column by 3-row grid in
+/// the strip to the right of the levels table: the referee (26-lap) preset
+/// on the left, the full (37-lap) preset on the right, one row per court
+/// length, ordered 25 / 23 / 21.
 ///
 /// The preset whose schedule matches the staged levels is highlighted with the
 /// same blue the selected-level column uses, so the screen reads back which
@@ -385,25 +388,49 @@ pub(in super::super) fn build_beep_test_edit_levels_page<'a>(
 /// levels stop matching, and the highlight drops on the next render — that is
 /// the whole mechanism, no separate "edited" flag is needed.
 fn build_preset_panel(levels: &[Level]) -> Element<'_, Message> {
-    let active = crate::config::BeepTestPreset::detect_levels(levels);
+    use crate::config::BeepTestPreset;
 
-    let mut col = Column::new().spacing(SPACING).width(Length::Fill);
-    for preset in crate::config::BeepTestPreset::ALL {
+    let active = BeepTestPreset::detect_levels(levels);
+
+    let preset_button = move |preset: BeepTestPreset| {
         let style = if Some(preset) == active {
             blue_selected_button
         } else {
             light_gray_button
         };
-        col = col.push(
-            button(centered_text(format!("{}M", preset.metres())))
-                .style(style)
-                .padding(PADDING)
-                .width(Length::Fill)
-                .height(Length::Fixed(XS_BUTTON_SIZE))
-                .on_press(Message::BeepTestEditSelectPreset(preset)),
-        );
-    }
-    col.into()
+        let label = if preset.is_ref() {
+            format!("{} {}M", fl!("beep-test-preset-ref"), preset.metres())
+        } else {
+            format!("{}M", preset.metres())
+        };
+        button(centered_text(label))
+            .style(style)
+            .padding(PADDING)
+            .width(Length::Fill)
+            .height(Length::Fixed(XS_BUTTON_SIZE))
+            .on_press(Message::BeepTestEditSelectPreset(preset))
+    };
+
+    column![
+        row![
+            preset_button(BeepTestPreset::Ref25),
+            preset_button(BeepTestPreset::Full25),
+        ]
+        .spacing(SPACING),
+        row![
+            preset_button(BeepTestPreset::Ref23),
+            preset_button(BeepTestPreset::Full23),
+        ]
+        .spacing(SPACING),
+        row![
+            preset_button(BeepTestPreset::Ref21),
+            preset_button(BeepTestPreset::Full21),
+        ]
+        .spacing(SPACING),
+    ]
+    .spacing(SPACING)
+    .width(Length::Fill)
+    .into()
 }
 
 /// Build the editor's transposed levels table. Mirrors the main view's

--- a/refbox/src/app/view_builders/beep_test_settings.rs
+++ b/refbox/src/app/view_builders/beep_test_settings.rs
@@ -292,9 +292,12 @@ pub(in super::super) fn build_beep_test_sound_settings_page<'a>(
     .into()
 }
 
-/// Maximum number of levels a schedule may contain. The table reserves exactly
-/// this many columns, which leaves a fixed strip to the right of it for the
-/// court-length preset buttons. The presets themselves use 7.
+/// Maximum number of levels a schedule may contain. The table reserves
+/// exactly this many columns; the court-length preset strip is a separate,
+/// fixed-width column beside it (see `table_and_presets` in
+/// `build_beep_test_edit_levels_page`) and does not grow or shrink with this
+/// cap. This value matches the Full presets' level count (10) — see
+/// `BeepTestPreset::FULL_LAP_COUNTS` in `config.rs`.
 pub(in super::super) const MAX_LEVELS: usize = 10;
 
 /// Spacing between cells in the editor's transposed table. Matches the
@@ -319,11 +322,12 @@ const EDIT_TABLE_CELL_HEIGHT: f32 = (MIN_BUTTON_SIZE - SPACING) / 2.0;
 /// tappable: tapping any element in a column selects that level. The
 /// selected column is highlighted with a distinct (blue) style to
 /// distinguish it from the main view's yellow "active lap" highlight. The
-/// table reserves `MAX_LEVELS` columns but the presets use only 7, so a
-/// fixed strip to its right holds the six preset buttons (a referee and a
-/// full schedule per court length, in a 2-column by 3-row grid) — the one
-/// whose schedule matches the staged levels renders highlighted; see
-/// `build_preset_panel`.
+/// table reserves `MAX_LEVELS` columns (10, matching the Full presets),
+/// beside a fixed strip that holds the six preset buttons (a referee and a
+/// full schedule per court length — 8 and 10 levels respectively — in a
+/// 2-column by 3-row grid); that strip's width does not depend on
+/// `MAX_LEVELS`. The preset whose schedule matches the staged levels
+/// renders highlighted; see `build_preset_panel`.
 ///
 /// Bottom middle: a per-level edit panel showing the selected level's
 /// duration and count, each with `[-]` `[+]` buttons, and a `REMOVE
@@ -1117,4 +1121,29 @@ fn make_beep_test_cancel_apply_footer<'a>(
     row![cancel, horizontal_space(), apply]
         .spacing(SPACING)
         .into()
+}
+
+#[cfg(test)]
+mod test {
+    use super::MAX_LEVELS;
+    use crate::config::BeepTestPreset;
+
+    // BeepTestEditAddLevel enforces this cap at runtime (see
+    // Message::BeepTestEditAddLevel in app/mod.rs), but BeepTestEditSelectPreset
+    // does not — it stages a preset's levels wholesale and relies on every
+    // preset already fitting under the cap. That is safe only because Full is
+    // exactly MAX_LEVELS levels today; nothing else ties the two together, so
+    // this test is the guard against either constant changing out from under
+    // the other.
+    #[test]
+    fn every_preset_fits_within_max_levels() {
+        for preset in BeepTestPreset::ALL {
+            let levels = preset.config().levels;
+            assert!(
+                levels.len() <= MAX_LEVELS,
+                "{preset:?} has {} levels, which exceeds MAX_LEVELS ({MAX_LEVELS})",
+                levels.len()
+            );
+        }
+    }
 }

--- a/refbox/src/app/view_builders/beep_test_settings.rs
+++ b/refbox/src/app/view_builders/beep_test_settings.rs
@@ -352,14 +352,19 @@ pub(in super::super) fn build_beep_test_edit_levels_page<'a>(
     // ----- Per-level edit panel -----
     let edit_panel = build_edit_panel(levels, selected);
 
+    // Content stacks at the top with the standard SPACING between every row;
+    // the slack sits below it so the footer stays pinned to the bottom. This
+    // mirrors `build_beep_test_sound_settings_page`. Putting the spacer between
+    // the table and the edit panel instead would widen that one seam to three
+    // times the spacing used everywhere else on the page.
     column![
         container(table_and_presets)
             .width(Length::Fill)
             .height(Length::Shrink),
-        row![horizontal_space()].height(Length::Fill),
         container(edit_panel)
             .width(Length::Fill)
             .height(Length::Shrink),
+        row![horizontal_space()].height(Length::Fill),
         make_beep_test_cancel_apply_footer(
             Message::BeepTestEditLevelsCancel,
             Message::BeepTestEditLevelsSave,

--- a/refbox/src/app/view_builders/beep_test_settings.rs
+++ b/refbox/src/app/view_builders/beep_test_settings.rs
@@ -292,6 +292,11 @@ pub(in super::super) fn build_beep_test_sound_settings_page<'a>(
     .into()
 }
 
+/// Maximum number of levels a schedule may contain. The table reserves exactly
+/// this many columns, which leaves a fixed strip to the right of it for the
+/// court-length preset buttons. The presets themselves use 7.
+pub(in super::super) const MAX_LEVELS: usize = 10;
+
 /// Spacing between cells in the editor's transposed table. Matches the
 /// main view's TABLE_CELL_SPACING so the editor reads as a tight grid.
 const EDIT_TABLE_CELL_SPACING: f32 = 2.0;
@@ -303,16 +308,21 @@ const EDIT_TABLE_CELL_HEIGHT: f32 = (MIN_BUTTON_SIZE - SPACING) / 2.0;
 
 /// Edit Levels sub-page.
 ///
-/// Standard refbox column layout: the transposed levels table + per-level
-/// edit panel in the middle (sized proportionally), and a Cancel / Apply
-/// footer at the bottom. Apply disables when the staged levels match the
-/// live config.
+/// Standard refbox column layout: the transposed levels table (with the
+/// court-length preset buttons in the strip to its right) + per-level edit
+/// panel in the middle (sized proportionally), and a Cancel / Apply footer
+/// at the bottom. Apply disables when the staged levels match the live
+/// config.
 ///
 /// Top middle: the same transposed level table from the main view, plus
 /// an extra `[+NEW]` header at the end. Every header and every cell is
 /// tappable: tapping any element in a column selects that level. The
 /// selected column is highlighted with a distinct (blue) style to
-/// distinguish it from the main view's yellow "active lap" highlight.
+/// distinguish it from the main view's yellow "active lap" highlight. The
+/// table reserves `MAX_LEVELS` columns but the presets use only 7, so a
+/// fixed strip to its right holds the three preset buttons — the one whose
+/// schedule matches the staged levels renders highlighted; see
+/// `build_preset_panel`.
 ///
 /// Bottom middle: a per-level edit panel showing the selected level's
 /// duration and count, each with `[-]` `[+]` buttons, and a `REMOVE
@@ -330,14 +340,22 @@ pub(in super::super) fn build_beep_test_edit_levels_page<'a>(
 
     let has_changes = config.beep_test.levels.as_slice() != levels;
 
-    // ----- Transposed table with tappable headers + cells -----
-    let table = build_editor_levels_table(levels, selected);
+    // ----- Transposed table, with the preset buttons in the strip to its right -----
+    let table_and_presets = row![
+        container(build_editor_levels_table(levels, selected)).width(Length::FillPortion(10)),
+        container(build_preset_panel(levels))
+            .width(Length::FillPortion(5))
+            .padding(EDIT_TABLE_CELL_SPACING),
+    ]
+    .spacing(SPACING);
 
     // ----- Per-level edit panel -----
     let edit_panel = build_edit_panel(levels, selected);
 
     column![
-        container(table).width(Length::Fill).height(Length::Shrink),
+        container(table_and_presets)
+            .width(Length::Fill)
+            .height(Length::Shrink),
         row![horizontal_space()].height(Length::Fill),
         container(edit_panel)
             .width(Length::Fill)
@@ -351,6 +369,36 @@ pub(in super::super) fn build_beep_test_edit_levels_page<'a>(
     .spacing(SPACING)
     .height(Length::Fill)
     .into()
+}
+
+/// The court-length preset buttons, stacked in the strip to the right of the
+/// levels table.
+///
+/// The preset whose schedule matches the staged levels is highlighted with the
+/// same blue the selected-level column uses, so the screen reads back which
+/// schedule is loaded. Hand-editing any time or lap count makes the staged
+/// levels stop matching, and the highlight drops on the next render — that is
+/// the whole mechanism, no separate "edited" flag is needed.
+fn build_preset_panel(levels: &[Level]) -> Element<'_, Message> {
+    let active = crate::config::BeepTestPreset::detect_levels(levels);
+
+    let mut col = Column::new().spacing(SPACING).width(Length::Fill);
+    for preset in crate::config::BeepTestPreset::ALL {
+        let style = if Some(preset) == active {
+            blue_selected_button
+        } else {
+            light_gray_button
+        };
+        col = col.push(
+            button(centered_text(format!("{}M", preset.metres())))
+                .style(style)
+                .padding(PADDING)
+                .width(Length::Fill)
+                .height(Length::Fixed(XS_BUTTON_SIZE))
+                .on_press(Message::BeepTestEditSelectPreset(preset)),
+        );
+    }
+    col.into()
 }
 
 /// Build the editor's transposed levels table. Mirrors the main view's
@@ -373,7 +421,7 @@ fn build_editor_levels_table(levels: &[Level], selected: usize) -> Element<'_, M
             is_selected,
         ));
     }
-    for _ in levels.len()..15 {
+    for _ in levels.len()..MAX_LEVELS {
         header_row = header_row.push(filler_cell());
     }
     rows = rows.push(header_row);
@@ -395,7 +443,7 @@ fn build_editor_levels_table(levels: &[Level], selected: usize) -> Element<'_, M
                 cell_row = cell_row.push(filler_cell());
             }
         }
-        for _ in levels.len()..15 {
+        for _ in levels.len()..MAX_LEVELS {
             cell_row = cell_row.push(filler_cell());
         }
         rows = rows.push(cell_row);
@@ -483,7 +531,7 @@ fn build_edit_panel(levels: &[Level], selected: usize) -> Element<'_, Message> {
     // already at the cap. Mirrors the existing remove_disabled +
     // count_inc_disabled patterns; defense-in-depth in the handler at
     // Message::BeepTestEditAddLevel.
-    let add_disabled = levels.len() >= 15;
+    let add_disabled = levels.len() >= MAX_LEVELS;
 
     // Safe to index because the caller already clamped `selected` to be
     // in range. If the list is empty we fall through to a placeholder

--- a/refbox/src/beep_test/cadence.rs
+++ b/refbox/src/beep_test/cadence.rs
@@ -45,9 +45,9 @@ pub struct TournamentManager {
     lap_count: u8,
     time_in_next_lap: Duration,
     /// Set exactly when the schedule runs off its end — the final lap of the
-    /// final level completes, or the sprint's single lap completes. Consumed
-    /// by `take_completed`, which the app polls each tick to return the page
-    /// to its idle state without the operator pressing RESET.
+    /// final level completes. Consumed by `take_completed`, which the app
+    /// polls each tick to return the page to its idle state without the
+    /// operator pressing RESET.
     completed: bool,
 }
 

--- a/refbox/src/config.rs
+++ b/refbox/src/config.rs
@@ -122,7 +122,7 @@ pub struct BeepTest {
 /// The level times scale with court length: the 21m and 23m columns are the
 /// 25m times multiplied by 21/25 and 23/25 and rounded up, matching the
 /// adjusted tables the tournament uses.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BeepTestPreset {
     M25,
     M23,
@@ -189,31 +189,6 @@ impl Default for BeepTest {
 }
 
 impl BeepTest {
-    /// The incorrect 10-level table that shipped as the default before the
-    /// 26-lap correction: 5 laps at Level 9 and a 38-lap run. A config file
-    /// holding exactly this table is holding the old default rather than a
-    /// deliberate operator choice, so `migrate` replaces it.
-    fn legacy_default_levels() -> Vec<Level> {
-        [
-            (3u8, 36u64),
-            (3, 34),
-            (3, 32),
-            (4, 30),
-            (4, 28),
-            (4, 26),
-            (4, 24),
-            (4, 22),
-            (5, 20),
-            (4, 18),
-        ]
-        .iter()
-        .map(|&(count, secs)| Level {
-            count,
-            duration: std::time::Duration::from_secs(secs),
-        })
-        .collect()
-    }
-
     pub fn migrate(old: &Table) -> Self {
         let Self {
             mut pre,
@@ -234,11 +209,6 @@ impl BeepTest {
                     if let Some(table) = value.as_table() {
                         levels.push(Level::migrate(table))
                     }
-                }
-                // ...unless it is the old, incorrect shipped default, in which
-                // case carry the operator forward onto the corrected table.
-                if levels == Self::legacy_default_levels() {
-                    levels = BeepTestPreset::M25.config().levels;
                 }
             }
         }
@@ -598,39 +568,6 @@ mod test {
     #[test]
     fn default_is_the_25m_preset() {
         assert_eq!(BeepTest::default(), BeepTestPreset::M25.config());
-    }
-
-    // A config file still holding the old, incorrect 10-level default table
-    // (which had 5 laps at Level 9 and ran to 38 laps) is migrated to the
-    // corrected 25m preset. That exact table was never a deliberate operator
-    // choice — it was the shipped default — so replacing it is safe.
-    #[test]
-    fn migrate_replaces_legacy_default_table() {
-        let mut bt = toml::value::Table::new();
-        let legacy: Vec<toml::Value> = [
-            (3u8, 36u64),
-            (3, 34),
-            (3, 32),
-            (4, 30),
-            (4, 28),
-            (4, 26),
-            (4, 24),
-            (4, 22),
-            (5, 20),
-            (4, 18),
-        ]
-        .iter()
-        .map(|&(count, secs)| {
-            let mut t = toml::value::Table::new();
-            t.insert("count".to_string(), toml::Value::Integer(count.into()));
-            t.insert("duration".to_string(), toml::Value::Integer(secs as i64));
-            toml::Value::Table(t)
-        })
-        .collect();
-        bt.insert("levels".to_string(), toml::Value::Array(legacy));
-
-        let migrated = BeepTest::migrate(&bt);
-        assert_eq!(migrated.levels, BeepTestPreset::M25.config().levels);
     }
 
     // A genuinely hand-edited table is preserved untouched.

--- a/refbox/src/config.rs
+++ b/refbox/src/config.rs
@@ -114,10 +114,11 @@ pub struct BeepTest {
 
 /// Court-length presets for the beep test.
 ///
-/// Each preset defines a whole schedule: the warm-up and seven levels
+/// Each preset defines a whole schedule: the warm-up and eight levels
 /// totalling 26 laps. 26 is the passing lap count, and the lap counts are
-/// arranged (3, 3, 4, 4, 4, 4, 4) so that lap 26 is the final lap of Level 7
-/// — the test ends exactly on the pass mark.
+/// arranged (3, 3, 3, 4, 4, 4, 4, 1) so that lap 26 is Level 8's single lap
+/// — the test ends exactly on the pass mark, on the first lap of a level
+/// rather than the last lap of one.
 ///
 /// The level times scale with court length: the 21m and 23m columns are the
 /// 25m times multiplied by 21/25 and 23/25 and rounded up, matching the
@@ -134,7 +135,7 @@ impl BeepTestPreset {
 
     /// Laps per level. Identical for every court length — only the times
     /// change. Sums to 26.
-    const LAP_COUNTS: [u8; 7] = [3, 3, 4, 4, 4, 4, 4];
+    const LAP_COUNTS: [u8; 8] = [3, 3, 3, 4, 4, 4, 4, 1];
 
     /// Court length in metres, used for the DISTANCE tile's label.
     pub fn metres(self) -> u8 {
@@ -145,12 +146,12 @@ impl BeepTestPreset {
         }
     }
 
-    /// The seven level durations in seconds, Level 1 first.
-    fn level_secs(self) -> [u64; 7] {
+    /// The eight level durations in seconds, Level 1 first.
+    fn level_secs(self) -> [u64; 8] {
         match self {
-            Self::M25 => [36, 34, 32, 30, 28, 26, 24],
-            Self::M23 => [34, 32, 30, 28, 26, 24, 23],
-            Self::M21 => [31, 29, 27, 26, 24, 22, 21],
+            Self::M25 => [36, 34, 32, 30, 28, 26, 24, 22],
+            Self::M23 => [34, 32, 30, 28, 26, 24, 23, 21],
+            Self::M21 => [31, 29, 27, 26, 24, 22, 21, 19],
         }
     }
 
@@ -466,13 +467,13 @@ mod test {
         );
     }
 
-    // Every preset ends on lap 26 — the passing lap — with lap 26 the final
-    // lap of Level 7. This is the invariant the whole feature rests on.
+    // Every preset ends on lap 26 — the passing lap — with lap 26 the single
+    // lap of Level 8. This is the invariant the whole feature rests on.
     #[test]
     fn every_preset_ends_on_lap_26() {
         for preset in BeepTestPreset::ALL {
             let config = preset.config();
-            assert_eq!(config.levels.len(), 7, "{preset:?} has 7 levels");
+            assert_eq!(config.levels.len(), 8, "{preset:?} has 8 levels");
             let laps: u32 = config.levels.iter().map(|l| u32::from(l.count)).sum();
             assert_eq!(laps, 26, "{preset:?} totals 26 laps");
         }
@@ -481,19 +482,19 @@ mod test {
     // Lap counts are identical across court lengths — only the times scale.
     #[test]
     fn preset_lap_counts_are_identical() {
-        let expected: Vec<u8> = vec![3, 3, 4, 4, 4, 4, 4];
+        let expected: Vec<u8> = vec![3, 3, 3, 4, 4, 4, 4, 1];
         for preset in BeepTestPreset::ALL {
             let counts: Vec<u8> = preset.config().levels.iter().map(|l| l.count).collect();
             assert_eq!(counts, expected, "{preset:?} lap counts");
         }
     }
 
-    // The confirmed 25m table, including its 13:00 total run time.
+    // The confirmed 25m table, including its total run time.
     #[test]
     fn preset_25m_matches_confirmed_table() {
         let config = BeepTestPreset::M25.config();
         let secs: Vec<u64> = config.levels.iter().map(|l| l.duration.as_secs()).collect();
-        assert_eq!(secs, vec![36, 34, 32, 30, 28, 26, 24]);
+        assert_eq!(secs, vec![36, 34, 32, 30, 28, 26, 24, 22]);
         assert_eq!(config.pre, std::time::Duration::from_secs(10));
 
         let total: u64 = config.pre.as_secs()
@@ -502,7 +503,7 @@ mod test {
                 .iter()
                 .map(|l| l.duration.as_secs() * u64::from(l.count))
                 .sum::<u64>();
-        assert_eq!(total, 780, "25m run is 13:00 including the warm-up");
+        assert_eq!(total, 770, "25m run is 12:50 including the warm-up");
     }
 
     // The confirmed 21m table, read off the operator's sheet.
@@ -510,7 +511,7 @@ mod test {
     fn preset_21m_matches_confirmed_table() {
         let config = BeepTestPreset::M21.config();
         let secs: Vec<u64> = config.levels.iter().map(|l| l.duration.as_secs()).collect();
-        assert_eq!(secs, vec![31, 29, 27, 26, 24, 22, 21]);
+        assert_eq!(secs, vec![31, 29, 27, 26, 24, 22, 21, 19]);
     }
 
     // 23m has no official table — it is DEFINED as ceil(25m x 0.92), the same

--- a/refbox/src/config.rs
+++ b/refbox/src/config.rs
@@ -120,6 +120,12 @@ pub struct BeepTest {
 /// it; every level after that one is dropped. General on purpose — it does
 /// not know or care which level index or lap count that turns out to be,
 /// so it works unchanged for any full schedule and any target.
+///
+/// Callers must pass a non-zero `target`: `target = 0` returns an empty
+/// `Vec<Level>` (nothing to keep), and downstream code does not accept an
+/// empty schedule — `TournamentManager::start_beep_test_now` in
+/// `beep_test/cadence.rs` expects `Level(0)` to have a duration precisely
+/// because it assumes `config.levels` is non-empty.
 fn truncate_at_laps(levels: &[Level], target: u8) -> Vec<Level> {
     let mut out = Vec::new();
     let mut total: u8 = 0;
@@ -595,6 +601,59 @@ mod test {
         }
     }
 
+    // truncate_at_laps is only ever called with PASSING_LAPS in production,
+    // so its general behaviour (documented above the function) is exercised
+    // directly here rather than only indirectly through the preset tests.
+    #[test]
+    fn truncate_at_laps_stops_exactly_on_a_level_boundary() {
+        let levels = vec![
+            Level {
+                count: 3,
+                duration: Duration::from_secs(10),
+            },
+            Level {
+                count: 4,
+                duration: Duration::from_secs(20),
+            },
+            Level {
+                count: 5,
+                duration: Duration::from_secs(30),
+            },
+        ];
+        // 3 + 4 = 7 lands exactly on the boundary between level 2 and level 3.
+        let truncated = truncate_at_laps(&levels, 7);
+        assert_eq!(truncated.len(), 2);
+        assert_eq!(truncated[0].count, 3);
+        assert_eq!(truncated[1].count, 4);
+    }
+
+    #[test]
+    fn truncate_at_laps_with_target_past_the_total_returns_everything() {
+        let levels = vec![
+            Level {
+                count: 3,
+                duration: Duration::from_secs(10),
+            },
+            Level {
+                count: 4,
+                duration: Duration::from_secs(20),
+            },
+        ];
+        // Total laps available is 7; ask for far more than that.
+        let truncated = truncate_at_laps(&levels, 100);
+        assert_eq!(truncated, levels);
+    }
+
+    #[test]
+    fn truncate_at_laps_with_zero_target_returns_an_empty_schedule() {
+        let levels = vec![Level {
+            count: 3,
+            duration: Duration::from_secs(10),
+        }];
+        let truncated = truncate_at_laps(&levels, 0);
+        assert_eq!(truncated, vec![]);
+    }
+
     // 23m has no official table — it is DEFINED as ceil(25m x 0.92), the same
     // method the official 21m table documents for itself (ceil(25m x 0.84)).
     // This test enforces the derivation across the whole 10-level full
@@ -681,6 +740,11 @@ mod test {
             total_secs(&BeepTestPreset::Ref25.config()),
             770,
             "Ref 25m run is 12:50 including the warm-up"
+        );
+        assert_eq!(
+            total_secs(&BeepTestPreset::Ref23.config()),
+            723,
+            "Ref 23m run is 12:03 including the warm-up"
         );
         // EXTERNAL CHECK: the official 21m sheet prints lap 27's start time
         // as 11:02 — the exact instant lap 26 (the pass mark) finishes.

--- a/refbox/src/config.rs
+++ b/refbox/src/config.rs
@@ -112,57 +112,110 @@ pub struct BeepTest {
     pub levels: Vec<Level>,
 }
 
+/// Court-length presets for the beep test.
+///
+/// Each preset defines a whole schedule: the warm-up and seven levels
+/// totalling 26 laps. 26 is the passing lap count, and the lap counts are
+/// arranged (3, 3, 4, 4, 4, 4, 4) so that lap 26 is the final lap of Level 7
+/// — the test ends exactly on the pass mark.
+///
+/// The level times scale with court length: the 21m and 23m columns are the
+/// 25m times multiplied by 21/25 and 23/25 and rounded up, matching the
+/// adjusted tables the tournament uses.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum BeepTestPreset {
+    M25,
+    M23,
+    M21,
+}
+
+// Wired up by the EDIT LEVELS preset buttons in the next task.
+#[allow(dead_code)]
+impl BeepTestPreset {
+    pub const ALL: [Self; 3] = [Self::M25, Self::M23, Self::M21];
+
+    /// Laps per level. Identical for every court length — only the times
+    /// change. Sums to 26.
+    const LAP_COUNTS: [u8; 7] = [3, 3, 4, 4, 4, 4, 4];
+
+    /// Court length in metres, used for the DISTANCE tile's label.
+    pub fn metres(self) -> u8 {
+        match self {
+            Self::M25 => 25,
+            Self::M23 => 23,
+            Self::M21 => 21,
+        }
+    }
+
+    /// The seven level durations in seconds, Level 1 first.
+    fn level_secs(self) -> [u64; 7] {
+        match self {
+            Self::M25 => [36, 34, 32, 30, 28, 26, 24],
+            Self::M23 => [34, 32, 30, 28, 26, 24, 23],
+            Self::M21 => [31, 29, 27, 26, 24, 22, 21],
+        }
+    }
+
+    /// The complete beep-test configuration for this court length.
+    pub fn config(self) -> BeepTest {
+        BeepTest {
+            pre: std::time::Duration::from_secs(10),
+            levels: Self::LAP_COUNTS
+                .iter()
+                .zip(self.level_secs())
+                .map(|(&count, secs)| Level {
+                    count,
+                    duration: std::time::Duration::from_secs(secs),
+                })
+                .collect(),
+        }
+    }
+
+    /// Which preset the given staged level list matches, if any.
+    ///
+    /// The EDIT LEVELS screen stages only the levels — not the whole config —
+    /// so detection compares level lists rather than configs. `None` means the
+    /// operator has hand-edited the schedule, and the screen highlights no
+    /// preset.
+    pub fn detect_levels(levels: &[Level]) -> Option<Self> {
+        Self::ALL
+            .into_iter()
+            .find(|p| p.config().levels.as_slice() == levels)
+    }
+}
+
 impl Default for BeepTest {
     fn default() -> Self {
-        Self {
-            pre: std::time::Duration::from_secs(10),
-            levels: vec![
-                Level {
-                    count: 3,
-                    duration: std::time::Duration::from_secs(36),
-                },
-                Level {
-                    count: 3,
-                    duration: std::time::Duration::from_secs(34),
-                },
-                Level {
-                    count: 3,
-                    duration: std::time::Duration::from_secs(32),
-                },
-                Level {
-                    count: 4,
-                    duration: std::time::Duration::from_secs(30),
-                },
-                Level {
-                    count: 4,
-                    duration: std::time::Duration::from_secs(28),
-                },
-                Level {
-                    count: 4,
-                    duration: std::time::Duration::from_secs(26),
-                },
-                Level {
-                    count: 4,
-                    duration: std::time::Duration::from_secs(24),
-                },
-                Level {
-                    count: 4,
-                    duration: std::time::Duration::from_secs(22),
-                },
-                Level {
-                    count: 5,
-                    duration: std::time::Duration::from_secs(20),
-                },
-                Level {
-                    count: 4,
-                    duration: std::time::Duration::from_secs(18),
-                },
-            ],
-        }
+        BeepTestPreset::M25.config()
     }
 }
 
 impl BeepTest {
+    /// The incorrect 10-level table that shipped as the default before the
+    /// 26-lap correction: 5 laps at Level 9 and a 38-lap run. A config file
+    /// holding exactly this table is holding the old default rather than a
+    /// deliberate operator choice, so `migrate` replaces it.
+    fn legacy_default_levels() -> Vec<Level> {
+        [
+            (3u8, 36u64),
+            (3, 34),
+            (3, 32),
+            (4, 30),
+            (4, 28),
+            (4, 26),
+            (4, 24),
+            (4, 22),
+            (5, 20),
+            (4, 18),
+        ]
+        .iter()
+        .map(|&(count, secs)| Level {
+            count,
+            duration: std::time::Duration::from_secs(secs),
+        })
+        .collect()
+    }
+
     pub fn migrate(old: &Table) -> Self {
         let Self {
             mut pre,
@@ -183,6 +236,11 @@ impl BeepTest {
                     if let Some(table) = value.as_table() {
                         levels.push(Level::migrate(table))
                     }
+                }
+                // ...unless it is the old, incorrect shipped default, in which
+                // case carry the operator forward onto the corrected table.
+                if levels == Self::legacy_default_levels() {
+                    levels = BeepTestPreset::M25.config().levels;
                 }
             }
         }
@@ -437,6 +495,164 @@ mod test {
         assert_eq!(
             config.beep_test.levels[0].duration,
             std::time::Duration::from_secs(15)
+        );
+    }
+
+    // Every preset ends on lap 26 — the passing lap — with lap 26 the final
+    // lap of Level 7. This is the invariant the whole feature rests on.
+    #[test]
+    fn every_preset_ends_on_lap_26() {
+        for preset in BeepTestPreset::ALL {
+            let config = preset.config();
+            assert_eq!(config.levels.len(), 7, "{preset:?} has 7 levels");
+            let laps: u32 = config.levels.iter().map(|l| u32::from(l.count)).sum();
+            assert_eq!(laps, 26, "{preset:?} totals 26 laps");
+        }
+    }
+
+    // Lap counts are identical across court lengths — only the times scale.
+    #[test]
+    fn preset_lap_counts_are_identical() {
+        let expected: Vec<u8> = vec![3, 3, 4, 4, 4, 4, 4];
+        for preset in BeepTestPreset::ALL {
+            let counts: Vec<u8> = preset.config().levels.iter().map(|l| l.count).collect();
+            assert_eq!(counts, expected, "{preset:?} lap counts");
+        }
+    }
+
+    // The confirmed 25m table, including its 13:00 total run time.
+    #[test]
+    fn preset_25m_matches_confirmed_table() {
+        let config = BeepTestPreset::M25.config();
+        let secs: Vec<u64> = config.levels.iter().map(|l| l.duration.as_secs()).collect();
+        assert_eq!(secs, vec![36, 34, 32, 30, 28, 26, 24]);
+        assert_eq!(config.pre, std::time::Duration::from_secs(10));
+
+        let total: u64 = config.pre.as_secs()
+            + config
+                .levels
+                .iter()
+                .map(|l| l.duration.as_secs() * u64::from(l.count))
+                .sum::<u64>();
+        assert_eq!(total, 780, "25m run is 13:00 including the warm-up");
+    }
+
+    // The confirmed 21m table, read off the operator's sheet.
+    #[test]
+    fn preset_21m_matches_confirmed_table() {
+        let config = BeepTestPreset::M21.config();
+        let secs: Vec<u64> = config.levels.iter().map(|l| l.duration.as_secs()).collect();
+        assert_eq!(secs, vec![31, 29, 27, 26, 24, 22, 21]);
+    }
+
+    // 23m has no official table — it is DEFINED as ceil(25m x 0.92), the same
+    // method the official 21m table documents for itself (ceil(25m x 0.84)).
+    // This test enforces the derivation, so the numbers cannot drift away from
+    // the rule that produced them. 21m is included to prove the rule holds for
+    // the column we can check against a real sheet.
+    #[test]
+    fn shorter_court_durations_are_the_25m_table_scaled_and_rounded_up() {
+        let base = BeepTestPreset::M25;
+        for (preset, ratio) in [
+            (BeepTestPreset::M23, 0.92_f64),
+            (BeepTestPreset::M21, 0.84_f64),
+        ] {
+            for (i, (short, long)) in preset
+                .config()
+                .levels
+                .iter()
+                .zip(base.config().levels.iter())
+                .enumerate()
+            {
+                let expected = (long.duration.as_secs() as f64 * ratio).ceil() as u64;
+                assert_eq!(
+                    short.duration.as_secs(),
+                    expected,
+                    "{preset:?} level {} should be ceil({}s x {ratio})",
+                    i + 1,
+                    long.duration.as_secs()
+                );
+            }
+        }
+    }
+
+    // detect_levels is the inverse of config().levels: it recognises each
+    // preset exactly and returns None for a hand-edited schedule. This drives
+    // which preset button is highlighted on the EDIT LEVELS screen.
+    #[test]
+    fn detect_levels_round_trips_and_rejects_custom() {
+        for preset in BeepTestPreset::ALL {
+            assert_eq!(
+                BeepTestPreset::detect_levels(&preset.config().levels),
+                Some(preset)
+            );
+        }
+        let mut custom = BeepTestPreset::M25.config().levels;
+        custom[0].duration = std::time::Duration::from_secs(35);
+        assert_eq!(BeepTestPreset::detect_levels(&custom), None);
+
+        // A truncated list must not match — a prefix is not the schedule.
+        let short = &BeepTestPreset::M25.config().levels[..3];
+        assert_eq!(BeepTestPreset::detect_levels(short), None);
+    }
+
+    // The built-in default is the 25m preset.
+    #[test]
+    fn default_is_the_25m_preset() {
+        assert_eq!(BeepTest::default(), BeepTestPreset::M25.config());
+    }
+
+    // A config file still holding the old, incorrect 10-level default table
+    // (which had 5 laps at Level 9 and ran to 38 laps) is migrated to the
+    // corrected 25m preset. That exact table was never a deliberate operator
+    // choice — it was the shipped default — so replacing it is safe.
+    #[test]
+    fn migrate_replaces_legacy_default_table() {
+        let mut bt = toml::value::Table::new();
+        let legacy: Vec<toml::Value> = [
+            (3u8, 36u64),
+            (3, 34),
+            (3, 32),
+            (4, 30),
+            (4, 28),
+            (4, 26),
+            (4, 24),
+            (4, 22),
+            (5, 20),
+            (4, 18),
+        ]
+        .iter()
+        .map(|&(count, secs)| {
+            let mut t = toml::value::Table::new();
+            t.insert("count".to_string(), toml::Value::Integer(count.into()));
+            t.insert("duration".to_string(), toml::Value::Integer(secs as i64));
+            toml::Value::Table(t)
+        })
+        .collect();
+        bt.insert("levels".to_string(), toml::Value::Array(legacy));
+
+        let migrated = BeepTest::migrate(&bt);
+        assert_eq!(migrated.levels, BeepTestPreset::M25.config().levels);
+    }
+
+    // A genuinely hand-edited table is preserved untouched.
+    #[test]
+    fn migrate_preserves_custom_levels() {
+        let mut bt = toml::value::Table::new();
+        let mut lvl = toml::value::Table::new();
+        lvl.insert("count".to_string(), toml::Value::Integer(2));
+        lvl.insert("duration".to_string(), toml::Value::Integer(45));
+        bt.insert(
+            "levels".to_string(),
+            toml::Value::Array(vec![toml::Value::Table(lvl)]),
+        );
+
+        let migrated = BeepTest::migrate(&bt);
+        assert_eq!(migrated.levels.len(), 1);
+        assert_eq!(migrated.levels[0].count, 2);
+        assert_eq!(
+            migrated.levels[0].duration,
+            std::time::Duration::from_secs(45)
         );
     }
 

--- a/refbox/src/config.rs
+++ b/refbox/src/config.rs
@@ -129,8 +129,6 @@ pub enum BeepTestPreset {
     M21,
 }
 
-// Wired up by the EDIT LEVELS preset buttons in the next task.
-#[allow(dead_code)]
 impl BeepTestPreset {
     pub const ALL: [Self; 3] = [Self::M25, Self::M23, Self::M21];
 

--- a/refbox/src/config.rs
+++ b/refbox/src/config.rs
@@ -112,61 +112,122 @@ pub struct BeepTest {
     pub levels: Vec<Level>,
 }
 
-/// Court-length presets for the beep test.
+/// Truncates a full level schedule to `target` total laps.
 ///
-/// Each preset defines a whole schedule: the warm-up and eight levels
-/// totalling 26 laps. 26 is the passing lap count, and the lap counts are
-/// arranged (3, 3, 3, 4, 4, 4, 4, 1) so that lap 26 is Level 8's single lap
-/// — the test ends exactly on the pass mark, on the first lap of a level
-/// rather than the last lap of one.
+/// Whole levels are kept unchanged while the running lap total is still
+/// short of `target`. The level whose laps would push the total past
+/// `target` is kept but cut down to exactly the laps still needed to reach
+/// it; every level after that one is dropped. General on purpose — it does
+/// not know or care which level index or lap count that turns out to be,
+/// so it works unchanged for any full schedule and any target.
+fn truncate_at_laps(levels: &[Level], target: u8) -> Vec<Level> {
+    let mut out = Vec::new();
+    let mut total: u8 = 0;
+    for level in levels {
+        if total >= target {
+            break;
+        }
+        let count = level.count.min(target - total);
+        out.push(Level {
+            count,
+            duration: level.duration,
+        });
+        total += count;
+    }
+    out
+}
+
+/// Court-length and test-length presets for the beep test.
+///
+/// Each court length (25m / 23m / 21m) has two variants:
+/// - **Full** — the tournament's official table end to end: 10 levels, 37
+///   laps. Players run this.
+/// - **Ref** — the same table truncated to the passing lap count (26).
+///   Referees run this. The Ref levels are never typed out separately;
+///   `config` derives them from the Full table via `truncate_at_laps`, so
+///   they cannot drift from it.
 ///
 /// The level times scale with court length: the 21m and 23m columns are the
 /// 25m times multiplied by 21/25 and 23/25 and rounded up, matching the
 /// adjusted tables the tournament uses.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BeepTestPreset {
-    M25,
-    M23,
-    M21,
+    Ref25,
+    Ref23,
+    Ref21,
+    Full25,
+    Full23,
+    Full21,
 }
 
 impl BeepTestPreset {
-    pub const ALL: [Self; 3] = [Self::M25, Self::M23, Self::M21];
+    pub const ALL: [Self; 6] = [
+        Self::Ref25,
+        Self::Ref23,
+        Self::Ref21,
+        Self::Full25,
+        Self::Full23,
+        Self::Full21,
+    ];
 
-    /// Laps per level. Identical for every court length — only the times
-    /// change. Sums to 26.
-    const LAP_COUNTS: [u8; 8] = [3, 3, 3, 4, 4, 4, 4, 1];
+    /// Laps per level in the full schedule. Identical for every court
+    /// length — only the times change. Sums to 37.
+    const FULL_LAP_COUNTS: [u8; 10] = [3, 3, 3, 4, 4, 4, 4, 4, 4, 4];
+
+    /// The number of laps that passes the test. The Ref schedules are the
+    /// Full schedule truncated to exactly this many laps.
+    const PASSING_LAPS: u8 = 26;
 
     /// Court length in metres, used for the DISTANCE tile's label.
     pub fn metres(self) -> u8 {
         match self {
-            Self::M25 => 25,
-            Self::M23 => 23,
-            Self::M21 => 21,
+            Self::Ref25 | Self::Full25 => 25,
+            Self::Ref23 | Self::Full23 => 23,
+            Self::Ref21 | Self::Full21 => 21,
         }
     }
 
-    /// The eight level durations in seconds, Level 1 first.
-    fn level_secs(self) -> [u64; 8] {
+    /// Whether this is the shorter, 26-lap referee schedule, as opposed to
+    /// the full, 37-lap player schedule.
+    pub fn is_ref(self) -> bool {
+        matches!(self, Self::Ref25 | Self::Ref23 | Self::Ref21)
+    }
+
+    /// The ten full-schedule level durations in seconds, Level 1 first. Ref
+    /// and Full share the same table for a given court length — Ref is a
+    /// truncation of Full, not a separately-tracked table.
+    fn full_level_secs(self) -> [u64; 10] {
         match self {
-            Self::M25 => [36, 34, 32, 30, 28, 26, 24, 22],
-            Self::M23 => [34, 32, 30, 28, 26, 24, 23, 21],
-            Self::M21 => [31, 29, 27, 26, 24, 22, 21, 19],
+            Self::Ref25 | Self::Full25 => [36, 34, 32, 30, 28, 26, 24, 22, 20, 18],
+            Self::Ref23 | Self::Full23 => [34, 32, 30, 28, 26, 24, 23, 21, 19, 17],
+            Self::Ref21 | Self::Full21 => [31, 29, 27, 26, 24, 22, 21, 19, 17, 16],
         }
     }
 
-    /// The complete beep-test configuration for this court length.
+    /// The full (37-lap) schedule's ten levels for this preset's court
+    /// length.
+    fn full_levels(self) -> Vec<Level> {
+        Self::FULL_LAP_COUNTS
+            .iter()
+            .zip(self.full_level_secs())
+            .map(|(&count, secs)| Level {
+                count,
+                duration: std::time::Duration::from_secs(secs),
+            })
+            .collect()
+    }
+
+    /// The complete beep-test configuration for this preset.
     pub fn config(self) -> BeepTest {
+        let full = self.full_levels();
+        let levels = if self.is_ref() {
+            truncate_at_laps(&full, Self::PASSING_LAPS)
+        } else {
+            full
+        };
         BeepTest {
             pre: std::time::Duration::from_secs(10),
-            levels: Self::LAP_COUNTS
-                .iter()
-                .zip(self.level_secs())
-                .map(|(&count, secs)| Level {
-                    count,
-                    duration: std::time::Duration::from_secs(secs),
-                })
-                .collect(),
+            levels,
         }
     }
 
@@ -185,7 +246,7 @@ impl BeepTestPreset {
 
 impl Default for BeepTest {
     fn default() -> Self {
-        BeepTestPreset::M25.config()
+        BeepTestPreset::Ref25.config()
     }
 }
 
@@ -467,72 +528,87 @@ mod test {
         );
     }
 
-    // Every preset ends on lap 26 — the passing lap — with lap 26 the single
-    // lap of Level 8. This is the invariant the whole feature rests on.
+    // Every full preset covers the whole official table: 10 levels, 37
+    // laps, in the same lap-count shape regardless of court length.
     #[test]
-    fn every_preset_ends_on_lap_26() {
-        for preset in BeepTestPreset::ALL {
+    fn every_full_preset_has_37_laps_over_ten_levels() {
+        let expected_counts: Vec<u8> = vec![3, 3, 3, 4, 4, 4, 4, 4, 4, 4];
+        for preset in [
+            BeepTestPreset::Full25,
+            BeepTestPreset::Full23,
+            BeepTestPreset::Full21,
+        ] {
             let config = preset.config();
-            assert_eq!(config.levels.len(), 8, "{preset:?} has 8 levels");
+            assert_eq!(config.levels.len(), 10, "{preset:?} has 10 levels");
+            let counts: Vec<u8> = config.levels.iter().map(|l| l.count).collect();
+            assert_eq!(counts, expected_counts, "{preset:?} lap counts");
             let laps: u32 = config.levels.iter().map(|l| u32::from(l.count)).sum();
-            assert_eq!(laps, 26, "{preset:?} totals 26 laps");
+            assert_eq!(laps, 37, "{preset:?} totals 37 laps");
         }
     }
 
-    // Lap counts are identical across court lengths — only the times scale.
+    // Every ref preset is the first 26 laps of its full counterpart: the
+    // same durations level for level, with only the final level's count
+    // reduced to land exactly on the pass mark. Comparing against the full
+    // preset programmatically (rather than a typed-out expected list) is
+    // what proves the truncation, not a second copy of the data.
     #[test]
-    fn preset_lap_counts_are_identical() {
-        let expected: Vec<u8> = vec![3, 3, 3, 4, 4, 4, 4, 1];
-        for preset in BeepTestPreset::ALL {
-            let counts: Vec<u8> = preset.config().levels.iter().map(|l| l.count).collect();
-            assert_eq!(counts, expected, "{preset:?} lap counts");
+    fn every_ref_preset_is_a_26_lap_prefix_of_its_full_counterpart() {
+        for (ref_preset, full_preset) in [
+            (BeepTestPreset::Ref25, BeepTestPreset::Full25),
+            (BeepTestPreset::Ref23, BeepTestPreset::Full23),
+            (BeepTestPreset::Ref21, BeepTestPreset::Full21),
+        ] {
+            let ref_levels = ref_preset.config().levels;
+            let full_levels = full_preset.config().levels;
+
+            let laps: u32 = ref_levels.iter().map(|l| u32::from(l.count)).sum();
+            assert_eq!(laps, 26, "{ref_preset:?} totals 26 laps");
+            assert!(
+                ref_levels.len() <= full_levels.len(),
+                "{ref_preset:?} has more levels than {full_preset:?}"
+            );
+
+            for (i, (r, f)) in ref_levels.iter().zip(full_levels.iter()).enumerate() {
+                assert_eq!(
+                    r.duration,
+                    f.duration,
+                    "{ref_preset:?} level {} duration should match {full_preset:?}",
+                    i + 1
+                );
+                if i + 1 == ref_levels.len() {
+                    assert!(
+                        r.count <= f.count,
+                        "{ref_preset:?} level {} count should not exceed {full_preset:?}'s",
+                        i + 1
+                    );
+                } else {
+                    assert_eq!(
+                        r.count,
+                        f.count,
+                        "{ref_preset:?} level {} count should match {full_preset:?} \
+                         until the last level",
+                        i + 1
+                    );
+                }
+            }
         }
-    }
-
-    // The confirmed 25m table, including its total run time.
-    #[test]
-    fn preset_25m_matches_confirmed_table() {
-        let config = BeepTestPreset::M25.config();
-        let secs: Vec<u64> = config.levels.iter().map(|l| l.duration.as_secs()).collect();
-        assert_eq!(secs, vec![36, 34, 32, 30, 28, 26, 24, 22]);
-        assert_eq!(config.pre, std::time::Duration::from_secs(10));
-
-        let total: u64 = config.pre.as_secs()
-            + config
-                .levels
-                .iter()
-                .map(|l| l.duration.as_secs() * u64::from(l.count))
-                .sum::<u64>();
-        assert_eq!(total, 770, "25m run is 12:50 including the warm-up");
-    }
-
-    // The confirmed 21m table, read off the operator's sheet.
-    #[test]
-    fn preset_21m_matches_confirmed_table() {
-        let config = BeepTestPreset::M21.config();
-        let secs: Vec<u64> = config.levels.iter().map(|l| l.duration.as_secs()).collect();
-        assert_eq!(secs, vec![31, 29, 27, 26, 24, 22, 21, 19]);
     }
 
     // 23m has no official table — it is DEFINED as ceil(25m x 0.92), the same
     // method the official 21m table documents for itself (ceil(25m x 0.84)).
-    // This test enforces the derivation, so the numbers cannot drift away from
-    // the rule that produced them. 21m is included to prove the rule holds for
-    // the column we can check against a real sheet.
+    // This test enforces the derivation across the whole 10-level full
+    // table, so the numbers cannot drift away from the rule that produced
+    // them. 21m is included to prove the rule holds for the column we can
+    // check against a real sheet.
     #[test]
     fn shorter_court_durations_are_the_25m_table_scaled_and_rounded_up() {
-        let base = BeepTestPreset::M25;
+        let base = BeepTestPreset::Full25.config().levels;
         for (preset, ratio) in [
-            (BeepTestPreset::M23, 0.92_f64),
-            (BeepTestPreset::M21, 0.84_f64),
+            (BeepTestPreset::Full23, 0.92_f64),
+            (BeepTestPreset::Full21, 0.84_f64),
         ] {
-            for (i, (short, long)) in preset
-                .config()
-                .levels
-                .iter()
-                .zip(base.config().levels.iter())
-                .enumerate()
-            {
+            for (i, (short, long)) in preset.config().levels.iter().zip(base.iter()).enumerate() {
                 let expected = (long.duration.as_secs() as f64 * ratio).ceil() as u64;
                 assert_eq!(
                     short.duration.as_secs(),
@@ -546,8 +622,9 @@ mod test {
     }
 
     // detect_levels is the inverse of config().levels: it recognises each
-    // preset exactly and returns None for a hand-edited schedule. This drives
-    // which preset button is highlighted on the EDIT LEVELS screen.
+    // of the six presets exactly and returns None for a hand-edited
+    // schedule. This drives which preset button is highlighted on the EDIT
+    // LEVELS screen.
     #[test]
     fn detect_levels_round_trips_and_rejects_custom() {
         for preset in BeepTestPreset::ALL {
@@ -556,19 +633,70 @@ mod test {
                 Some(preset)
             );
         }
-        let mut custom = BeepTestPreset::M25.config().levels;
+        let mut custom = BeepTestPreset::Full25.config().levels;
         custom[0].duration = std::time::Duration::from_secs(35);
         assert_eq!(BeepTestPreset::detect_levels(&custom), None);
 
         // A truncated list must not match — a prefix is not the schedule.
-        let short = &BeepTestPreset::M25.config().levels[..3];
+        let short = &BeepTestPreset::Full25.config().levels[..3];
         assert_eq!(BeepTestPreset::detect_levels(short), None);
     }
 
-    // The built-in default is the 25m preset.
+    // Totals including the 10s warm-up, checked against the two numbers
+    // printed on the tournament's own paper 21m schedule. These two
+    // assertions are checks against a real external document, not
+    // incidental restatements of the lap-count/derivation tests above —
+    // do not "simplify" them away as redundant.
     #[test]
-    fn default_is_the_25m_preset() {
-        assert_eq!(BeepTest::default(), BeepTestPreset::M25.config());
+    fn preset_totals_match_the_official_sheets() {
+        fn total_secs(config: &BeepTest) -> u64 {
+            config.pre.as_secs()
+                + config
+                    .levels
+                    .iter()
+                    .map(|l| l.duration.as_secs() * u64::from(l.count))
+                    .sum::<u64>()
+        }
+
+        assert_eq!(
+            total_secs(&BeepTestPreset::Full25.config()),
+            988,
+            "Full 25m run is 16:28 including the warm-up"
+        );
+        assert_eq!(
+            total_secs(&BeepTestPreset::Full23.config()),
+            930,
+            "Full 23m run is 15:30 including the warm-up"
+        );
+        // EXTERNAL CHECK: the official 21m sheet prints "End 14:11" at the
+        // foot of the full table. This validates the full 10-level schedule
+        // end to end against that real document.
+        assert_eq!(
+            total_secs(&BeepTestPreset::Full21.config()),
+            851,
+            "Full 21m run is 14:11, matching the official sheet's End time"
+        );
+
+        assert_eq!(
+            total_secs(&BeepTestPreset::Ref25.config()),
+            770,
+            "Ref 25m run is 12:50 including the warm-up"
+        );
+        // EXTERNAL CHECK: the official 21m sheet prints lap 27's start time
+        // as 11:02 — the exact instant lap 26 (the pass mark) finishes.
+        // This validates the referee truncation end to end against that
+        // real document.
+        assert_eq!(
+            total_secs(&BeepTestPreset::Ref21.config()),
+            662,
+            "Ref 21m run is 11:02, matching the official sheet's lap-27 start time"
+        );
+    }
+
+    // The built-in default is the referee 25m preset.
+    #[test]
+    fn default_is_the_ref_25m_preset() {
+        assert_eq!(BeepTest::default(), BeepTestPreset::Ref25.config());
     }
 
     // A genuinely hand-edited table is preserved untouched.

--- a/refbox/translations/de-DE/refbox.ftl
+++ b/refbox/translations/de-DE/refbox.ftl
@@ -406,6 +406,7 @@ beep-test-edit-time = ZEIT
 beep-test-edit-count = ANZAHL
 beep-test-edit-new = STUFE HINZUFÜGEN
 beep-test-edit-remove = STUFE ENTFERNEN
+beep-test-preset-ref = SR
 
 # Vergehen
 stick-foul = Schläger-Foul

--- a/refbox/translations/en-US/refbox.ftl
+++ b/refbox/translations/en-US/refbox.ftl
@@ -443,6 +443,7 @@ beep-test-edit-time = TIME
 beep-test-edit-count = COUNT
 beep-test-edit-new = ADD LEVEL
 beep-test-edit-remove = REMOVE LEVEL
+beep-test-preset-ref = REF
 
 # Infractions
 stick-foul = Stick Foul

--- a/refbox/translations/es/refbox.ftl
+++ b/refbox/translations/es/refbox.ftl
@@ -417,6 +417,7 @@ beep-test-edit-time = TIEMPO
 beep-test-edit-count = CANTIDAD
 beep-test-edit-new = AÑADIR NIVEL
 beep-test-edit-remove = ELIMINAR NIVEL
+beep-test-preset-ref = ÁRB
 
 # Infractions
 stick-foul = Infracción con el palo

--- a/refbox/translations/fr/refbox.ftl
+++ b/refbox/translations/fr/refbox.ftl
@@ -408,6 +408,7 @@ beep-test-edit-time = TEMPS
 beep-test-edit-count = NOMBRE
 beep-test-edit-new = AJOUTER NIVEAU
 beep-test-edit-remove = SUPPRIMER NIVEAU
+beep-test-preset-ref = ARB
 
 # Infractions
 stick-foul = Faute de crosse

--- a/refbox/translations/id-ID/refbox.ftl
+++ b/refbox/translations/id-ID/refbox.ftl
@@ -406,6 +406,7 @@ beep-test-edit-time = WAKTU
 beep-test-edit-count = JUMLAH
 beep-test-edit-new = TAMBAH LEVEL
 beep-test-edit-remove = HAPUS LEVEL
+beep-test-preset-ref = WASIT
 
 # Pelanggaran
 stick-foul = Pelanggaran Stik

--- a/refbox/translations/it-IT/refbox.ftl
+++ b/refbox/translations/it-IT/refbox.ftl
@@ -406,6 +406,7 @@ beep-test-edit-time = TEMPO
 beep-test-edit-count = NUMERO
 beep-test-edit-new = AGGIUNGI LIVELLO
 beep-test-edit-remove = RIMUOVI LIVELLO
+beep-test-preset-ref = ARB
 
 # Infrazioni
 stick-foul = Fallo di Mazzetta

--- a/refbox/translations/ja-JP/refbox.ftl
+++ b/refbox/translations/ja-JP/refbox.ftl
@@ -406,6 +406,7 @@ beep-test-edit-time = 時間
 beep-test-edit-count = 回数
 beep-test-edit-new = レベル追加
 beep-test-edit-remove = レベル削除
+beep-test-preset-ref = 審判
 
 # 反則種別
 stick-foul = スティック反則

--- a/refbox/translations/ko-KR/refbox.ftl
+++ b/refbox/translations/ko-KR/refbox.ftl
@@ -408,6 +408,7 @@ beep-test-edit-time = 시간
 beep-test-edit-count = 카운트
 beep-test-edit-new = 레벨 추가
 beep-test-edit-remove = 레벨 제거
+beep-test-preset-ref = 심판
 
 # 위반 항목
 stick-foul = 스틱 반칙

--- a/refbox/translations/ms-MY/refbox.ftl
+++ b/refbox/translations/ms-MY/refbox.ftl
@@ -406,6 +406,7 @@ beep-test-edit-time = MASA
 beep-test-edit-count = BILANGAN
 beep-test-edit-new = TAMBAH TAHAP
 beep-test-edit-remove = BUANG TAHAP
+beep-test-preset-ref = PENGADIL
 
 # Pelanggaran
 stick-foul = Kesalahan Kayu

--- a/refbox/translations/ms-MY/refbox.ftl
+++ b/refbox/translations/ms-MY/refbox.ftl
@@ -406,7 +406,7 @@ beep-test-edit-time = MASA
 beep-test-edit-count = BILANGAN
 beep-test-edit-new = TAMBAH TAHAP
 beep-test-edit-remove = BUANG TAHAP
-beep-test-preset-ref = PENGADIL
+beep-test-preset-ref = REF
 
 # Pelanggaran
 stick-foul = Kesalahan Kayu

--- a/refbox/translations/nl-NL/refbox.ftl
+++ b/refbox/translations/nl-NL/refbox.ftl
@@ -406,6 +406,7 @@ beep-test-edit-time = TIJD
 beep-test-edit-count = AANTAL
 beep-test-edit-new = NIVEAU TOEVOEGEN
 beep-test-edit-remove = NIVEAU VERWIJDEREN
+beep-test-preset-ref = SR
 
 # Overtredingen
 stick-foul = Stokfout

--- a/refbox/translations/pt-PT/refbox.ftl
+++ b/refbox/translations/pt-PT/refbox.ftl
@@ -406,6 +406,7 @@ beep-test-edit-time = TEMPO
 beep-test-edit-count = CONT
 beep-test-edit-new = ADICIONAR NÍVEL
 beep-test-edit-remove = REMOVER NÍVEL
+beep-test-preset-ref = ÁRB
 
 # Infrações
 stick-foul = Falta de Taco

--- a/refbox/translations/th-TH/refbox.ftl
+++ b/refbox/translations/th-TH/refbox.ftl
@@ -405,6 +405,7 @@ beep-test-edit-time = เวลา
 beep-test-edit-count = จำนวน
 beep-test-edit-new = เพิ่มระดับ
 beep-test-edit-remove = ลบระดับ
+beep-test-preset-ref = ผู้ตัดสิน
 
 # การฝ่าฝืน
 stick-foul = ฟาวล์ด้วยไม้

--- a/refbox/translations/tl-PH/refbox.ftl
+++ b/refbox/translations/tl-PH/refbox.ftl
@@ -406,6 +406,7 @@ beep-test-edit-time = ORAS
 beep-test-edit-count = BILANG
 beep-test-edit-new = MAGDAGDAG NG ANTAS
 beep-test-edit-remove = ALISIN ANG ANTAS
+beep-test-preset-ref = REF
 
 # Mga Paglabag
 stick-foul = Poul sa Stick

--- a/refbox/translations/tr-TR/refbox.ftl
+++ b/refbox/translations/tr-TR/refbox.ftl
@@ -406,6 +406,7 @@ beep-test-edit-time = SÜRE
 beep-test-edit-count = ADET
 beep-test-edit-new = SEVİYE EKLE
 beep-test-edit-remove = SEVİYE KALDIR
+beep-test-preset-ref = HKM
 
 # İhlaller
 stick-foul = Sopa Faulü

--- a/refbox/translations/zh-CN/refbox.ftl
+++ b/refbox/translations/zh-CN/refbox.ftl
@@ -405,6 +405,7 @@ beep-test-edit-time = 时间
 beep-test-edit-count = 次数
 beep-test-edit-new = 添加级别
 beep-test-edit-remove = 删除级别
+beep-test-preset-ref = 裁判
 
 # 违规类型
 stick-foul = 球棍犯规


### PR DESCRIPTION
## What changed

The beep test's EDIT LEVELS screen gains six court-length presets, in the strip to the right of the
levels table:

```
[REF 25M]  [25M]
[REF 23M]  [23M]
[REF 21M]  [21M]
```

- **Full** (right column) is the tournament's official sheet end to end: 10 levels, 37 laps.
- **REF** (left column) is that same schedule stopped at lap 26 — the passing lap — for referees.

One press loads a whole schedule instead of hand-editing every level. The change is *staged*: the
table redraws immediately, APPLY commits it, CANCEL discards it, exactly like every other edit on
that page. The button matching the current levels is highlighted, so the screen tells you which
schedule is loaded; touch any level time or lap count and the highlight drops, because the schedule
is now hand-edited.

Levels are capped at 10 (previously 15). Nothing truncates a saved schedule that already exceeds
that — it only stops you adding an 11th.

**This also corrects the beep test data.** The table that shipped as the default had 5 laps at
Level 9; the official sheet has 4. The full presets restore the real 37-lap schedule.

## Why

Setting up a beep test meant typing in ten levels by hand, and the schedule the app shipped with
did not match the official table. Referees and players also run different lengths of the same test
— 26 laps versus the full 37 — which previously had to be built by hand each time.

## Scope

`refbox` only: `config.rs`, `app/mod.rs`, `app/message.rs`, the two beep-test view builders, and one
new translation key across all 15 locales. No new dependencies.

Built on top of #1869, which has since merged, so this targets `master` directly.

(Supersedes #1963. That PR was opened against the #1869 branch; when #1869 merged and its branch was
deleted, GitHub closed #1963 and mislabelled it "merged". None of its commits reached `master` —
verified with `git cherry` — so this PR carries the same 8 commits, unchanged.)

## How to verify

1. Put the app in beep test mode, then **SETTINGS → EDIT LEVELS**.
2. Press **25M**. The table becomes 10 levels: 36, 34, 32, 30, 28, 26, 24, 22, 20, 18 with lap
   counts 3, 3, 3, 4, 4, 4, 4, 4, 4, 4 — 37 laps — and 25M highlights.
3. Press **REF 25M**. Eight levels, the last a single lap of 22 — 26 laps.
4. Change any level's TIME by one second. The highlight disappears. Change it back; it returns.
5. Press **21M**, then **APPLY**, then run the test. Level 1 laps count down from 0:31.
6. Press **ADD LEVEL** repeatedly — it greys out at 10.

**The data is checked against the tournament's printed 21m sheet, and the tests assert it:** the
full 21m schedule totals 14:11, the "End" time printed at the foot of that sheet, and the referee
version totals 11:02, its lap-27 start time — the instant lap 26 finishes. 23m has no official
sheet; it is defined as the 25m times × 0.92 rounded up, the same method the 21m sheet documents for
itself, and a test enforces that derivation level by level.

`just check` passes clean. Verified in the running app by the operator.

## Note on existing installs

A device that already has a config file keeps its current schedule on upgrade, and no preset will
highlight until one is selected and applied. That is deliberate — an automatic rewrite was
considered and dropped, since no other installations exist.
