### PR TITLE
feat(refbox): add a player number grid from portal rosters

### DIFF
--- a/docs/superpowers/specs/2026-08-08-player-number-grid-design.md
+++ b/docs/superpowers/specs/2026-08-08-player-number-grid-design.md
@@ -1,0 +1,234 @@
+# Player number grid: pick a player instead of typing a number
+
+**Date:** 2026-08-08
+**Branch (proposed):** `feat/refbox/player-number-grid` (off `origin/master`)
+**Crate:** `refbox` only
+
+## Problem
+
+Every player attribution in refbox — a goal, a penalty, a foul, a warning — is entered by
+typing digits on a number pad and reading the result back from a small indicator. The pad
+accepts any value from 0 to 99, so a mistyped digit records a player who is not in the game,
+and the operator has no way to tell from the screen that anything is wrong. Under poolside
+time pressure that is a real source of bad data, and bad data reaches the portal.
+
+The set of players is known in advance. The portal holds each team's roster with cap numbers,
+and team sizes are capped by the rules. There is no reason to type.
+
+## Decision
+
+On the four pages that ask *which player*, replace the number pad and its readout with a
+3-column grid of that team's actual cap numbers. Where refbox has no usable roster for the
+selected team, the page keeps today's number pad unchanged.
+
+Scope is `refbox` only. Nothing about the wire format, the LED panel, the overlay, the
+wireless remote, or the portal submission changes.
+
+### Explicitly not doing
+
+- Not changing how a goal, foul, warning or penalty is recorded once a player is chosen.
+- Not showing player names anywhere.
+- Not persisting rosters to disk (see "Deliberate limitations").
+
+## What the operator sees
+
+### Where it applies
+
+The four pages that ask which player: **goal** (`AddScore`), **penalty**, **foul**,
+**warning**. `GameNumber`, `TeamTimeouts` and `PortalLogin` need free digit entry and keep the
+number pad exactly as it is.
+
+### The grid
+
+Three columns, top-aligned, occupying the space the pad and its number readout use today. The
+readout row is gone; the grid starts at the top of the panel. Row count is fixed by the mode:
+
+| Mode | Max roster | Grid |
+|---|---|---|
+| `Hockey3V3` | 6 | 3 × 2 |
+| `Hockey6V6` | 12 | 3 × 4 |
+| `Rugby` (UWR) | 15 | 3 × 5 |
+| `BeepTest` | — | no player entry exists |
+
+Cells are filled with the team's cap numbers in ascending order, left to right then top to
+bottom. Cells left over after the roster runs out are greyed and not tappable.
+
+```
+  3v3 — 6 cells        6v6 — 12 cells       UWR — 15 cells
+  ┌───┬───┬───┐        ┌───┬───┬───┐        ┌───┬───┬───┐
+  │ 1 │ 2 │ 3 │        │ 1 │ 2 │ 3 │        │ 1 │ 2 │ 3 │
+  ├───┼───┼───┤        ├───┼───┼───┤        ├───┼───┼───┤
+  │ 4 │ 5 │ ░ │        │ 4 │ 5 │ 7 │        │ 4 │ 5 │ 7 │
+  └───┴───┴───┘        ├───┼───┼───┤        ├───┼───┼───┤
+                       │ 8 │ 9 │11 │        │ 8 │ 9 │11 │
+   5 numbered          ├───┼───┼───┤        ├───┼───┼───┤
+   players, 1 cell     │12 │15 │ ░ │        │12 │14 │15 │
+   left over           └───┴───┴───┘        ├───┼───┼───┤
+                                            │16 │ ░ │ ░ │
+                        ░ = leftover,       └───┴───┴───┘
+                            greyed, not
+                            tappable
+```
+
+The grid never grows beyond the mode's size: the portal restricts team size, so a roster
+cannot exceed it. Note the limit is on the *count* of players, not on the numbers themselves —
+a 13-player UWR roster may legitimately include cap number 16, as in the example above.
+
+### Button size
+
+Buttons are square, one size for all modes, chosen so the worst case (3 × 5) fits with margin.
+
+The keypad pages render a time banner (`MIN_BUTTON_SIZE`, 89px), the panel, and the timeout
+ribbon (89px). In the 691px default window that leaves roughly 481px of usable panel height
+after container padding. Five rows at the standard 89px come to 477px — it fits by four
+pixels, which is too fine a margin to depend on across DPI and text scaling. **Target ~80px
+square**, confirmed by measurement during implementation.
+
+### Using it
+
+- Tap a number to select it; the cell highlights.
+- Tap the selected number again to clear the selection.
+- **DONE** commits and **CANCEL** abandons, exactly as today. The grid replaces the typing,
+  not the flow.
+- The existing DONE gating is unchanged: fouls and warnings still require a player number
+  unless they are team/equal entries; penalties require a player number.
+
+All four pages also open in edit mode on an existing entry. There the stored player number is
+preselected — its cell is highlighted on arrival, the same way the pad arrives preloaded
+today. See "Deliberate limitations" for the case where the stored number is not on the grid.
+
+### Per team
+
+The panel follows whichever team button is currently lit. Toggling teams switches the panel to
+that team's grid — or to the number pad if that team has no usable roster. One of each on the
+same page is normal and expected.
+
+Switching teams **clears the number already selected**: #7 on one roster is not #7 on the
+other.
+
+With no team selected at all — an "equal" foul (`color == None`) or a team warning
+(`team_warning == true`) — the panel greys out, as the pad does today.
+
+### Goals with no scorer
+
+Unchanged. Nothing selected means the goal is recorded to the team (player number 0). No new
+button; `AddScoreComplete` already accepts 0.
+
+### When the number pad appears instead
+
+Any of the following, evaluated for the **selected team**:
+
+- the Using-UWH-Portal setting is off;
+- the game slot has no portal team assigned (a placeholder such as "winner of A");
+- no roster fetch has ever succeeded for that team;
+- the roster came back with nobody holding a cap number.
+
+In all of these the page looks and behaves precisely as it does today.
+
+## Where the numbers come from
+
+Refbox keeps a session roster cache: portal team ID → that team's cap numbers. Roster entries
+with no cap number are skipped — there is nothing to tap.
+
+**Bulk load, when the schedule arrives.** Refbox already fetches the event schedule and team
+list when an event is linked or REFRESH is pressed (`request_schedule`,
+`refbox/src/app/mod.rs:752`). At the same point it pulls a roster for every team appearing in
+that schedule — one call per team, once, while there is time and network. This covers the
+first game of the day.
+
+**Targeted refresh during the break.** Refbox already determines the next game the moment a
+game starts (`handle_game_start`, `refbox/src/app/mod.rs:842`). That is where the two rosters
+for the *upcoming* game are re-pulled, giving the fetch the whole break to land rather than
+the instant of kickoff. Success overwrites the cached copy; failure leaves the cached copy
+untouched. The same refresh fires when the operator selects a different next game by hand.
+
+**Kickoff takes a copy.** When a game starts it takes its own copy of both rosters from the
+cache. Nothing changes it for the rest of that game — a REFRESH mid-game re-pulls the event
+but cannot move the grid under the operator's hand. The fresh copy is adopted at the next
+kickoff.
+
+This ordering is what makes the design safe: because a game's grid is fixed from kickoff, a
+number recorded during that game is always present on that game's grid.
+
+### The portal call
+
+`UwhPortalClient::get_team_roster(team_id)` already exists and is unit-tested
+(`uwh-common/src/uwhportal/mod.rs:671`). It calls `/api/admin/get-event-team`, which despite
+the route is marked `[AllowAnonymous]` in the portal
+(`api/Controllers/AdminController.Events.cs:173`) — refbox needs no admin login and no new
+permission.
+
+A bulk endpoint `get-event-teams` exists and returns every team's roster in a single call, but
+its response omits team IDs, so rosters could only be matched to games by team name.
+Rejected: one small call per team keyed by ID is unambiguous and reuses tested code.
+
+## Deliberate limitations
+
+- **The cache is in memory only.** After a refbox restart with no network, every team falls
+  back to the number pad until a fetch succeeds. Persisting rosters to disk is a reasonable
+  follow-up and is deliberately not in this work.
+- **Nothing is stored in the game.** Cap numbers are recorded exactly as today — a plain
+  number on the goal, foul, warning or penalty.
+- **Safety net for off-grid numbers.** If an entry being edited holds a number the game's grid
+  does not contain, that edit shows the number pad with the value loaded, so nothing already
+  recorded can become invisible. The ordering above should make this unreachable; it is kept
+  because it costs almost nothing and removes the need to prove impossibility.
+
+## Forward compatibility
+
+A planned future feature lets a coach mark which rostered players are actually available for a
+given game (a 12-player roster may field only 10). This design already carries "the numbers
+this team may use *in this game*" as a per-game copy taken at kickoff, and the grid packs
+whatever it is given — 10 of 12 simply fills ten cells and greys two, with no layout change.
+Availability would filter between the fetch and the kickoff copy. Not in scope here.
+
+## Implementation sketch
+
+Everything is inside `refbox`. `uwh-common` is untouched.
+
+| File | Change |
+|---|---|
+| `refbox/src/app/view_builders/keypad_pages/mod.rs` | Selects the left-hand panel — grid or pad — from the selected team's numbers. Today's inline pad moves into its own function, otherwise unchanged. |
+| `refbox/src/app/view_builders/keypad_pages/player_grid.rs` *(new)* | Builds the grid: packing, leftover greying, selection highlight. |
+| `refbox/src/app/message.rs` | One new action, "player number tapped", mirroring `SetTeamTimeoutCount`, which already sets a value directly rather than digit by digit. |
+| `refbox/src/app/mod.rs` | Roster cache, the two fetch points, the kickoff copy, and handling the new action. |
+| `refbox/src/app/theme/` | Reuses existing `blue_button` / `blue_selected_button`. Leftover cells are buttons with no `on_press`, which already renders as disabled. |
+
+No new translation keys — the grid is numbers only. No new dependencies.
+
+The core is one pure function: given a team's cap numbers and the mode, produce the grid's
+rows. Every visible behaviour agreed above — packing order, leftover greying, grid size per
+mode, "no usable numbers" — is decided there.
+
+## Acceptance criteria
+
+Automated:
+
+- The grid-building function is unit-tested for: packing order; a full roster with no
+  leftovers; a short roster with leftovers; gaps in cap numbers; unnumbered players skipped;
+  an empty roster reported as "no usable numbers"; grid size per mode.
+- Existing `foul_add_can_commit` / `warning_add_can_commit` / `penalty_edit_can_commit` tests
+  still pass unchanged — the commit rules are not being modified.
+- `just check` clean.
+
+Observable by the human, on a linked event (the San Diego Beach Bash sandbox, `events/177-B`):
+
+1. Open a foul on a linked team: a grid of that team's numbers, no keypad, no readout.
+2. Toggle to a team without a portal link on the same page: today's number pad appears for
+   that team only, and the number already selected is cleared.
+3. Tap a number, then tap it again: selection clears; on the goal page pressing DONE then
+   records a team goal, as it does today.
+4. Record a foul from the grid and confirm the penalty/foul list shows that number.
+5. Switch to 3v3 and to UWR: 2-row and 5-row grids, same button size, no clipping against the
+   timeout ribbon.
+6. Pull the network, start the next game, and confirm the previously cached grid is still
+   shown rather than falling back to the pad.
+
+## Open items for implementation
+
+- Measure the panel height on the Pi's actual screen and fix the button size; ~80px is the
+  starting target, not a measured result.
+- The targeted refresh must fire from every path that establishes the next game, not only
+  `handle_game_start`. In `refbox/src/app/mod.rs` those are: `handle_game_start` (869),
+  `apply_game_options` (1188 and 1243), `apply_game_confirmation` (1337), and the
+  `RecvSchedule` arm that selects the next game by number (4206).

--- a/refbox/src/app/message.rs
+++ b/refbox/src/app/message.rs
@@ -12,7 +12,7 @@ use uwh_common::{
     game_snapshot::{GameSnapshot, Infraction},
     uwhportal::{
         PortalTokenResponse,
-        schedule::{Event, EventId, Schedule, TeamList},
+        schedule::{Event, EventId, Schedule, TeamId, TeamList},
     },
 };
 
@@ -179,6 +179,10 @@ pub enum Message {
     AutoConfirmScores(GameSnapshot),
     RecvEventList(Vec<Event>),
     RecvTeamsList(EventId, TeamList),
+    /// A team's roster arrived from the portal, reduced to the cap numbers on
+    /// it. Players with no cap number are dropped at the fetch — there is
+    /// nothing to tap for them.
+    RecvTeamRoster(TeamId, Vec<u8>),
     RecvSchedule(EventId, Schedule),
     RecvPortalToken(PortalTokenResponse),
     /// Result of a portal token-validity check for a specific event. Carries
@@ -333,6 +337,7 @@ impl Message {
             | Self::CycleParameter(_)
             | Self::RecvEventList(_)
             | Self::RecvTeamsList(_, _)
+            | Self::RecvTeamRoster(_, _)
             | Self::RecvSchedule(_, _)
             | Self::RecvPortalToken(_)
             | Self::RecvTokenValid(_, _)
@@ -665,6 +670,7 @@ impl PartialEq for Message {
             (Self::TimeUpdaterStarted(a), Self::TimeUpdaterStarted(b)) => a.same_channel(b),
             (Self::RecvEventList(a), Self::RecvEventList(b)) => a == b,
             (Self::RecvTeamsList(a, b), Self::RecvTeamsList(c, d)) => a == c && b == d,
+            (Self::RecvTeamRoster(a, b), Self::RecvTeamRoster(c, d)) => a == c && b == d,
             (Self::RecvSchedule(a, b), Self::RecvSchedule(c, d)) => a == c && b == d,
             (Self::RecvPortalToken(a), Self::RecvPortalToken(b)) => a == b,
             (Self::RecvTokenValid(a, b), Self::RecvTokenValid(c, d)) => a == c && b == d,
@@ -748,6 +754,7 @@ impl PartialEq for Message {
             | (Self::AutoConfirmScores(_), _)
             | (Self::RecvEventList(_), _)
             | (Self::RecvTeamsList(_, _), _)
+            | (Self::RecvTeamRoster(_, _), _)
             | (Self::RecvSchedule(_, _), _)
             | (Self::RecvPortalToken(_), _)
             | (Self::RecvTokenValid(_, _), _)

--- a/refbox/src/app/message.rs
+++ b/refbox/src/app/message.rs
@@ -72,6 +72,10 @@ pub enum Message {
     },
     KeypadPage(KeypadPage),
     KeypadButtonPress(KeypadButton),
+    /// A cell in the player-number grid was tapped. Sets the value outright,
+    /// unlike `KeypadButtonPress`, which appends a digit. `0` clears the
+    /// selection — and on the goal page that means a team goal.
+    SelectPlayerNumber(u32),
     ChangeColor(Option<GameColor>),
     AddScoreComplete {
         canceled: bool,
@@ -324,6 +328,7 @@ impl Message {
             | Self::ChangeScore { .. }
             | Self::Scroll { .. }
             | Self::KeypadButtonPress(_)
+            | Self::SelectPlayerNumber(_)
             | Self::ToggleBoolParameter(_)
             | Self::CycleParameter(_)
             | Self::RecvEventList(_)
@@ -612,6 +617,7 @@ impl PartialEq for Message {
             ) => a == d && b == e && c == f,
             (Self::KeypadPage(a), Self::KeypadPage(b)) => a == b,
             (Self::KeypadButtonPress(a), Self::KeypadButtonPress(b)) => a == b,
+            (Self::SelectPlayerNumber(a), Self::SelectPlayerNumber(b)) => a == b,
             (Self::ChangeColor(a), Self::ChangeColor(b)) => a == b,
             (Self::AddScoreComplete { canceled: a }, Self::AddScoreComplete { canceled: b }) => {
                 a == b
@@ -692,6 +698,7 @@ impl PartialEq for Message {
             | (Self::FoulEditComplete { .. }, _)
             | (Self::KeypadPage(_), _)
             | (Self::KeypadButtonPress(_), _)
+            | (Self::SelectPlayerNumber(_), _)
             | (Self::ChangeColor(_), _)
             | (Self::AddScoreComplete { .. }, _)
             | (Self::ShowGameDetails, _)

--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -40,7 +40,7 @@ use uwh_common::{
     drawing_support::*,
     game_snapshot::{GamePeriod, GameSnapshot, Infraction, TimeoutSnapshot},
     uwhportal::{
-        PortalTokenResponse, UwhPortalClient,
+        PortalTokenResponse, RosterPlayer, UwhPortalClient,
         schedule::{Event, EventId, GameNumber, Schedule, TeamId},
     },
 };
@@ -764,7 +764,7 @@ impl RefBoxApp {
             Task::future(async move {
                 match request.await {
                     Ok(players) => {
-                        let numbers: Vec<u8> = players.iter().filter_map(|p| p.number).collect();
+                        let numbers = usable_cap_numbers(&players);
                         info!(
                             "Got roster for team {}: {} numbered players",
                             team_id.full(),
@@ -1200,6 +1200,14 @@ impl RefBoxApp {
         self.set_current_event_id(None);
         self.current_court = None;
         self.schedule = None;
+        // The Using-UWH-Portal setting is now off, which the player-grid design
+        // spec lists as an unconditional number-pad condition. `game_rosters` is
+        // otherwise only written at kickoff, so without this the grid would keep
+        // showing the previous event's numbers until the next kickoff.
+        self.game_rosters = BlackWhiteBundle {
+            black: Vec::new(),
+            white: Vec::new(),
+        };
         self.config.game = manual_config;
         self.persist_config();
         // Delete the saved portal-link note now that the portal is off, so a
@@ -4292,21 +4300,25 @@ impl RefBoxApp {
 
                 // Pre-load every team in the schedule while there is time and
                 // network, so the grid is available from the first game of the
-                // day and no game start depends on a live fetch.
+                // day and no game start depends on a live fetch. `RecvSchedule`
+                // is not once-per-link: handle_game_end requests a fresh
+                // schedule at the end of every portal-linked game, and REFRESH,
+                // event selection and startup restore all trigger it too. Skip
+                // teams already in the roster cache so a 40-team event does not
+                // re-fire ~40 concurrent GETs at the end of every game, right
+                // when that game's score/stats POST is being enqueued.
                 let mut roster_tasks: Vec<Task<Message>> = Vec::new();
                 let mut seen_teams = BTreeSet::new();
+                let mut courts = BTreeSet::new();
                 for game in schedule.games.values() {
                     for team in [&game.dark, &game.light] {
                         if let Some(id) = team.assigned() {
-                            if seen_teams.insert(id.clone()) {
+                            if seen_teams.insert(id.clone()) && !self.team_rosters.contains_key(id)
+                            {
                                 roster_tasks.push(self.request_team_roster(id.clone()));
                             }
                         }
                     }
-                }
-
-                let mut courts = BTreeSet::new();
-                for game in schedule.games.values() {
                     if !courts.contains(&game.court) {
                         courts.insert(game.court.clone());
                     }
@@ -5594,6 +5606,69 @@ impl RefBoxApp {
             background_color: window_background(),
             text_color,
         }
+    }
+}
+
+/// Cap numbers from a roster that are usable on the player grid.
+///
+/// Entries with no cap number are skipped — there is nothing to tap. Entries
+/// outside `1..=99` are skipped too: every player-attribution page gates
+/// `SelectPlayerNumber` on `page.max_val()`, which is 99, so a cap of 100+
+/// would render a tappable cell that silently does nothing, and a cap of 0
+/// would render a cell that can never highlight (0 already means "no player
+/// selected" everywhere in the app — a team goal, on the goal page).
+fn usable_cap_numbers(players: &[RosterPlayer]) -> Vec<u8> {
+    players
+        .iter()
+        .filter_map(|p| p.number)
+        .filter(|n| (1..=99).contains(n))
+        .collect()
+}
+
+#[cfg(test)]
+mod usable_cap_numbers_tests {
+    use super::*;
+
+    fn player(number: Option<u8>) -> RosterPlayer {
+        RosterPlayer {
+            number,
+            name: String::new(),
+            is_captain: false,
+            is_vice_captain: false,
+        }
+    }
+
+    #[test]
+    fn unnumbered_players_are_skipped() {
+        assert_eq!(usable_cap_numbers(&[player(None)]), Vec::<u8>::new());
+    }
+
+    #[test]
+    fn in_range_numbers_pass_through() {
+        assert_eq!(
+            usable_cap_numbers(&[player(Some(1)), player(Some(7)), player(Some(99))]),
+            vec![1, 7, 99]
+        );
+    }
+
+    #[test]
+    fn zero_is_filtered_out() {
+        // 0 means "no player selected" (a team goal on the goal page); a
+        // roster entry of 0 must not become a tappable, never-highlighting cell.
+        assert_eq!(
+            usable_cap_numbers(&[player(Some(0)), player(Some(5))]),
+            vec![5]
+        );
+    }
+
+    #[test]
+    fn caps_above_ninety_nine_are_filtered_out() {
+        // Every player page gates SelectPlayerNumber on max_val() == 99; a
+        // cap of 100+ would be a dead cell.
+        assert_eq!(
+            usable_cap_numbers(&[player(Some(100)), player(Some(255)), player(Some(50))]),
+            vec![50]
+        );
     }
 }
 

--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -41,7 +41,7 @@ use uwh_common::{
     game_snapshot::{GamePeriod, GameSnapshot, Infraction, TimeoutSnapshot},
     uwhportal::{
         PortalTokenResponse, UwhPortalClient,
-        schedule::{Event, EventId, GameNumber, Schedule},
+        schedule::{Event, EventId, GameNumber, Schedule, TeamId},
     },
 };
 
@@ -172,6 +172,10 @@ pub struct RefBoxApp {
     /// a mid-game REFRESH cannot move the grid under the operator's hand. Empty
     /// vectors mean "no usable roster" and the number pad is shown.
     game_rosters: BlackWhiteBundle<Vec<u8>>,
+    /// Cap numbers for every team the portal has told us about, keyed by portal
+    /// team id. Session-only: never written to disk, so a restart with no
+    /// network falls back to the number pad until a fetch succeeds.
+    team_rosters: BTreeMap<TeamId, Vec<u8>>,
     current_event_id: Option<EventId>,
     current_court: Option<String>,
     /// One-shot: the game number to re-select once the schedule arrives during
@@ -531,7 +535,7 @@ impl RefBoxApp {
             if new_snapshot.current_period == GamePeriod::BetweenGames {
                 task = self.handle_game_end(&new_snapshot.game_number);
             } else if self.snapshot.current_period == GamePeriod::BetweenGames {
-                self.handle_game_start(&new_snapshot.game_number);
+                task = self.handle_game_start(&new_snapshot.game_number);
             }
         }
 
@@ -753,6 +757,34 @@ impl RefBoxApp {
         }
     }
 
+    fn request_team_roster(&self, team_id: TeamId) -> Task<Message> {
+        if let Some(client) = &self.uwhportal_client {
+            // why this cannot panic: see `request_event_list` above.
+            let request = client.lock().unwrap().get_team_roster(&team_id);
+            Task::future(async move {
+                match request.await {
+                    Ok(players) => {
+                        let numbers: Vec<u8> = players.iter().filter_map(|p| p.number).collect();
+                        info!(
+                            "Got roster for team {}: {} numbered players",
+                            team_id.full(),
+                            numbers.len()
+                        );
+                        Message::RecvTeamRoster(team_id, numbers)
+                    }
+                    Err(e) => {
+                        // A failure must leave whatever is cached untouched, so
+                        // this reports nothing rather than an empty roster.
+                        error!("Failed to get roster for team {}: {e}", team_id.full());
+                        Message::NoAction
+                    }
+                }
+            })
+        } else {
+            Task::none()
+        }
+    }
+
     fn request_schedule(&self, event_id: EventId) -> Task<Message> {
         if let Some(client) = &self.uwhportal_client {
             // why this cannot panic: see `request_event_list` above.
@@ -843,7 +875,38 @@ impl RefBoxApp {
         }
     }
 
-    fn handle_game_start(&mut self, new_game_num: &GameNumber) {
+    /// Both teams' cap numbers for a scheduled game, read from the session
+    /// cache. Empty vectors where the slot has no portal team assigned (a
+    /// placeholder such as "winner of A") or no roster has arrived — those
+    /// teams get the number pad.
+    fn rosters_for_game(&self, game_num: &GameNumber) -> BlackWhiteBundle<Vec<u8>> {
+        let mut out = BlackWhiteBundle {
+            black: Vec::new(),
+            white: Vec::new(),
+        };
+
+        if let Some(schedule) = &self.schedule {
+            if let Some(game) = schedule.games.get(game_num) {
+                for (color, team) in [(Color::Black, &game.dark), (Color::White, &game.light)] {
+                    if let Some(numbers) = team.assigned().and_then(|id| self.team_rosters.get(id))
+                    {
+                        out[color] = numbers.clone();
+                    }
+                }
+            }
+        }
+
+        out
+    }
+
+    fn handle_game_start(&mut self, new_game_num: &GameNumber) -> Task<Message> {
+        // Fix this game's rosters now. From here until the next kickoff they do
+        // not change: a REFRESH mid-game re-pulls the event, but must not move
+        // the grid under the operator's hand.
+        self.game_rosters = self.rosters_for_game(new_game_num);
+
+        let mut tasks: Vec<Task<Message>> = Vec::new();
+
         if self.using_uwhportal {
             debug!("Searching for next game info after game {new_game_num}");
             if let (Some(schedule), Some(pool)) = (&self.schedule, &self.current_court) {
@@ -851,7 +914,7 @@ impl RefBoxApp {
                     Some(g) => g.start_time,
                     None => {
                         error!("Could not find new game's start time (game {new_game_num}");
-                        return;
+                        return Task::batch(tasks);
                     }
                 };
 
@@ -863,7 +926,7 @@ impl RefBoxApp {
                     .min_by_key(|game| game.start_time);
 
                 let mut tm = self.tm.lock().unwrap();
-                if let Some(next_game) = next_game {
+                let next_game_number = if let Some(next_game) = next_game {
                     let timing = schedule.get_game_timing(&next_game.number).cloned();
                     let info = NextGameInfo {
                         number: next_game.number.clone(),
@@ -871,14 +934,45 @@ impl RefBoxApp {
                         start_time: Some(next_game.start_time),
                     };
                     tm.set_next_game(info);
+                    Some(next_game.number.clone())
                 } else {
                     error!("Couldn't find a next game");
-                }
+                    None
+                };
                 self.config.game = tm.config().clone();
+                // `roster_refresh_tasks` borrows `self`, so the `tm` lock (a
+                // borrow of `self.tm`) must be released first.
+                drop(tm);
+
+                if let Some(next_game_number) = next_game_number {
+                    tasks.extend(self.roster_refresh_tasks(&next_game_number));
+                }
             }
         } else {
             debug!("Skipped next game info search after game {new_game_num}");
         }
+
+        Task::batch(tasks)
+    }
+
+    /// Re-pull both teams' rosters for an upcoming game. Fired at the kickoff of
+    /// the previous game so the fetch has the whole break to land rather than
+    /// the instant of the next start. A failure changes nothing: the fetch
+    /// reports `NoAction` and the cached copy stands.
+    fn roster_refresh_tasks(&self, game_num: &GameNumber) -> Vec<Task<Message>> {
+        let mut tasks = Vec::new();
+
+        if let Some(schedule) = &self.schedule {
+            if let Some(game) = schedule.games.get(game_num) {
+                for team in [&game.dark, &game.light] {
+                    if let Some(id) = team.assigned() {
+                        tasks.push(self.request_team_roster(id.clone()));
+                    }
+                }
+            }
+        }
+
+        tasks
     }
 
     fn handle_game_end(&mut self, game_number: &GameNumber) -> Task<Message> {
@@ -1926,6 +2020,7 @@ impl RefBoxApp {
                 black: Vec::new(),
                 white: Vec::new(),
             },
+            team_rosters: BTreeMap::new(),
             current_event_id: None,
             current_court: None,
             pending_restore_game: None,
@@ -4165,6 +4260,10 @@ impl RefBoxApp {
                 }
                 Task::none()
             }
+            Message::RecvTeamRoster(team_id, numbers) => {
+                self.team_rosters.insert(team_id, numbers);
+                Task::none()
+            }
             Message::RecvSchedule(event_id, mut schedule) => {
                 // A manual REFRESH (RequestPortalRefresh) spins the Game Info
                 // button until a schedule arrives. Clear it for every success
@@ -4190,6 +4289,21 @@ impl RefBoxApp {
                 schedule
                     .games
                     .sort_by(|_, v1, _, v2| v1.start_time.cmp(&v2.start_time));
+
+                // Pre-load every team in the schedule while there is time and
+                // network, so the grid is available from the first game of the
+                // day and no game start depends on a live fetch.
+                let mut roster_tasks: Vec<Task<Message>> = Vec::new();
+                let mut seen_teams = BTreeSet::new();
+                for game in schedule.games.values() {
+                    for team in [&game.dark, &game.light] {
+                        if let Some(id) = team.assigned() {
+                            if seen_teams.insert(id.clone()) {
+                                roster_tasks.push(self.request_team_roster(id.clone()));
+                            }
+                        }
+                    }
+                }
 
                 let mut courts = BTreeSet::new();
                 for game in schedule.games.values() {
@@ -4256,7 +4370,8 @@ impl RefBoxApp {
                                                 let snapshot = tm.generate_snapshot(now).unwrap();
                                                 std::mem::drop(tm);
                                                 self.config.game = new_game_config;
-                                                return self.apply_snapshot(snapshot);
+                                                roster_tasks.push(self.apply_snapshot(snapshot));
+                                                return Task::batch(roster_tasks);
                                             }
                                         }
                                     }
@@ -4275,7 +4390,7 @@ impl RefBoxApp {
                         event_id.full()
                     );
                 }
-                Task::none()
+                Task::batch(roster_tasks)
             }
             Message::RecvPortalToken(token_response) => {
                 let mut task = Task::none();

--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -168,6 +168,10 @@ pub struct RefBoxApp {
     using_uwhportal: bool,
     events: Option<BTreeMap<EventId, Event>>,
     schedule: Option<Schedule>,
+    /// The running game's copy of both teams' cap numbers, taken at kickoff so
+    /// a mid-game REFRESH cannot move the grid under the operator's hand. Empty
+    /// vectors mean "no usable roster" and the number pad is shown.
+    game_rosters: BlackWhiteBundle<Vec<u8>>,
     current_event_id: Option<EventId>,
     current_court: Option<String>,
     /// One-shot: the game number to re-select once the schedule arrives during
@@ -1918,6 +1922,10 @@ impl RefBoxApp {
             using_uwhportal: false,
             events: None,
             schedule: None,
+            game_rosters: BlackWhiteBundle {
+                black: Vec::new(),
+                white: Vec::new(),
+            },
             current_event_id: None,
             current_court: None,
             pending_restore_game: None,
@@ -2646,6 +2654,17 @@ impl RefBoxApp {
                 trace!("AppState changed to {:?}", self.app_state);
                 Task::none()
             }
+            Message::SelectPlayerNumber(number) => {
+                if let AppState::KeypadPage(ref page, ref mut val) = self.app_state {
+                    if number <= page.max_val() {
+                        *val = number;
+                    }
+                } else {
+                    unreachable!()
+                }
+                trace!("AppState changed to {:?}", self.app_state);
+                Task::none()
+            }
             Message::SetTeamTimeoutCount(count) => {
                 if let AppState::KeypadPage(KeypadPage::TeamTimeouts(_, _), ref mut val) =
                     self.app_state
@@ -2670,13 +2689,29 @@ impl RefBoxApp {
             }
             Message::ChangeColor(new_color) => {
                 match self.app_state {
-                    AppState::KeypadPage(KeypadPage::AddScore(ref mut color), _)
-                    | AppState::KeypadPage(KeypadPage::Penalty(_, ref mut color, _, _), _)
-                    | AppState::KeypadPage(KeypadPage::WarningAdd { ref mut color, .. }, _) => {
+                    AppState::KeypadPage(
+                        KeypadPage::AddScore(ref mut color),
+                        ref mut player_num,
+                    )
+                    | AppState::KeypadPage(
+                        KeypadPage::Penalty(_, ref mut color, _, _),
+                        ref mut player_num,
+                    )
+                    | AppState::KeypadPage(
+                        KeypadPage::WarningAdd { ref mut color, .. },
+                        ref mut player_num,
+                    ) => {
                         *color = new_color.expect("Invalid color value");
+                        // A number chosen for one team means nothing on the
+                        // other — #7 is a different person on each roster.
+                        *player_num = 0;
                     }
-                    AppState::KeypadPage(KeypadPage::FoulAdd { ref mut color, .. }, _) => {
+                    AppState::KeypadPage(
+                        KeypadPage::FoulAdd { ref mut color, .. },
+                        ref mut player_num,
+                    ) => {
                         *color = new_color;
+                        *player_num = 0;
                     }
                     _ => {
                         unreachable!()
@@ -5144,6 +5179,7 @@ impl RefBoxApp {
                     player_num,
                     self.config.track_fouls_and_warnings,
                     self.edited_settings.as_ref().map(|e| e.game_number.clone()),
+                    &self.game_rosters,
                 ),
             AppState::GameDetailsPage(is_refreshing) => build_game_info_page(
                 data,

--- a/refbox/src/app/view_builders/keypad_pages/mod.rs
+++ b/refbox/src/app/view_builders/keypad_pages/mod.rs
@@ -56,6 +56,11 @@ pub(in super::super) fn build_keypad_page<'a>(
         ..
     } = data;
 
+    // Today these are exactly the two cases where `panel_team` (below) returns
+    // `None`, so a grid is never actually rendered while disabled. That
+    // agreement is not enforced by the type system, so `enabled` is passed
+    // into `make_player_grid`/`make_grid_cell` too — if a future disabling
+    // condition is ever added here alone, the grid still cannot be tapped.
     let enabled = match page {
         KeypadPage::WarningAdd { team_warning, .. } => !team_warning,
         KeypadPage::FoulAdd { color, .. } => color.is_some(),
@@ -105,7 +110,7 @@ pub(in super::super) fn build_keypad_page<'a>(
         ),
         row![
             container(if show_grid(panel_numbers, mode, player_num) {
-                make_player_grid(panel_numbers, mode, player_num)
+                make_player_grid(panel_numbers, mode, player_num, enabled)
             } else {
                 make_number_pad(&page, player_num, enabled)
             })
@@ -114,7 +119,15 @@ pub(in super::super) fn build_keypad_page<'a>(
             } else {
                 disabled_container
             })
-            .padding(PADDING),
+            .padding(PADDING)
+            // Fixed to the pad's own width (3 columns of MIN_BUTTON_SIZE) so the
+            // panel is the same box whichever child it holds — the grid is
+            // narrower, so it gets centred inside this box instead of shifting
+            // DONE/CANCEL sideways when a page shows a grid for one team and the
+            // pad for the other.
+            .width(Length::Fixed(
+                3.0 * MIN_BUTTON_SIZE + 2.0 * SPACING + 2.0 * PADDING
+            )),
             match page {
                 KeypadPage::AddScore(color) => make_score_add_page(color),
                 KeypadPage::Penalty(origin, color, kind, foul) => {

--- a/refbox/src/app/view_builders/keypad_pages/mod.rs
+++ b/refbox/src/app/view_builders/keypad_pages/mod.rs
@@ -13,6 +13,8 @@ use iced::{
         text,
     },
 };
+use uwh_common::bundles::BlackWhiteBundle;
+use uwh_common::color::Color as GameColor;
 
 mod score_add;
 use score_add::*;
@@ -32,6 +34,9 @@ use foul_add::*;
 mod warning_add;
 use warning_add::*;
 
+mod player_grid;
+use player_grid::*;
+
 mod portal_login;
 use portal_login::*;
 
@@ -41,6 +46,7 @@ pub(in super::super) fn build_keypad_page<'a>(
     player_num: u32,
     track_fouls_and_warnings: bool,
     original_game_number: Option<String>,
+    rosters: &BlackWhiteBundle<Vec<u8>>,
 ) -> Element<'a, Message> {
     let ViewData {
         snapshot,
@@ -77,45 +83,15 @@ pub(in super::super) fn build_keypad_page<'a>(
         .into();
     }
 
-    let setup_keypad_button =
-        |button: Button<'a, Message>, message: Message| -> Button<'a, Message> {
-            let button = if enabled {
-                button.on_press(message)
-            } else {
-                button
-            };
-            button.style(blue_button)
-        };
-
-    let text_displayed = match page {
-        KeypadPage::WarningAdd { team_warning, .. } => {
-            if team_warning {
-                "TEAM".to_string()
-            } else {
-                player_num.to_string()
-            }
-        }
-        KeypadPage::AddScore(_) => {
-            if player_num == 0 {
-                "TEAM".to_string()
-            } else {
-                player_num.to_string()
-            }
-        }
-        KeypadPage::FoulAdd { color, .. } => {
-            if color.is_none() {
-                "TEAM".to_string()
-            } else {
-                player_num.to_string()
-            }
-        }
-        KeypadPage::GameNumber
-        | KeypadPage::Penalty(_, _, _, _)
-        | KeypadPage::TeamTimeouts(_, _)
-        | KeypadPage::PortalLogin(_, _) => player_num.to_string(),
+    // An empty slice means "no usable roster": the number pad is shown, exactly
+    // as it is today. That covers the portal being off, an unassigned team slot,
+    // a fetch that never succeeded, a roster with no cap numbers — and the pages
+    // that are not about players at all, since `panel_team` returns `None`.
+    const NO_ROSTER: &[u8] = &[];
+    let panel_numbers: &[u8] = match panel_team(&page) {
+        Some(color) => &rosters[color],
+        None => NO_ROSTER,
     };
-
-    let text_size = MEDIUM_TEXT;
 
     column![
         make_game_time_button(
@@ -128,85 +104,11 @@ pub(in super::super) fn build_keypad_page<'a>(
             None
         ),
         row![
-            container(
-                column![
-                    row![
-                        text(page.text()).align_x(Horizontal::Left),
-                        Space::with_width(Length::Fill),
-                        text(text_displayed).size(text_size),
-                    ]
-                    .width(Length::Fixed(3.0 * MIN_BUTTON_SIZE + 2.0 * SPACING)),
-                    row![
-                        setup_keypad_button(
-                            make_small_button("7", MEDIUM_TEXT),
-                            Message::KeypadButtonPress(KeypadButton::Seven,)
-                        ),
-                        setup_keypad_button(
-                            make_small_button("8", MEDIUM_TEXT),
-                            Message::KeypadButtonPress(KeypadButton::Eight,)
-                        ),
-                        setup_keypad_button(
-                            make_small_button("9", MEDIUM_TEXT),
-                            Message::KeypadButtonPress(KeypadButton::Nine,)
-                        ),
-                    ]
-                    .spacing(SPACING),
-                    row![
-                        setup_keypad_button(
-                            make_small_button("4", MEDIUM_TEXT),
-                            Message::KeypadButtonPress(KeypadButton::Four,)
-                        ),
-                        setup_keypad_button(
-                            make_small_button("5", MEDIUM_TEXT),
-                            Message::KeypadButtonPress(KeypadButton::Five,)
-                        ),
-                        setup_keypad_button(
-                            make_small_button("6", MEDIUM_TEXT),
-                            Message::KeypadButtonPress(KeypadButton::Six,)
-                        ),
-                    ]
-                    .spacing(SPACING),
-                    row![
-                        setup_keypad_button(
-                            make_small_button("1", MEDIUM_TEXT),
-                            Message::KeypadButtonPress(KeypadButton::One,)
-                        ),
-                        setup_keypad_button(
-                            make_small_button("2", MEDIUM_TEXT),
-                            Message::KeypadButtonPress(KeypadButton::Two,)
-                        ),
-                        setup_keypad_button(
-                            make_small_button("3", MEDIUM_TEXT),
-                            Message::KeypadButtonPress(KeypadButton::Three,)
-                        ),
-                    ]
-                    .spacing(SPACING),
-                    row![
-                        setup_keypad_button(
-                            make_small_button("0", MEDIUM_TEXT),
-                            Message::KeypadButtonPress(KeypadButton::Zero),
-                        ),
-                        setup_keypad_button(
-                            button(
-                                container(
-                                    Svg::new(svg::Handle::from_memory(
-                                        &include_bytes!("../../../../resources/backspace.svg")[..],
-                                    ))
-                                    .style(if enabled { white_svg } else { disabled_svg })
-                                    .height(Length::Fixed(MEDIUM_TEXT * 1.2)),
-                                )
-                                .style(transparent_container)
-                                .center(Length::Fill),
-                            )
-                            .width(Length::Fixed(2.0 * MIN_BUTTON_SIZE + SPACING))
-                            .height(Length::Fixed(MIN_BUTTON_SIZE)),
-                            Message::KeypadButtonPress(KeypadButton::Delete,)
-                        ),
-                    ]
-                    .spacing(SPACING),
-                ]
-                .spacing(SPACING),
-            )
+            container(if show_grid(panel_numbers, mode, player_num) {
+                make_player_grid(panel_numbers, mode, player_num)
+            } else {
+                make_number_pad(&page, player_num, enabled)
+            })
             .style(if enabled {
                 light_gray_container
             } else {
@@ -261,5 +163,150 @@ pub(in super::super) fn build_keypad_page<'a>(
     ]
     .spacing(SPACING)
     .height(Length::Fill)
+    .into()
+}
+
+/// The team whose roster the left-hand panel should show. `None` where the page
+/// has no team selected — an "equal" foul or a team warning — and where the page
+/// is not about a player at all.
+fn panel_team(page: &KeypadPage) -> Option<GameColor> {
+    match page {
+        KeypadPage::AddScore(color) | KeypadPage::Penalty(_, color, _, _) => Some(*color),
+        KeypadPage::FoulAdd { color, .. } => *color,
+        KeypadPage::WarningAdd {
+            color,
+            team_warning,
+            ..
+        } => {
+            if *team_warning {
+                None
+            } else {
+                Some(*color)
+            }
+        }
+        KeypadPage::GameNumber | KeypadPage::TeamTimeouts(_, _) | KeypadPage::PortalLogin(_, _) => {
+            None
+        }
+    }
+}
+
+fn make_number_pad<'a>(page: &KeypadPage, player_num: u32, enabled: bool) -> Element<'a, Message> {
+    let setup_keypad_button =
+        |button: Button<'a, Message>, message: Message| -> Button<'a, Message> {
+            let button = if enabled {
+                button.on_press(message)
+            } else {
+                button
+            };
+            button.style(blue_button)
+        };
+
+    let text_displayed = match *page {
+        KeypadPage::WarningAdd { team_warning, .. } => {
+            if team_warning {
+                "TEAM".to_string()
+            } else {
+                player_num.to_string()
+            }
+        }
+        KeypadPage::AddScore(_) => {
+            if player_num == 0 {
+                "TEAM".to_string()
+            } else {
+                player_num.to_string()
+            }
+        }
+        KeypadPage::FoulAdd { color, .. } => {
+            if color.is_none() {
+                "TEAM".to_string()
+            } else {
+                player_num.to_string()
+            }
+        }
+        KeypadPage::GameNumber
+        | KeypadPage::Penalty(_, _, _, _)
+        | KeypadPage::TeamTimeouts(_, _)
+        | KeypadPage::PortalLogin(_, _) => player_num.to_string(),
+    };
+
+    let text_size = MEDIUM_TEXT;
+
+    column![
+        row![
+            text(page.text()).align_x(Horizontal::Left),
+            Space::with_width(Length::Fill),
+            text(text_displayed).size(text_size),
+        ]
+        .width(Length::Fixed(3.0 * MIN_BUTTON_SIZE + 2.0 * SPACING)),
+        row![
+            setup_keypad_button(
+                make_small_button("7", MEDIUM_TEXT),
+                Message::KeypadButtonPress(KeypadButton::Seven,)
+            ),
+            setup_keypad_button(
+                make_small_button("8", MEDIUM_TEXT),
+                Message::KeypadButtonPress(KeypadButton::Eight,)
+            ),
+            setup_keypad_button(
+                make_small_button("9", MEDIUM_TEXT),
+                Message::KeypadButtonPress(KeypadButton::Nine,)
+            ),
+        ]
+        .spacing(SPACING),
+        row![
+            setup_keypad_button(
+                make_small_button("4", MEDIUM_TEXT),
+                Message::KeypadButtonPress(KeypadButton::Four,)
+            ),
+            setup_keypad_button(
+                make_small_button("5", MEDIUM_TEXT),
+                Message::KeypadButtonPress(KeypadButton::Five,)
+            ),
+            setup_keypad_button(
+                make_small_button("6", MEDIUM_TEXT),
+                Message::KeypadButtonPress(KeypadButton::Six,)
+            ),
+        ]
+        .spacing(SPACING),
+        row![
+            setup_keypad_button(
+                make_small_button("1", MEDIUM_TEXT),
+                Message::KeypadButtonPress(KeypadButton::One,)
+            ),
+            setup_keypad_button(
+                make_small_button("2", MEDIUM_TEXT),
+                Message::KeypadButtonPress(KeypadButton::Two,)
+            ),
+            setup_keypad_button(
+                make_small_button("3", MEDIUM_TEXT),
+                Message::KeypadButtonPress(KeypadButton::Three,)
+            ),
+        ]
+        .spacing(SPACING),
+        row![
+            setup_keypad_button(
+                make_small_button("0", MEDIUM_TEXT),
+                Message::KeypadButtonPress(KeypadButton::Zero),
+            ),
+            setup_keypad_button(
+                button(
+                    container(
+                        Svg::new(svg::Handle::from_memory(
+                            &include_bytes!("../../../../resources/backspace.svg")[..],
+                        ))
+                        .style(if enabled { white_svg } else { disabled_svg })
+                        .height(Length::Fixed(MEDIUM_TEXT * 1.2)),
+                    )
+                    .style(transparent_container)
+                    .center(Length::Fill),
+                )
+                .width(Length::Fixed(2.0 * MIN_BUTTON_SIZE + SPACING))
+                .height(Length::Fixed(MIN_BUTTON_SIZE)),
+                Message::KeypadButtonPress(KeypadButton::Delete,)
+            ),
+        ]
+        .spacing(SPACING),
+    ]
+    .spacing(SPACING)
     .into()
 }

--- a/refbox/src/app/view_builders/keypad_pages/mod.rs
+++ b/refbox/src/app/view_builders/keypad_pages/mod.rs
@@ -103,7 +103,13 @@ pub(in super::super) fn build_keypad_page<'a>(
         ),
         row![
             container(if show_grid(panel_numbers, mode, player_num) {
-                make_player_grid(panel_numbers, mode, player_num, enabled)
+                make_player_grid(
+                    make_panel_label(&page, player_num),
+                    panel_numbers,
+                    mode,
+                    player_num,
+                    enabled,
+                )
             } else {
                 make_number_pad(&page, player_num, enabled, role.is_player_page())
             })
@@ -240,22 +246,15 @@ fn panel_role(page: &KeypadPage) -> PanelRole {
     }
 }
 
-fn make_number_pad<'a>(
-    page: &KeypadPage,
-    player_num: u32,
-    enabled: bool,
-    bottom_justified: bool,
-) -> Element<'a, Message> {
-    let setup_keypad_button =
-        |button: Button<'a, Message>, message: Message| -> Button<'a, Message> {
-            let button = if enabled {
-                button.on_press(message)
-            } else {
-                button
-            };
-            button.style(blue_button)
-        };
-
+/// The panel's title row: the page's own label on the left, the value being
+/// entered or selected on the right.
+///
+/// The grid and the pad share it rather than each wording their own title. Two
+/// reasons: the `player-number` label is a two-line phrase ending in a colon in
+/// every locale, so it only reads correctly with the value beside it; and a
+/// shared row is the same box whichever child the panel holds, so no text moves
+/// when the operator toggles to a team the grid cannot be shown for.
+fn make_panel_label<'a>(page: &KeypadPage, player_num: u32) -> Element<'a, Message> {
     let text_displayed = match *page {
         KeypadPage::WarningAdd { team_warning, .. } => {
             if team_warning {
@@ -284,14 +283,32 @@ fn make_number_pad<'a>(
         | KeypadPage::PortalLogin(_, _) => player_num.to_string(),
     };
 
-    let text_size = MEDIUM_TEXT;
-
-    let label = row![
+    row![
         text(page.text()).align_x(Horizontal::Left),
         Space::with_width(Length::Fill),
-        text(text_displayed).size(text_size),
+        text(text_displayed).size(MEDIUM_TEXT),
     ]
-    .width(Length::Fixed(3.0 * MIN_BUTTON_SIZE + 2.0 * SPACING));
+    .width(Length::Fixed(3.0 * MIN_BUTTON_SIZE + 2.0 * SPACING))
+    .into()
+}
+
+fn make_number_pad<'a>(
+    page: &KeypadPage,
+    player_num: u32,
+    enabled: bool,
+    bottom_justified: bool,
+) -> Element<'a, Message> {
+    let setup_keypad_button =
+        |button: Button<'a, Message>, message: Message| -> Button<'a, Message> {
+            let button = if enabled {
+                button.on_press(message)
+            } else {
+                button
+            };
+            button.style(blue_button)
+        };
+
+    let label = make_panel_label(page, player_num);
 
     let digits = column![
         row![

--- a/refbox/src/app/view_builders/keypad_pages/mod.rs
+++ b/refbox/src/app/view_builders/keypad_pages/mod.rs
@@ -56,16 +56,9 @@ pub(in super::super) fn build_keypad_page<'a>(
         ..
     } = data;
 
-    // Today these are exactly the two cases where `panel_team` (below) returns
-    // `None`, so a grid is never actually rendered while disabled. That
-    // agreement is not enforced by the type system, so `enabled` is passed
-    // into `make_player_grid`/`make_grid_cell` too — if a future disabling
-    // condition is ever added here alone, the grid still cannot be tapped.
-    let enabled = match page {
-        KeypadPage::WarningAdd { team_warning, .. } => !team_warning,
-        KeypadPage::FoulAdd { color, .. } => color.is_some(),
-        _ => true,
-    };
+    // Single source of truth for every question the panel asks about this page.
+    let role = panel_role(&page);
+    let enabled = role.is_enabled();
 
     // The team-timeout settings page does not use the shared number pad; it
     // renders as a full-width panel below the game-time bar.
@@ -90,12 +83,12 @@ pub(in super::super) fn build_keypad_page<'a>(
 
     // An empty slice means "no usable roster": the number pad is shown, exactly
     // as it is today. That covers the portal being off, an unassigned team slot,
-    // a fetch that never succeeded, a roster with no cap numbers — and the pages
-    // that are not about players at all, since `panel_team` returns `None`.
+    // a fetch that never succeeded, a roster with no cap numbers — and every
+    // page that names no team, since those roles carry no colour.
     const NO_ROSTER: &[u8] = &[];
-    let panel_numbers: &[u8] = match panel_team(&page) {
-        Some(color) => &rosters[color],
-        None => NO_ROSTER,
+    let panel_numbers: &[u8] = match role {
+        PanelRole::Player(color) => &rosters[color],
+        PanelRole::TeamEntry | PanelRole::NotPlayer => NO_ROSTER,
     };
 
     column![
@@ -112,7 +105,7 @@ pub(in super::super) fn build_keypad_page<'a>(
             container(if show_grid(panel_numbers, mode, player_num) {
                 make_player_grid(panel_numbers, mode, player_num, enabled)
             } else {
-                make_number_pad(&page, player_num, enabled)
+                make_number_pad(&page, player_num, enabled, role.is_player_page())
             })
             .style(if enabled {
                 light_gray_container
@@ -121,13 +114,21 @@ pub(in super::super) fn build_keypad_page<'a>(
             })
             .padding(PADDING)
             // Fixed to the pad's own width (3 columns of MIN_BUTTON_SIZE) so the
-            // panel is the same box whichever child it holds — the grid is
-            // narrower, so it gets centred inside this box instead of shifting
-            // DONE/CANCEL sideways when a page shows a grid for one team and the
-            // pad for the other.
+            // panel is the same box whichever child it holds, and DONE/CANCEL
+            // cannot shift sideways when a page shows a grid for one team and
+            // the pad for the other.
             .width(Length::Fixed(
                 3.0 * MIN_BUTTON_SIZE + 2.0 * SPACING + 2.0 * PADDING
-            )),
+            ))
+            // The player pages get a full-height panel so grid and pad can both
+            // bottom-justify against it (and, in Rugby, so the grid's rows can
+            // share it). The pad-only pages stay content-sized, exactly as they
+            // are today.
+            .height(if role.is_player_page() {
+                Length::Fill
+            } else {
+                Length::Shrink
+            }),
             match page {
                 KeypadPage::AddScore(color) => make_score_add_page(color),
                 KeypadPage::Penalty(origin, color, kind, foul) => {
@@ -179,31 +180,72 @@ pub(in super::super) fn build_keypad_page<'a>(
     .into()
 }
 
-/// The team whose roster the left-hand panel should show. `None` where the page
-/// has no team selected — an "equal" foul or a team warning — and where the page
-/// is not about a player at all.
-fn panel_team(page: &KeypadPage) -> Option<GameColor> {
+/// What the left-hand panel is being asked for on a page.
+///
+/// Everything the panel needs to decide — whether it is enabled, whose roster
+/// it shows, and whether it is full height with its buttons at the bottom —
+/// derives from this one value. Keeping them separate let them drift: three
+/// places each re-deriving "is this a player page" from the page variants is
+/// three places to update when a variant is added.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PanelRole {
+    /// Asks which player, with a team selected. Shows that team's grid, or the
+    /// pad when there is no usable roster for them.
+    Player(GameColor),
+    /// Asks which player, but this entry belongs to no player — an "equal"
+    /// foul, or a team warning. The panel is greyed out.
+    TeamEntry,
+    /// Not about a player at all: game number, timeouts per half, portal login.
+    /// Free digit entry, always enabled, panel sized to its contents.
+    NotPlayer,
+}
+
+impl PanelRole {
+    /// A page that asks which player, whether or not one is currently named.
+    /// These panels are full height with their buttons pinned to the bottom, so
+    /// the grid and the pad cannot disagree about where the buttons sit.
+    fn is_player_page(self) -> bool {
+        matches!(self, Self::Player(_) | Self::TeamEntry)
+    }
+
+    /// The panel greys out only where the entry has no player to name.
+    fn is_enabled(self) -> bool {
+        !matches!(self, Self::TeamEntry)
+    }
+}
+
+fn panel_role(page: &KeypadPage) -> PanelRole {
     match page {
-        KeypadPage::AddScore(color) | KeypadPage::Penalty(_, color, _, _) => Some(*color),
-        KeypadPage::FoulAdd { color, .. } => *color,
+        KeypadPage::AddScore(color) | KeypadPage::Penalty(_, color, _, _) => {
+            PanelRole::Player(*color)
+        }
+        KeypadPage::FoulAdd { color, .. } => match color {
+            Some(color) => PanelRole::Player(*color),
+            None => PanelRole::TeamEntry,
+        },
         KeypadPage::WarningAdd {
             color,
             team_warning,
             ..
         } => {
             if *team_warning {
-                None
+                PanelRole::TeamEntry
             } else {
-                Some(*color)
+                PanelRole::Player(*color)
             }
         }
         KeypadPage::GameNumber | KeypadPage::TeamTimeouts(_, _) | KeypadPage::PortalLogin(_, _) => {
-            None
+            PanelRole::NotPlayer
         }
     }
 }
 
-fn make_number_pad<'a>(page: &KeypadPage, player_num: u32, enabled: bool) -> Element<'a, Message> {
+fn make_number_pad<'a>(
+    page: &KeypadPage,
+    player_num: u32,
+    enabled: bool,
+    bottom_justified: bool,
+) -> Element<'a, Message> {
     let setup_keypad_button =
         |button: Button<'a, Message>, message: Message| -> Button<'a, Message> {
             let button = if enabled {
@@ -244,13 +286,14 @@ fn make_number_pad<'a>(page: &KeypadPage, player_num: u32, enabled: bool) -> Ele
 
     let text_size = MEDIUM_TEXT;
 
-    column![
-        row![
-            text(page.text()).align_x(Horizontal::Left),
-            Space::with_width(Length::Fill),
-            text(text_displayed).size(text_size),
-        ]
-        .width(Length::Fixed(3.0 * MIN_BUTTON_SIZE + 2.0 * SPACING)),
+    let label = row![
+        text(page.text()).align_x(Horizontal::Left),
+        Space::with_width(Length::Fill),
+        text(text_displayed).size(text_size),
+    ]
+    .width(Length::Fixed(3.0 * MIN_BUTTON_SIZE + 2.0 * SPACING));
+
+    let digits = column![
         row![
             setup_keypad_button(
                 make_small_button("7", MEDIUM_TEXT),
@@ -320,6 +363,20 @@ fn make_number_pad<'a>(page: &KeypadPage, player_num: u32, enabled: bool) -> Ele
         ]
         .spacing(SPACING),
     ]
-    .spacing(SPACING)
-    .into()
+    .spacing(SPACING);
+
+    if bottom_justified {
+        // On the four player pages the panel swaps between this pad and the
+        // number grid as the operator toggles teams, so both are pinned to the
+        // bottom of a full-height panel. The button block then lands in exactly
+        // the same place either way and nothing moves under their finger.
+        column![label, Space::with_height(Length::Fill), digits]
+            .spacing(SPACING)
+            .height(Length::Fill)
+            .into()
+    } else {
+        // The pages that only ever show the pad — game number, timeouts per
+        // half, portal login — keep their content-sized panel unchanged.
+        column![label, digits].spacing(SPACING).into()
+    }
 }

--- a/refbox/src/app/view_builders/keypad_pages/mod.rs
+++ b/refbox/src/app/view_builders/keypad_pages/mod.rs
@@ -10,7 +10,7 @@ use iced::{
         button::Button,
         column, container, row,
         svg::{self, Svg},
-        text,
+        text, vertical_space,
     },
 };
 use uwh_common::bundles::BlackWhiteBundle;
@@ -370,8 +370,12 @@ fn make_number_pad<'a>(
         // number grid as the operator toggles teams, so both are pinned to the
         // bottom of a full-height panel. The button block then lands in exactly
         // the same place either way and nothing moves under their finger.
-        column![label, Space::with_height(Length::Fill), digits]
-            .spacing(SPACING)
+        //
+        // No `.spacing()` here: the fill spacer already supplies all the
+        // separation there is slack for, so an outer spacing would only add
+        // two dead gaps this column never uses (see `GRID_BUTTON_SIZE` in
+        // `player_grid.rs` for the height budget that makes those gaps costly).
+        column![label, vertical_space(), digits]
             .height(Length::Fill)
             .into()
     } else {

--- a/refbox/src/app/view_builders/keypad_pages/mod.rs
+++ b/refbox/src/app/view_builders/keypad_pages/mod.rs
@@ -384,3 +384,96 @@ fn make_number_pad<'a>(
         column![label, digits].spacing(SPACING).into()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The three questions the panel asks, for every page variant. `panel_role`
+    /// is the single source of truth for all of them, so a wrong arm here greys
+    /// the wrong panel or shows the wrong team's roster.
+    #[test]
+    fn panel_role_per_page() {
+        let cases: &[(KeypadPage, PanelRole)] = &[
+            (
+                KeypadPage::AddScore(GameColor::Black),
+                PanelRole::Player(GameColor::Black),
+            ),
+            (
+                KeypadPage::Penalty(
+                    None,
+                    GameColor::White,
+                    PenaltyKind::OneMinute,
+                    Infraction::Unknown,
+                ),
+                PanelRole::Player(GameColor::White),
+            ),
+            // An individual foul names a team; an "equal" foul names none.
+            (
+                KeypadPage::FoulAdd {
+                    origin: None,
+                    color: Some(GameColor::Black),
+                    infraction: Infraction::Unknown,
+                    ret_to_overview: false,
+                },
+                PanelRole::Player(GameColor::Black),
+            ),
+            (
+                KeypadPage::FoulAdd {
+                    origin: None,
+                    color: None,
+                    infraction: Infraction::Unknown,
+                    ret_to_overview: false,
+                },
+                PanelRole::TeamEntry,
+            ),
+            // A warning carries a colour either way, so it is `team_warning`
+            // that decides whether a player is being named.
+            (
+                KeypadPage::WarningAdd {
+                    origin: None,
+                    color: GameColor::White,
+                    infraction: Infraction::Unknown,
+                    team_warning: false,
+                    ret_to_overview: false,
+                },
+                PanelRole::Player(GameColor::White),
+            ),
+            (
+                KeypadPage::WarningAdd {
+                    origin: None,
+                    color: GameColor::White,
+                    infraction: Infraction::Unknown,
+                    team_warning: true,
+                    ret_to_overview: false,
+                },
+                PanelRole::TeamEntry,
+            ),
+            (KeypadPage::GameNumber, PanelRole::NotPlayer),
+            (
+                KeypadPage::TeamTimeouts(std::time::Duration::from_secs(60), true),
+                PanelRole::NotPlayer,
+            ),
+            (KeypadPage::PortalLogin(0, false), PanelRole::NotPlayer),
+        ];
+
+        for (page, expected) in cases {
+            assert_eq!(panel_role(page), *expected, "wrong role for {page:?}");
+        }
+    }
+
+    /// Greying and full-height are separate questions: the two team-entry pages
+    /// are greyed but still full height, so the panel does not resize when the
+    /// operator switches an individual foul to an equal one.
+    #[test]
+    fn team_entry_is_greyed_but_still_full_height() {
+        assert!(!PanelRole::TeamEntry.is_enabled());
+        assert!(PanelRole::TeamEntry.is_player_page());
+
+        assert!(PanelRole::Player(GameColor::Black).is_enabled());
+        assert!(PanelRole::Player(GameColor::Black).is_player_page());
+
+        assert!(PanelRole::NotPlayer.is_enabled());
+        assert!(!PanelRole::NotPlayer.is_player_page());
+    }
+}

--- a/refbox/src/app/view_builders/keypad_pages/player_grid.rs
+++ b/refbox/src/app/view_builders/keypad_pages/player_grid.rs
@@ -31,12 +31,18 @@ pub(super) const GRID_BUTTON_SIZE: f32 = MIN_BUTTON_SIZE;
 
 /// Whether this mode's grid stretches to fill the panel's height.
 ///
-/// Every mode carries the panel's title row (about 70px of the 465px budget).
-/// Rugby's five rows cannot keep their square 89px height under that — five
-/// squares plus their gaps need 477 — so the rows share what is left and the
-/// buttons come out visibly shorter than they are wide, rather than the grid
-/// overflowing the panel. The hockey modes have slack even with the title, so
-/// they keep square buttons and sit at the bottom of the panel.
+/// Every mode carries the panel's title row, which measures about 75px of the
+/// 465px budget (two lines of 29px text at iced's 1.3 line height).
+///
+/// Rugby's five square rows do not fit the panel even with no title at all:
+/// `5 * 89 + 4 * SPACING = 477` against 465. The title is not what tips it
+/// over. So its rows share whatever height is left below the title instead, and
+/// the buttons come out visibly shorter than they are wide rather than the grid
+/// overflowing. The hockey modes are at most four rows
+/// (`4 * 89 + 3 * SPACING = 380`), which fits below the title with about 10px
+/// to spare, so they keep square buttons and sit at the bottom of the panel —
+/// see `fixed_height_modes_fit_four_rows_at_most` below, which guards that
+/// margin.
 /// Exhaustive rather than a `matches!`, to match `grid_cells` below: a new mode
 /// should not silently inherit a layout nobody chose for it.
 fn grid_fills_height(mode: Mode) -> bool {
@@ -188,6 +194,28 @@ mod tests {
         // No grid at all, so the value is never read — pinned so the exhaustive
         // match keeps an answer for every mode.
         assert!(!grid_fills_height(Mode::BeepTest));
+    }
+
+    /// The modes that do not stretch keep fixed `GRID_BUTTON_SIZE` rows, and
+    /// four of those plus the title leave only about 10px spare in the panel. A
+    /// fifth fixed row would overflow it while every other test stayed green, so
+    /// the row count is pinned: a mode that grows past four rows has to move to
+    /// `Length::Fill` the way Rugby did, or have the height budget re-checked on
+    /// the display.
+    #[test]
+    fn fixed_height_modes_fit_four_rows_at_most() {
+        for mode in [Mode::Hockey6V6, Mode::Hockey3V3] {
+            assert!(
+                !grid_fills_height(mode),
+                "{mode:?} stretches, so it is exempt"
+            );
+            let rows = grid_cells(mode).div_ceil(GRID_COLUMNS);
+            assert!(
+                rows <= 4,
+                "{mode:?} needs {rows} rows at a fixed {GRID_BUTTON_SIZE}px; the panel \
+                 fits four below the title — stretch this mode or re-check the budget"
+            );
+        }
     }
 }
 

--- a/refbox/src/app/view_builders/keypad_pages/player_grid.rs
+++ b/refbox/src/app/view_builders/keypad_pages/player_grid.rs
@@ -12,10 +12,15 @@ use iced::{
 pub(super) const GRID_COLUMNS: usize = 3;
 
 /// Side length of one grid button. Smaller than `MIN_BUTTON_SIZE` (89) so the
-/// worst case fits with margin: the keypad pages render a time banner (89) and
-/// a timeout ribbon (89) in a 691px window, leaving roughly 481px of usable
-/// panel height. Five rows at 89 comes to 477 — a four-pixel margin. At 80 it
-/// comes to 5 * 80 + 4 * SPACING = 432, which has real headroom.
+/// worst case — five rows in Rugby — fits with margin.
+///
+/// In the default 691px window a keypad page spends 89 on the time banner, 89
+/// on the timeout ribbon, `SPACING` above and below the panel, and `PADDING`
+/// inside its container top and bottom:
+/// `691 - 89 - 8 - 89 - 8 - 16 = 481` px of usable panel height. Five rows at
+/// `MIN_BUTTON_SIZE` need `5 * 89 + 4 * SPACING = 477` — a four-pixel margin,
+/// too fine to rely on across DPI and text scaling. At 80 they need
+/// `5 * 80 + 4 * SPACING = 432`, which leaves real headroom.
 pub(super) const GRID_BUTTON_SIZE: f32 = 80.0;
 
 /// Cells the grid shows for a mode: the rules maximum roster size. `BeepTest`

--- a/refbox/src/app/view_builders/keypad_pages/player_grid.rs
+++ b/refbox/src/app/view_builders/keypad_pages/player_grid.rs
@@ -10,17 +10,20 @@ use iced::{
 /// top to bottom, so this is fixed rather than derived from the roster.
 pub(super) const GRID_COLUMNS: usize = 3;
 
-/// Side length of one grid button. Smaller than `MIN_BUTTON_SIZE` (89) so the
-/// worst case — five rows in Rugby — fits with margin.
+/// Side length of one grid button: the same size the number pad's own buttons
+/// use, so three of them plus two `SPACING` gaps fill the panel's content width
+/// exactly (`3 * 89 + 2 * 8 = 283`). Grid and pad are therefore the same width,
+/// and toggling between a team with a roster and one without cannot shift the
+/// CANCEL and DONE buttons beside them.
 ///
-/// In the default 691px window a keypad page spends 89 on the time banner, 89
-/// on the timeout ribbon, `SPACING` above and below the panel, and `PADDING`
-/// inside its container top and bottom:
-/// `691 - 89 - 8 - 89 - 8 - 16 = 481` px of usable panel height. Five rows at
-/// `MIN_BUTTON_SIZE` need `5 * 89 + 4 * SPACING = 477` — a four-pixel margin,
-/// too fine to rely on across DPI and text scaling. At 80 they need
-/// `5 * 80 + 4 * SPACING = 432`, which leaves real headroom.
-pub(super) const GRID_BUTTON_SIZE: f32 = 80.0;
+/// The binding constraint is height, not width. In the default 691px window a
+/// keypad page spends 89 on the time banner, 89 on the timeout ribbon,
+/// `SPACING` above and below the panel, and `PADDING` inside its container top
+/// and bottom: `691 - 89 - 8 - 89 - 8 - 16 = 481` px of usable panel height.
+/// Rugby's five rows need `5 * 89 + 4 * SPACING = 477`, which fits — but by
+/// only four pixels, so a shorter screen or a larger text scale needs this
+/// checked again on the target display.
+pub(super) const GRID_BUTTON_SIZE: f32 = MIN_BUTTON_SIZE;
 
 /// Cells the grid shows for a mode: the rules maximum roster size. `BeepTest`
 /// has no player attribution at all, so it has no grid.
@@ -169,7 +172,9 @@ pub(super) fn make_player_grid<'a>(
     // Centred, not left-aligned: the grid (3 * GRID_BUTTON_SIZE wide) sits
     // inside a panel box sized for the wider number pad, so without this it
     // would hug the box's left edge instead of sitting in the middle of it.
-    let mut grid = column![].spacing(SPACING).align_x(iced::Alignment::Center);
+    // No horizontal alignment needed: the rows fill the panel's content width
+    // exactly, so there is no slack to distribute.
+    let mut grid = column![].spacing(SPACING);
 
     for cells in grid_rows(numbers, mode) {
         let mut line = row![].spacing(SPACING);

--- a/refbox/src/app/view_builders/keypad_pages/player_grid.rs
+++ b/refbox/src/app/view_builders/keypad_pages/player_grid.rs
@@ -3,7 +3,7 @@
 use super::*;
 use iced::{
     Length,
-    widget::{column, row, text, vertical_space},
+    widget::{column, row, vertical_space},
 };
 
 /// Columns in the player-number grid. The grid is read left to right, then
@@ -31,11 +31,12 @@ pub(super) const GRID_BUTTON_SIZE: f32 = MIN_BUTTON_SIZE;
 
 /// Whether this mode's grid stretches to fill the panel's height.
 ///
-/// Rugby's five rows leave only a few pixels spare, so the rows share the
-/// height between them and the buttons go very slightly off square rather than
-/// leaving an odd gap. The hockey modes have enough slack to keep square
-/// buttons and still fit the page's title above them, so they sit at the
-/// bottom of the panel instead of stretching.
+/// Every mode carries the panel's title row (about 70px of the 465px budget).
+/// Rugby's five rows cannot keep their square 89px height under that — five
+/// squares plus their gaps need 477 — so the rows share what is left and the
+/// buttons come out visibly shorter than they are wide, rather than the grid
+/// overflowing the panel. The hockey modes have slack even with the title, so
+/// they keep square buttons and sit at the bottom of the panel.
 /// Exhaustive rather than a `matches!`, to match `grid_cells` below: a new mode
 /// should not silently inherit a layout nobody chose for it.
 fn grid_fills_height(mode: Mode) -> bool {
@@ -195,7 +196,12 @@ mod tests {
 /// disabled, has no `on_press`, which iced renders in `Status::Disabled` and
 /// `blue_button` paints as window background with grayed text — the
 /// greyed-out look, with no extra style needed.
+///
+/// `label` is the panel's title row, built by `make_panel_label` and identical
+/// to the one the number pad carries. Every mode gets it, so no text appears or
+/// vanishes when the operator toggles to a team whose grid cannot be shown.
 pub(super) fn make_player_grid<'a>(
+    label: Element<'a, Message>,
     numbers: &[u8],
     mode: Mode,
     selected: u32,
@@ -223,17 +229,24 @@ pub(super) fn make_player_grid<'a>(
     }
 
     if fills_height {
-        return grid.into();
+        // Rugby's rows already claim every pixel below the title, so there is
+        // no spacer to separate the two — one `SPACING` gap is spent here
+        // instead, and the rows divide what is left. A two-element column takes
+        // exactly one gap, which the height budget can afford.
+        return column![label, grid]
+            .spacing(SPACING)
+            .height(Length::Fill)
+            .into();
     }
 
-    // The hockey modes have vertical slack, so the page's own title sits at the
-    // top of the panel and the square buttons are pushed to the bottom of it.
+    // The hockey modes have vertical slack, so the title sits at the top of the
+    // panel and the square buttons are pushed to the bottom of it.
     //
     // No `.spacing()` here: the fill spacer already supplies all the
     // separation there is slack for, so an outer spacing would only add two
     // dead gaps this column never uses (see `GRID_BUTTON_SIZE`'s doc comment
     // for the height budget that makes those gaps costly).
-    column![text(fl!("player-number")), vertical_space(), grid]
+    column![label, vertical_space(), grid]
         .height(Length::Fill)
         .into()
 }

--- a/refbox/src/app/view_builders/keypad_pages/player_grid.rs
+++ b/refbox/src/app/view_builders/keypad_pages/player_grid.rs
@@ -184,24 +184,9 @@ mod tests {
         assert!(grid_fills_height(Mode::Rugby));
         assert!(!grid_fills_height(Mode::Hockey6V6));
         assert!(!grid_fills_height(Mode::Hockey3V3));
-    }
-
-    /// Rugby stretches its rows because five of them already fill the panel.
-    /// That reasoning is only sound while Rugby's grid is five rows, so this
-    /// fails if the cell count moves — a prompt to re-check the layout, not a
-    /// rule about the rules.
-    #[test]
-    fn rugby_still_fits_the_five_rows_its_layout_assumes() {
-        let rows = grid_cells(Mode::Rugby).div_ceil(GRID_COLUMNS);
-        assert_eq!(
-            rows, 5,
-            "Rugby's grid changed size; re-check that stretched rows still fit \
-             the panel before updating this number"
-        );
-        assert!(
-            grid_cells(Mode::Rugby) >= grid_cells(Mode::Hockey6V6),
-            "Rugby is assumed to be the tallest grid"
-        );
+        // No grid at all, so the value is never read — pinned so the exhaustive
+        // match keeps an answer for every mode.
+        assert!(!grid_fills_height(Mode::BeepTest));
     }
 }
 
@@ -285,11 +270,11 @@ fn make_grid_cell<'a>(
                 cell_button.on_press(Message::SelectPlayerNumber(target))
             } else {
                 // A disabled panel (team warning, equal foul) must not offer a
-                // tappable cell. `panel_team` returning `None` already empties
-                // the roster for these two cases, so this is currently
-                // unreachable — it stays as a deliberate guard against a
-                // future disabling condition being added to `enabled` alone
-                // (see the doc comment on `enabled` in keypad_pages/mod.rs).
+                // tappable cell. Those pages take `PanelRole::TeamEntry`, which
+                // `build_keypad_page` maps to an empty roster, so no grid is
+                // built for them at all and this is currently unreachable — it
+                // stays as a deliberate guard against a future disabling
+                // condition that greys the panel without emptying the roster.
                 cell_button
             };
             cell_button

--- a/refbox/src/app/view_builders/keypad_pages/player_grid.rs
+++ b/refbox/src/app/view_builders/keypad_pages/player_grid.rs
@@ -3,7 +3,7 @@
 use super::*;
 use iced::{
     Length,
-    widget::{column, row},
+    widget::{column, row, text, vertical_space},
 };
 
 /// Columns in the player-number grid. The grid is read left to right, then
@@ -24,6 +24,24 @@ pub(super) const GRID_COLUMNS: usize = 3;
 /// only four pixels, so a shorter screen or a larger text scale needs this
 /// checked again on the target display.
 pub(super) const GRID_BUTTON_SIZE: f32 = MIN_BUTTON_SIZE;
+
+/// Whether this mode's grid stretches to fill the panel's height.
+///
+/// Rugby's five rows leave only a few pixels spare, so the rows share the
+/// height between them and the buttons go very slightly off square rather than
+/// leaving an odd gap. The hockey modes have a whole row's worth of slack, so
+/// they keep square buttons, sit at the bottom of the panel, and carry the
+/// page's title above them.
+/// Exhaustive rather than a `matches!`, to match `grid_cells` below: a new mode
+/// should not silently inherit a layout nobody chose for it.
+fn grid_fills_height(mode: Mode) -> bool {
+    match mode {
+        Mode::Rugby => true,
+        Mode::Hockey6V6 | Mode::Hockey3V3 => false,
+        // No grid at all, so this is never read.
+        Mode::BeepTest => false,
+    }
+}
 
 /// Cells the grid shows for a mode: the rules maximum roster size. `BeepTest`
 /// has no player attribution at all, so it has no grid.
@@ -156,6 +174,31 @@ mod tests {
     fn number_off_the_roster_falls_back_to_the_pad() {
         assert!(!show_grid(&[1, 7, 12], Mode::Hockey6V6, 23));
     }
+
+    #[test]
+    fn only_rugby_stretches_its_rows() {
+        assert!(grid_fills_height(Mode::Rugby));
+        assert!(!grid_fills_height(Mode::Hockey6V6));
+        assert!(!grid_fills_height(Mode::Hockey3V3));
+    }
+
+    /// Rugby stretches its rows because five of them already fill the panel.
+    /// That reasoning is only sound while Rugby's grid is five rows, so this
+    /// fails if the cell count moves — a prompt to re-check the layout, not a
+    /// rule about the rules.
+    #[test]
+    fn rugby_still_fits_the_five_rows_its_layout_assumes() {
+        let rows = grid_cells(Mode::Rugby).div_ceil(GRID_COLUMNS);
+        assert_eq!(
+            rows, 5,
+            "Rugby's grid changed size; re-check that stretched rows still fit \
+             the panel before updating this number"
+        );
+        assert!(
+            grid_cells(Mode::Rugby) >= grid_cells(Mode::Hockey6V6),
+            "Rugby is assumed to be the tallest grid"
+        );
+    }
 }
 
 /// One row of three cells per grid row. A cell with a number is tappable
@@ -169,28 +212,50 @@ pub(super) fn make_player_grid<'a>(
     selected: u32,
     enabled: bool,
 ) -> Element<'a, Message> {
-    // Centred, not left-aligned: the grid (3 * GRID_BUTTON_SIZE wide) sits
-    // inside a panel box sized for the wider number pad, so without this it
-    // would hug the box's left edge instead of sitting in the middle of it.
     // No horizontal alignment needed: the rows fill the panel's content width
     // exactly, so there is no slack to distribute.
+    let fills_height = grid_fills_height(mode);
+
     let mut grid = column![].spacing(SPACING);
+    if fills_height {
+        grid = grid.height(Length::Fill);
+    }
 
     for cells in grid_rows(numbers, mode) {
         let mut line = row![].spacing(SPACING);
+        if fills_height {
+            // Every row takes an equal share of the panel, so the buttons end
+            // up the same height as each other rather than each keeping the
+            // square height and leaving a gap at the bottom.
+            line = line.height(Length::Fill);
+        }
         for cell in cells {
-            line = line.push(make_grid_cell(cell, selected, enabled));
+            line = line.push(make_grid_cell(cell, selected, enabled, fills_height));
         }
         grid = grid.push(line);
     }
 
-    grid.into()
+    if fills_height {
+        return grid.into();
+    }
+
+    // The hockey modes have vertical slack, so the page's own title sits at the
+    // top of the panel and the square buttons are pushed to the bottom of it.
+    column![text(fl!("player-number")), vertical_space(), grid]
+        .spacing(SPACING)
+        .height(Length::Fill)
+        .into()
 }
 
 /// Reuses `make_small_button` from `shared_elements.rs` (text centred inside
 /// a filled container inside a fixed-size button), overriding its size to
 /// `GRID_BUTTON_SIZE`.
-fn make_grid_cell<'a>(cell: Option<u8>, selected: u32, enabled: bool) -> Element<'a, Message> {
+fn make_grid_cell<'a>(
+    cell: Option<u8>,
+    selected: u32,
+    enabled: bool,
+    fills_height: bool,
+) -> Element<'a, Message> {
     let label = match cell {
         Some(number) => number.to_string(),
         None => String::new(),
@@ -198,7 +263,11 @@ fn make_grid_cell<'a>(cell: Option<u8>, selected: u32, enabled: bool) -> Element
 
     let cell_button = make_small_button(label, MEDIUM_TEXT)
         .width(Length::Fixed(GRID_BUTTON_SIZE))
-        .height(Length::Fixed(GRID_BUTTON_SIZE));
+        .height(if fills_height {
+            Length::Fill
+        } else {
+            Length::Fixed(GRID_BUTTON_SIZE)
+        });
 
     match cell {
         Some(number) => {

--- a/refbox/src/app/view_builders/keypad_pages/player_grid.rs
+++ b/refbox/src/app/view_builders/keypad_pages/player_grid.rs
@@ -16,22 +16,26 @@ pub(super) const GRID_COLUMNS: usize = 3;
 /// and toggling between a team with a roster and one without cannot shift the
 /// CANCEL and DONE buttons beside them.
 ///
-/// The binding constraint is height, not width. In the default 691px window a
-/// keypad page spends 89 on the time banner, 89 on the timeout ribbon,
-/// `SPACING` above and below the panel, and `PADDING` inside its container top
-/// and bottom: `691 - 89 - 8 - 89 - 8 - 16 = 481` px of usable panel height.
-/// Rugby's five rows need `5 * 89 + 4 * SPACING = 477`, which fits — but by
-/// only four pixels, so a shorter screen or a larger text scale needs this
-/// checked again on the target display.
+/// This is not a side length in every mode, though: in Rugby
+/// `GRID_BUTTON_SIZE` is a button *width* only. The height there comes from
+/// `Length::Fill` (see `grid_fills_height` below), which divides up whatever
+/// height the panel has rather than needing five rows to fit at a fixed size.
+///
+/// In the default 691px window a keypad page has `691` window height, minus
+/// `16` for `main_view`'s own top-and-bottom `.padding(PADDING)`, minus `89`
+/// for the timeout ribbon, minus `8` spacing, minus `89` for the game-time
+/// banner, minus `8` spacing, minus `16` for the panel container's own
+/// top-and-bottom `.padding(PADDING)`: `691 - 16 - 89 - 8 - 89 - 8 - 16 = 465`
+/// px of usable panel content height.
 pub(super) const GRID_BUTTON_SIZE: f32 = MIN_BUTTON_SIZE;
 
 /// Whether this mode's grid stretches to fill the panel's height.
 ///
 /// Rugby's five rows leave only a few pixels spare, so the rows share the
 /// height between them and the buttons go very slightly off square rather than
-/// leaving an odd gap. The hockey modes have a whole row's worth of slack, so
-/// they keep square buttons, sit at the bottom of the panel, and carry the
-/// page's title above them.
+/// leaving an odd gap. The hockey modes have enough slack to keep square
+/// buttons and still fit the page's title above them, so they sit at the
+/// bottom of the panel instead of stretching.
 /// Exhaustive rather than a `matches!`, to match `grid_cells` below: a new mode
 /// should not silently inherit a layout nobody chose for it.
 fn grid_fills_height(mode: Mode) -> bool {
@@ -212,8 +216,6 @@ pub(super) fn make_player_grid<'a>(
     selected: u32,
     enabled: bool,
 ) -> Element<'a, Message> {
-    // No horizontal alignment needed: the rows fill the panel's content width
-    // exactly, so there is no slack to distribute.
     let fills_height = grid_fills_height(mode);
 
     let mut grid = column![].spacing(SPACING);
@@ -241,8 +243,12 @@ pub(super) fn make_player_grid<'a>(
 
     // The hockey modes have vertical slack, so the page's own title sits at the
     // top of the panel and the square buttons are pushed to the bottom of it.
+    //
+    // No `.spacing()` here: the fill spacer already supplies all the
+    // separation there is slack for, so an outer spacing would only add two
+    // dead gaps this column never uses (see `GRID_BUTTON_SIZE`'s doc comment
+    // for the height budget that makes those gaps costly).
     column![text(fl!("player-number")), vertical_space(), grid]
-        .spacing(SPACING)
         .height(Length::Fill)
         .into()
 }

--- a/refbox/src/app/view_builders/keypad_pages/player_grid.rs
+++ b/refbox/src/app/view_builders/keypad_pages/player_grid.rs
@@ -3,8 +3,7 @@
 use super::*;
 use iced::{
     Length,
-    alignment::{Horizontal, Vertical},
-    widget::{button, column, container, row, text},
+    widget::{column, row},
 };
 
 /// Columns in the player-number grid. The grid is read left to right, then
@@ -156,21 +155,26 @@ mod tests {
     }
 }
 
-/// One row of three cells per grid row. A cell with a number is tappable; a
-/// leftover cell has no `on_press`, which iced renders in `Status::Disabled`
-/// and `blue_button` paints as window background with grayed text — the
+/// One row of three cells per grid row. A cell with a number is tappable
+/// unless the panel is disabled; a leftover cell (`None`), or any cell while
+/// disabled, has no `on_press`, which iced renders in `Status::Disabled` and
+/// `blue_button` paints as window background with grayed text — the
 /// greyed-out look, with no extra style needed.
 pub(super) fn make_player_grid<'a>(
     numbers: &[u8],
     mode: Mode,
     selected: u32,
+    enabled: bool,
 ) -> Element<'a, Message> {
-    let mut grid = column![].spacing(SPACING);
+    // Centred, not left-aligned: the grid (3 * GRID_BUTTON_SIZE wide) sits
+    // inside a panel box sized for the wider number pad, so without this it
+    // would hug the box's left edge instead of sitting in the middle of it.
+    let mut grid = column![].spacing(SPACING).align_x(iced::Alignment::Center);
 
     for cells in grid_rows(numbers, mode) {
         let mut line = row![].spacing(SPACING);
         for cell in cells {
-            line = line.push(make_grid_cell(cell, selected));
+            line = line.push(make_grid_cell(cell, selected, enabled));
         }
         grid = grid.push(line);
     }
@@ -178,21 +182,16 @@ pub(super) fn make_player_grid<'a>(
     grid.into()
 }
 
-/// Mirrors `make_small_button` in `shared_elements.rs` (text centred inside a
-/// filled container inside a fixed-size button), but at `GRID_BUTTON_SIZE`.
-fn make_grid_cell<'a>(cell: Option<u8>, selected: u32) -> Element<'a, Message> {
+/// Reuses `make_small_button` from `shared_elements.rs` (text centred inside
+/// a filled container inside a fixed-size button), overriding its size to
+/// `GRID_BUTTON_SIZE`.
+fn make_grid_cell<'a>(cell: Option<u8>, selected: u32, enabled: bool) -> Element<'a, Message> {
     let label = match cell {
         Some(number) => number.to_string(),
         None => String::new(),
     };
 
-    let content = text(label)
-        .align_x(Horizontal::Center)
-        .align_y(Vertical::Center)
-        .width(Length::Shrink)
-        .size(MEDIUM_TEXT);
-
-    let cell_button = button(container(content).center(Length::Fill))
+    let cell_button = make_small_button(label, MEDIUM_TEXT)
         .width(Length::Fixed(GRID_BUTTON_SIZE))
         .height(Length::Fixed(GRID_BUTTON_SIZE));
 
@@ -202,8 +201,18 @@ fn make_grid_cell<'a>(cell: Option<u8>, selected: u32) -> Element<'a, Message> {
             // Tapping the selected cell again clears the selection, which on
             // the goal page returns to a team goal.
             let target = if is_selected { 0 } else { u32::from(number) };
+            let cell_button = if enabled {
+                cell_button.on_press(Message::SelectPlayerNumber(target))
+            } else {
+                // A disabled panel (team warning, equal foul) must not offer a
+                // tappable cell. `panel_team` returning `None` already empties
+                // the roster for these two cases, so this is currently
+                // unreachable — it stays as a deliberate guard against a
+                // future disabling condition being added to `enabled` alone
+                // (see the doc comment on `enabled` in keypad_pages/mod.rs).
+                cell_button
+            };
             cell_button
-                .on_press(Message::SelectPlayerNumber(target))
                 .style(if is_selected {
                     blue_selected_button
                 } else {

--- a/refbox/src/app/view_builders/keypad_pages/player_grid.rs
+++ b/refbox/src/app/view_builders/keypad_pages/player_grid.rs
@@ -1,0 +1,211 @@
+// `use super::*` is how every sibling in this directory picks up the theme
+// constants, styles and `Message` — mirror `foul_add.rs`, do not re-import them.
+use super::*;
+use iced::{
+    Length,
+    alignment::{Horizontal, Vertical},
+    widget::{button, column, container, row, text},
+};
+
+/// Columns in the player-number grid. The grid is read left to right, then
+/// top to bottom, so this is fixed rather than derived from the roster.
+pub(super) const GRID_COLUMNS: usize = 3;
+
+/// Side length of one grid button. Smaller than `MIN_BUTTON_SIZE` (89) so the
+/// worst case fits with margin: the keypad pages render a time banner (89) and
+/// a timeout ribbon (89) in a 691px window, leaving roughly 481px of usable
+/// panel height. Five rows at 89 comes to 477 — a four-pixel margin. At 80 it
+/// comes to 5 * 80 + 4 * SPACING = 432, which has real headroom.
+pub(super) const GRID_BUTTON_SIZE: f32 = 80.0;
+
+/// Cells the grid shows for a mode: the rules maximum roster size. `BeepTest`
+/// has no player attribution at all, so it has no grid.
+pub(super) fn grid_cells(mode: Mode) -> usize {
+    match mode {
+        Mode::Hockey3V3 => 6,
+        Mode::Hockey6V6 => 12,
+        Mode::Rugby => 15,
+        Mode::BeepTest => 0,
+    }
+}
+
+/// Lay a team's cap numbers into grid rows: ascending, packed from the top
+/// left, `None` for the cells left over once the roster runs out.
+///
+/// The portal restricts team size, so a roster longer than the mode's grid
+/// should not occur; `truncate` keeps that from panicking or silently
+/// reflowing the grid if it ever does.
+pub(super) fn grid_rows(numbers: &[u8], mode: Mode) -> Vec<Vec<Option<u8>>> {
+    let cells = grid_cells(mode);
+
+    let mut sorted = numbers.to_vec();
+    sorted.sort_unstable();
+    sorted.dedup();
+    sorted.truncate(cells);
+
+    let mut flat: Vec<Option<u8>> = sorted.into_iter().map(Some).collect();
+    flat.resize(cells, None);
+
+    flat.chunks(GRID_COLUMNS).map(<[_]>::to_vec).collect()
+}
+
+/// Whether the grid can be shown for this team, or the number pad must be.
+///
+/// The grid needs usable numbers and a mode that has a grid at all. It also
+/// has to be able to display whatever number is already entered: an entry
+/// being edited may hold a number that is not on the current roster, and that
+/// number must stay visible, so those fall back to the pad. `0` means nothing
+/// is selected (and, on the goal page, a team goal), which the grid shows fine.
+pub(super) fn show_grid(numbers: &[u8], mode: Mode, current: u32) -> bool {
+    if numbers.is_empty() || grid_cells(mode) == 0 {
+        return false;
+    }
+
+    match u8::try_from(current) {
+        Ok(0) => true,
+        Ok(n) => numbers.contains(&n),
+        Err(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cells_per_mode() {
+        assert_eq!(grid_cells(Mode::Hockey3V3), 6);
+        assert_eq!(grid_cells(Mode::Hockey6V6), 12);
+        assert_eq!(grid_cells(Mode::Rugby), 15);
+        assert_eq!(grid_cells(Mode::BeepTest), 0);
+    }
+
+    #[test]
+    fn packs_ascending_left_to_right_then_down() {
+        let rows = grid_rows(&[5, 1, 4, 2], Mode::Hockey3V3);
+        assert_eq!(
+            rows,
+            vec![vec![Some(1), Some(2), Some(4)], vec![Some(5), None, None],]
+        );
+    }
+
+    #[test]
+    fn full_roster_leaves_no_gaps() {
+        let numbers: Vec<u8> = (1..=12).collect();
+        let rows = grid_rows(&numbers, Mode::Hockey6V6);
+        assert_eq!(rows.len(), 4);
+        assert!(rows.iter().flatten().all(Option::is_some));
+    }
+
+    #[test]
+    fn gaps_in_cap_numbers_are_packed_not_positioned() {
+        // 1, 2, 4 — no hole where 3 would be.
+        let rows = grid_rows(&[1, 2, 4], Mode::Hockey3V3);
+        assert_eq!(rows[0], vec![Some(1), Some(2), Some(4)]);
+    }
+
+    #[test]
+    fn numbers_above_the_cell_count_are_allowed() {
+        // The portal caps the number of players, not the numbers they wear.
+        let rows = grid_rows(&[1, 16], Mode::Rugby);
+        assert_eq!(rows[0], vec![Some(1), Some(16), None]);
+    }
+
+    #[test]
+    fn duplicates_collapse() {
+        let rows = grid_rows(&[7, 7, 8], Mode::Hockey3V3);
+        assert_eq!(rows[0], vec![Some(7), Some(8), None]);
+    }
+
+    #[test]
+    fn oversized_roster_is_truncated_not_reflowed() {
+        let numbers: Vec<u8> = (1..=20).collect();
+        let rows = grid_rows(&numbers, Mode::Hockey6V6);
+        assert_eq!(rows.len(), 4, "grid must stay at the mode's size");
+        assert_eq!(rows[3], vec![Some(10), Some(11), Some(12)]);
+    }
+
+    #[test]
+    fn empty_roster_means_no_grid() {
+        assert!(!show_grid(&[], Mode::Hockey6V6, 0));
+    }
+
+    #[test]
+    fn beep_test_has_no_grid() {
+        assert!(!show_grid(&[1, 2, 3], Mode::BeepTest, 0));
+    }
+
+    #[test]
+    fn roster_with_numbers_shows_grid() {
+        assert!(show_grid(&[1, 2, 3], Mode::Hockey6V6, 0));
+    }
+
+    #[test]
+    fn number_on_the_roster_shows_grid() {
+        assert!(show_grid(&[1, 7, 12], Mode::Hockey6V6, 7));
+    }
+
+    #[test]
+    fn number_off_the_roster_falls_back_to_the_pad() {
+        assert!(!show_grid(&[1, 7, 12], Mode::Hockey6V6, 23));
+    }
+}
+
+/// One row of three cells per grid row. A cell with a number is tappable; a
+/// leftover cell has no `on_press`, which iced renders in `Status::Disabled`
+/// and `blue_button` paints as window background with grayed text — the
+/// greyed-out look, with no extra style needed.
+pub(super) fn make_player_grid<'a>(
+    numbers: &[u8],
+    mode: Mode,
+    selected: u32,
+) -> Element<'a, Message> {
+    let mut grid = column![].spacing(SPACING);
+
+    for cells in grid_rows(numbers, mode) {
+        let mut line = row![].spacing(SPACING);
+        for cell in cells {
+            line = line.push(make_grid_cell(cell, selected));
+        }
+        grid = grid.push(line);
+    }
+
+    grid.into()
+}
+
+/// Mirrors `make_small_button` in `shared_elements.rs` (text centred inside a
+/// filled container inside a fixed-size button), but at `GRID_BUTTON_SIZE`.
+fn make_grid_cell<'a>(cell: Option<u8>, selected: u32) -> Element<'a, Message> {
+    let label = match cell {
+        Some(number) => number.to_string(),
+        None => String::new(),
+    };
+
+    let content = text(label)
+        .align_x(Horizontal::Center)
+        .align_y(Vertical::Center)
+        .width(Length::Shrink)
+        .size(MEDIUM_TEXT);
+
+    let cell_button = button(container(content).center(Length::Fill))
+        .width(Length::Fixed(GRID_BUTTON_SIZE))
+        .height(Length::Fixed(GRID_BUTTON_SIZE));
+
+    match cell {
+        Some(number) => {
+            let is_selected = selected != 0 && selected == u32::from(number);
+            // Tapping the selected cell again clears the selection, which on
+            // the goal page returns to a team goal.
+            let target = if is_selected { 0 } else { u32::from(number) };
+            cell_button
+                .on_press(Message::SelectPlayerNumber(target))
+                .style(if is_selected {
+                    blue_selected_button
+                } else {
+                    blue_button
+                })
+                .into()
+        }
+        None => cell_button.style(blue_button).into(),
+    }
+}


### PR DESCRIPTION
## What changed

On the four pages that ask which player — goal, penalty, foul and warning — the number keypad is
replaced by a grid of that team's actual cap numbers, taken from the tournament portal. The operator
taps the player's number instead of typing it.

The grid only appears when there is something to show. If a team has no usable roster — the portal is
off, the team slot is unassigned, the fetch failed, or nobody has a cap number — the page shows
exactly the keypad it always has. Pages that are not about a player (game number, timeouts per half,
portal login) are untouched.

Three smaller behaviour changes come with it:

- Switching teams now clears the number already entered, on the keypad as well as the grid. Without
  this, a number tapped for one team could be committed against the other.
- Each team's roster is fixed at kickoff and held for the whole game. A mid-game portal refresh will
  not move the grid under the operator's hand.
- Tapping the selected number again clears it, which on the goal page means a team goal.

## Why

Typing a cap number is slow and easy to get wrong at poolside, and a wrong number is worse than
none: it attributes a goal or a penalty to a player who did not earn it, and that attribution is what
gets sent to the portal's statistics. Tapping a number that is known to be on the team's roster
removes both the typing and the class of error where the number does not belong to anyone playing.

## Scope

`refbox` only. Changes are limited to:

- `refbox/src/app/view_builders/keypad_pages/` — the panel itself and the new grid
- `refbox/src/app/mod.rs` — fetching team rosters and freezing them at kickoff
- `refbox/src/app/message.rs` — one new action for tapping a grid cell

No changes to `uwh-common`, the wire format, the game clock, or the tournament manager. No new
dependencies. No translation keys added — the panel's existing label is reused.

## How to verify

Needs a portal event whose teams have cap numbers on their rosters.

1. Link an event and court, then start a game.
2. Record a goal. The panel shows that team's numbers as buttons, four rows of three, sitting at the
   bottom of the panel under the "PLAYER NUMBER:" heading.
3. Tap a number — it highlights. Tap it again — it clears back to TEAM.
4. Switch to the other team. The numbers change to that team's, and any number you had entered is
   cleared.
5. Repeat on the penalty, foul and warning pages — same panel in the same position.
6. Switch to a team with no cap numbers in the portal. You get the ordinary keypad, and the CANCEL
   and DONE buttons beside the panel do not move.
7. An "equal" foul or a team warning greys the panel out, as it does today.

Verified before opening: `just check` clean; a full walkthrough of all four pages in Hockey 6V6 and
Rugby; and an end-to-end run against dev.uwhportal.com where numbers tapped on the grid arrived in
the portal's statistics as named scorers and a penalty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
