### PR TITLE
feat(refbox): add a team score button and show a dash for no player

### DIFF
--- a/refbox/src/app/message.rs
+++ b/refbox/src/app/message.rs
@@ -886,6 +886,9 @@ pub enum BoolGameParameter {
     // editor (surfaced per the former ADR-009 Task 14 TODO). Toggles the staged
     // `single_half` choice held in AppState::ParameterEditor.
     SingleHalf,
+    /// Emitted by the TEAM SCORE button on the goal page. Toggles
+    /// `KeypadPage::AddScore`'s `team_score`, mirroring `TeamWarning`.
+    TeamScore,
     WhiteOnRight,
     UsingUwhPortal,
     SoundEnabled,
@@ -925,7 +928,15 @@ pub enum ScrollOption {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum KeypadPage {
-    AddScore(GameColor),
+    AddScore {
+        color: GameColor,
+        /// Set when the operator has explicitly attributed the goal to the team
+        /// rather than to a player — an unknown scorer, or a penalty goal where
+        /// no individual is credited. Mirrors `WarningAdd`'s `team_warning`: it
+        /// greys the number panel, and it is what lets DONE tell "the team
+        /// scored" apart from "nobody chosen yet".
+        team_score: bool,
+    },
     Penalty(
         Option<(GameColor, usize)>,
         GameColor,
@@ -953,7 +964,7 @@ pub enum KeypadPage {
 impl KeypadPage {
     pub fn max_val(&self) -> u32 {
         match self {
-            Self::AddScore(_)
+            Self::AddScore { .. }
             | Self::Penalty(_, _, _, _)
             | Self::FoulAdd { .. }
             | Self::WarningAdd { .. } => 99,
@@ -965,7 +976,7 @@ impl KeypadPage {
 
     pub fn text(&self) -> String {
         match self {
-            Self::AddScore(_)
+            Self::AddScore { .. }
             | Self::Penalty(_, _, _, _)
             | Self::FoulAdd { .. }
             | Self::WarningAdd { .. } => fl!("player-number"),

--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -2239,7 +2239,16 @@ impl RefBoxApp {
             }
             Message::AddNewScore(color) => {
                 let task = if self.config.collect_scorer_cap_num {
-                    self.app_state = AppState::KeypadPage(KeypadPage::AddScore(color), 0);
+                    // Opens with `team_score` off: naming the scorer is the
+                    // normal case, so the grid stays live and the operator taps
+                    // TEAM SCORE only when there is no individual to credit.
+                    self.app_state = AppState::KeypadPage(
+                        KeypadPage::AddScore {
+                            color,
+                            team_score: false,
+                        },
+                        0,
+                    );
                     Task::none()
                 } else {
                     let mut tm = self.tm.lock().unwrap();
@@ -2682,7 +2691,7 @@ impl RefBoxApp {
             }
             Message::KeypadPage(mut page) => {
                 let init_val = match page {
-                    KeypadPage::AddScore(_)
+                    KeypadPage::AddScore { .. }
                     | KeypadPage::Penalty(None, _, _, _)
                     | KeypadPage::FoulAdd { origin: None, .. }
                     | KeypadPage::WarningAdd { origin: None, .. } => 0,
@@ -2793,7 +2802,7 @@ impl RefBoxApp {
             Message::ChangeColor(new_color) => {
                 match self.app_state {
                     AppState::KeypadPage(
-                        KeypadPage::AddScore(ref mut color),
+                        KeypadPage::AddScore { ref mut color, .. },
                         ref mut player_num,
                     )
                     | AppState::KeypadPage(
@@ -2826,7 +2835,7 @@ impl RefBoxApp {
             Message::AddScoreComplete { canceled } => {
                 let mut task = Task::none();
                 self.app_state = if !canceled {
-                    if let AppState::KeypadPage(KeypadPage::AddScore(color), player) =
+                    if let AppState::KeypadPage(KeypadPage::AddScore { color, .. }, player) =
                         self.app_state
                     {
                         let mut tm = self.tm.lock().unwrap();
@@ -3800,6 +3809,27 @@ impl RefBoxApp {
                         trace!("AppState changed to {:?}", self.app_state)
                     }
 
+                    BoolGameParameter::TeamScore => {
+                        if let AppState::KeypadPage(
+                            KeypadPage::AddScore {
+                                ref mut team_score, ..
+                            },
+                            ref mut player_num,
+                        ) = self.app_state
+                        {
+                            *team_score ^= true;
+                            if *team_score {
+                                // The goal is the team's, so no player number
+                                // may linger: the readout, the greyed panel and
+                                // the score that gets recorded must agree.
+                                *player_num = 0;
+                            }
+                        } else {
+                            unreachable!()
+                        }
+                        trace!("AppState changed to {:?}", self.app_state)
+                    }
+
                     BoolGameParameter::TimeoutsCountedPerHalf => {
                         if let AppState::KeypadPage(
                             KeypadPage::TeamTimeouts(_, ref mut per_half),
@@ -3892,6 +3922,7 @@ impl RefBoxApp {
                                 edited_settings.show_behind_schedule_time ^= true
                             }
                             BoolGameParameter::TeamWarning
+                            | BoolGameParameter::TeamScore
                             | BoolGameParameter::TimeoutsCountedPerHalf
                             | BoolGameParameter::SingleHalf => {
                                 unreachable!()

--- a/refbox/src/app/view_builders/keypad_pages/mod.rs
+++ b/refbox/src/app/view_builders/keypad_pages/mod.rs
@@ -104,14 +104,14 @@ pub(in super::super) fn build_keypad_page<'a>(
         row![
             container(if show_grid(panel_numbers, mode, player_num) {
                 make_player_grid(
-                    make_panel_label(&page, player_num),
+                    make_panel_label(&page, role, player_num),
                     panel_numbers,
                     mode,
                     player_num,
                     enabled,
                 )
             } else {
-                make_number_pad(&page, player_num, enabled, role.is_player_page())
+                make_number_pad(&page, role, player_num, enabled)
             })
             .style(if enabled {
                 light_gray_container
@@ -220,6 +220,31 @@ impl PanelRole {
     }
 }
 
+/// The title row's value when no individual player is named. Deliberately a
+/// glyph rather than a translated word — see `panel_value`.
+const NO_PLAYER_VALUE: &str = "-";
+
+/// Shown at the right of the panel's title row: the player's number, or
+/// `NO_PLAYER_VALUE` where no individual player is named.
+///
+/// A glyph rather than a word for two reasons. It needs no translation, and one
+/// narrow character cannot overflow the fixed-width title row — a translated
+/// "TEAM" could, since German "MANNSCHAFT" at `MEDIUM_TEXT` is most of the row
+/// on its own.
+///
+/// Derived from `PanelRole` rather than matched per page, so it cannot drift
+/// from `panel_role`, which is already the single source of truth for which
+/// pages name a player. The non-player pages keep their real digits, including
+/// `0`: zero timeouts per half is a legitimate setting, and a portal login code
+/// may begin with `0`.
+fn panel_value(role: PanelRole, player_num: u32) -> String {
+    if role.is_player_page() && player_num == 0 {
+        NO_PLAYER_VALUE.to_string()
+    } else {
+        player_num.to_string()
+    }
+}
+
 fn panel_role(page: &KeypadPage) -> PanelRole {
     match page {
         KeypadPage::AddScore(color) | KeypadPage::Penalty(_, color, _, _) => {
@@ -254,39 +279,15 @@ fn panel_role(page: &KeypadPage) -> PanelRole {
 /// every locale, so it only reads correctly with the value beside it; and a
 /// shared row is the same box whichever child the panel holds, so no text moves
 /// when the operator toggles to a team the grid cannot be shown for.
-fn make_panel_label<'a>(page: &KeypadPage, player_num: u32) -> Element<'a, Message> {
-    let text_displayed = match *page {
-        KeypadPage::WarningAdd { team_warning, .. } => {
-            if team_warning {
-                "TEAM".to_string()
-            } else {
-                player_num.to_string()
-            }
-        }
-        KeypadPage::AddScore(_) => {
-            if player_num == 0 {
-                "TEAM".to_string()
-            } else {
-                player_num.to_string()
-            }
-        }
-        KeypadPage::FoulAdd { color, .. } => {
-            if color.is_none() {
-                "TEAM".to_string()
-            } else {
-                player_num.to_string()
-            }
-        }
-        KeypadPage::GameNumber
-        | KeypadPage::Penalty(_, _, _, _)
-        | KeypadPage::TeamTimeouts(_, _)
-        | KeypadPage::PortalLogin(_, _) => player_num.to_string(),
-    };
-
+fn make_panel_label<'a>(
+    page: &KeypadPage,
+    role: PanelRole,
+    player_num: u32,
+) -> Element<'a, Message> {
     row![
         text(page.text()).align_x(Horizontal::Left),
         Space::with_width(Length::Fill),
-        text(text_displayed).size(MEDIUM_TEXT),
+        text(panel_value(role, player_num)).size(MEDIUM_TEXT),
     ]
     .width(Length::Fixed(3.0 * MIN_BUTTON_SIZE + 2.0 * SPACING))
     .into()
@@ -294,9 +295,9 @@ fn make_panel_label<'a>(page: &KeypadPage, player_num: u32) -> Element<'a, Messa
 
 fn make_number_pad<'a>(
     page: &KeypadPage,
+    role: PanelRole,
     player_num: u32,
     enabled: bool,
-    bottom_justified: bool,
 ) -> Element<'a, Message> {
     let setup_keypad_button =
         |button: Button<'a, Message>, message: Message| -> Button<'a, Message> {
@@ -308,7 +309,7 @@ fn make_number_pad<'a>(
             button.style(blue_button)
         };
 
-    let label = make_panel_label(page, player_num);
+    let label = make_panel_label(page, role, player_num);
 
     let digits = column![
         row![
@@ -382,7 +383,7 @@ fn make_number_pad<'a>(
     ]
     .spacing(SPACING);
 
-    if bottom_justified {
+    if role.is_player_page() {
         // On the four player pages the panel swaps between this pad and the
         // number grid as the operator toggles teams, so both are pinned to the
         // bottom of a full-height panel. The button block then lands in exactly
@@ -492,5 +493,32 @@ mod tests {
 
         assert!(PanelRole::NotPlayer.is_enabled());
         assert!(!PanelRole::NotPlayer.is_player_page());
+    }
+
+    /// `-` means "no individual player named". It replaces both the old English
+    /// `"TEAM"` (which no locale had a key for, and whose translations would
+    /// overflow the fixed-width row) and the bare `0` the penalty/foul/warning
+    /// pages showed before a number was entered — `0` is not a value on those
+    /// pages, since all three commit gates require `player_num > 0`.
+    #[test]
+    fn panel_value_shows_a_dash_where_no_player_is_named() {
+        // Team entry — an equal foul or a team warning names nobody, ever.
+        assert_eq!(panel_value(PanelRole::TeamEntry, 0), "-");
+
+        // A player page with nothing entered yet.
+        assert_eq!(panel_value(PanelRole::Player(GameColor::Black), 0), "-");
+
+        // A player page with a number: the number, unchanged.
+        assert_eq!(panel_value(PanelRole::Player(GameColor::Black), 7), "7");
+        assert_eq!(panel_value(PanelRole::Player(GameColor::White), 99), "99");
+    }
+
+    /// The pages that are not about a player keep showing real digits, including
+    /// `0`: timeouts-per-half of 0 is a legitimate setting, and a portal login
+    /// code may legitimately begin with 0.
+    #[test]
+    fn panel_value_keeps_zero_on_the_non_player_pages() {
+        assert_eq!(panel_value(PanelRole::NotPlayer, 0), "0");
+        assert_eq!(panel_value(PanelRole::NotPlayer, 42), "42");
     }
 }

--- a/refbox/src/app/view_builders/keypad_pages/mod.rs
+++ b/refbox/src/app/view_builders/keypad_pages/mod.rs
@@ -136,7 +136,8 @@ pub(in super::super) fn build_keypad_page<'a>(
                 Length::Shrink
             }),
             match page {
-                KeypadPage::AddScore(color) => make_score_add_page(color),
+                KeypadPage::AddScore { color, team_score } =>
+                    make_score_add_page(color, team_score, player_num),
                 KeypadPage::Penalty(origin, color, kind, foul) => {
                     make_penalty_edit_page(
                         origin,
@@ -247,9 +248,16 @@ fn panel_value(role: PanelRole, player_num: u32) -> String {
 
 fn panel_role(page: &KeypadPage) -> PanelRole {
     match page {
-        KeypadPage::AddScore(color) | KeypadPage::Penalty(_, color, _, _) => {
-            PanelRole::Player(*color)
+        // A team goal names no individual, so it takes the same greyed panel an
+        // equal foul and a team warning do.
+        KeypadPage::AddScore { color, team_score } => {
+            if *team_score {
+                PanelRole::TeamEntry
+            } else {
+                PanelRole::Player(*color)
+            }
         }
+        KeypadPage::Penalty(_, color, _, _) => PanelRole::Player(*color),
         KeypadPage::FoulAdd { color, .. } => match color {
             Some(color) => PanelRole::Player(*color),
             None => PanelRole::TeamEntry,
@@ -414,8 +422,20 @@ mod tests {
     fn panel_role_per_page() {
         let cases: &[(KeypadPage, PanelRole)] = &[
             (
-                KeypadPage::AddScore(GameColor::Black),
+                KeypadPage::AddScore {
+                    color: GameColor::Black,
+                    team_score: false,
+                },
                 PanelRole::Player(GameColor::Black),
+            ),
+            // A team goal names nobody, so it greys the panel like a team
+            // warning does.
+            (
+                KeypadPage::AddScore {
+                    color: GameColor::Black,
+                    team_score: true,
+                },
+                PanelRole::TeamEntry,
             ),
             (
                 KeypadPage::Penalty(

--- a/refbox/src/app/view_builders/keypad_pages/score_add.rs
+++ b/refbox/src/app/view_builders/keypad_pages/score_add.rs
@@ -10,18 +10,32 @@ use uwh_common::color::Color as GameColor;
 
 type StyleFn = fn(&Theme, Status) -> Style;
 
-pub(super) fn make_score_add_page<'a>(color: GameColor) -> Element<'a, Message> {
+pub(super) fn make_score_add_page<'a>(
+    color: GameColor,
+    team_score: bool,
+    player_num: u32,
+) -> Element<'a, Message> {
     let (black_style, white_style): (StyleFn, StyleFn) = match color {
         GameColor::Black => (black_selected_button, white_button),
         GameColor::White => (black_button, white_selected_button),
     };
 
+    let team_score_style = if team_score {
+        blue_selected_button
+    } else {
+        blue_button
+    };
+
     column![
-        vertical_space(),
+        // The team option sits between the two teams, matching the foul page's
+        // "=" button, and the row is pinned to the top like the warnings page's.
         row![
             make_button(fl!("dark-team-name-caps"))
                 .style(black_style)
                 .on_press(Message::ChangeColor(Some(GameColor::Black))),
+            make_multi_label_button((fl!("team-score-line-1"), fl!("team-score-line-2")))
+                .on_press(Message::ToggleBoolParameter(BoolGameParameter::TeamScore))
+                .style(team_score_style),
             make_button(fl!("light-team-name-caps"))
                 .style(white_style)
                 .on_press(Message::ChangeColor(Some(GameColor::White))),
@@ -36,10 +50,39 @@ pub(super) fn make_score_add_page<'a>(color: GameColor) -> Element<'a, Message> 
             make_button(fl!("done"))
                 .style(green_button)
                 .width(Length::Fill)
-                .on_press(Message::AddScoreComplete { canceled: false }),
+                .on_press_maybe(
+                    score_add_can_commit(team_score, player_num)
+                        .then_some(Message::AddScoreComplete { canceled: false }),
+                ),
         ]
         .spacing(SPACING),
     ]
     .spacing(SPACING)
     .into()
+}
+
+/// Returns true when the goal can be saved: either a scorer is named, or the
+/// operator has explicitly attributed it to the team — an unknown scorer, or a
+/// penalty goal where no individual is credited.
+///
+/// Not default-true. Previously DONE committed a team goal whenever no number
+/// was selected, so a forgotten scorer was silently recorded as a team goal.
+/// Attribution now costs one deliberate tap.
+fn score_add_can_commit(team_score: bool, player_num: u32) -> bool {
+    team_score || player_num > 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn score_needs_a_player_or_an_explicit_team_choice() {
+        // Nothing chosen — the old silent-team-goal case, now blocked.
+        assert!(!score_add_can_commit(false, 0));
+        // Explicitly the team's goal.
+        assert!(score_add_can_commit(true, 0));
+        // A named scorer.
+        assert!(score_add_can_commit(false, 7));
+    }
 }

--- a/refbox/src/app/view_builders/keypad_pages/warning_add.rs
+++ b/refbox/src/app/view_builders/keypad_pages/warning_add.rs
@@ -71,12 +71,14 @@ pub(super) fn make_warning_add_page<'a>(
     );
     column![
         row![
-            make_multi_label_button((fl!("team-warning-line-1"), fl!("team-warning-line-2")))
-                .on_press(Message::ToggleBoolParameter(BoolGameParameter::TeamWarning))
-                .style(team_warning_style),
             make_button(fl!("dark-team-name-caps"))
                 .style(black_style)
                 .on_press(Message::ChangeColor(Some(GameColor::Black))),
+            // Between the two teams, matching the foul page's "=" button and the
+            // goal page's TEAM SCORE. Order only — no behaviour change.
+            make_multi_label_button((fl!("team-warning-line-1"), fl!("team-warning-line-2")))
+                .on_press(Message::ToggleBoolParameter(BoolGameParameter::TeamWarning))
+                .style(team_warning_style),
             make_button(fl!("light-team-name-caps"))
                 .style(white_style)
                 .on_press(Message::ChangeColor(Some(GameColor::White))),

--- a/refbox/translations/de-DE/refbox.ftl
+++ b/refbox/translations/de-DE/refbox.ftl
@@ -39,6 +39,8 @@ team-warning = MANNSCHAFT
     VERWARNUNG
 team-warning-line-1 = MANNSCHAFT
 team-warning-line-2 = VERWARNUNG
+team-score-line-1 = MANNSCHAFT
+team-score-line-2 = TORE
 
 # Konfiguration
 none-selected = Nichts ausgewählt

--- a/refbox/translations/en-US/refbox.ftl
+++ b/refbox/translations/en-US/refbox.ftl
@@ -38,6 +38,8 @@ team-warning = TEAM
     WARNING
 team-warning-line-1 = TEAM
 team-warning-line-2 = WARNING
+team-score-line-1 = TEAM
+team-score-line-2 = SCORE
 
 # Configuration
 none-selected = None Selected

--- a/refbox/translations/es/refbox.ftl
+++ b/refbox/translations/es/refbox.ftl
@@ -38,6 +38,8 @@ team-warning = AVISO
     DE EQUIPO
 team-warning-line-1 = AVISO
 team-warning-line-2 = DE EQUIPO
+team-score-line-1 = PUNTUACIÓN
+team-score-line-2 = DE EQUIPO
 
 # Configuration
 none-selected = Ninguno seleccionado

--- a/refbox/translations/fr/refbox.ftl
+++ b/refbox/translations/fr/refbox.ftl
@@ -36,6 +36,8 @@ team-timeout-count = NOMBRE DE
 team-warning = AVERT. D'ÉQUIPE
 team-warning-line-1 = AVERT.
 team-warning-line-2 = D'ÉQUIPE
+team-score-line-1 = SCORE
+team-score-line-2 = D'ÉQUIPE
 
 # Configuration
 none-selected = Aucun Sélectionné

--- a/refbox/translations/id-ID/refbox.ftl
+++ b/refbox/translations/id-ID/refbox.ftl
@@ -39,6 +39,8 @@ team-warning = PERINGATAN
     TIM
 team-warning-line-1 = PERINGATAN
 team-warning-line-2 = TIM
+team-score-line-1 = SKOR
+team-score-line-2 = TIM
 
 # Konfigurasi
 none-selected = Tidak Ada Dipilih

--- a/refbox/translations/it-IT/refbox.ftl
+++ b/refbox/translations/it-IT/refbox.ftl
@@ -39,6 +39,8 @@ team-warning = AMMONIZIONE
     DI SQUADRA
 team-warning-line-1 = AMMONIZIONE
 team-warning-line-2 = DI SQUADRA
+team-score-line-1 = PUNTEGGIO
+team-score-line-2 = DI SQUADRA
 
 # Configurazione
 none-selected = Nessuno Selezionato

--- a/refbox/translations/ja-JP/refbox.ftl
+++ b/refbox/translations/ja-JP/refbox.ftl
@@ -39,6 +39,8 @@ team-warning = チーム
     警告
 team-warning-line-1 = チーム
 team-warning-line-2 = 警告
+team-score-line-1 = チーム
+team-score-line-2 = 得点
 
 # 設定
 none-selected = 未選択

--- a/refbox/translations/ko-KR/refbox.ftl
+++ b/refbox/translations/ko-KR/refbox.ftl
@@ -41,6 +41,8 @@ team-warning = 팀
     경고
 team-warning-line-1 = 팀
 team-warning-line-2 = 경고
+team-score-line-1 = 팀
+team-score-line-2 = 점수
 
 # 설정
 none-selected = 선택 없음

--- a/refbox/translations/ms-MY/refbox.ftl
+++ b/refbox/translations/ms-MY/refbox.ftl
@@ -39,6 +39,8 @@ team-warning = AMARAN
     PASUKAN
 team-warning-line-1 = AMARAN
 team-warning-line-2 = PASUKAN
+team-score-line-1 = MARKAH
+team-score-line-2 = PASUKAN
 
 # Konfigurasi
 none-selected = Tiada Dipilih

--- a/refbox/translations/nl-NL/refbox.ftl
+++ b/refbox/translations/nl-NL/refbox.ftl
@@ -39,6 +39,8 @@ team-warning = TEAM-
     WAARSCHUWING
 team-warning-line-1 = TEAM-
 team-warning-line-2 = WAARSCHUWING
+team-score-line-1 = TEAM-
+team-score-line-2 = SCORE
 
 # Configuratie
 none-selected = Niets Geselecteerd

--- a/refbox/translations/pt-PT/refbox.ftl
+++ b/refbox/translations/pt-PT/refbox.ftl
@@ -39,6 +39,8 @@ team-warning = AVISO DE
     EQUIPA
 team-warning-line-1 = AVISO DE
 team-warning-line-2 = EQUIPA
+team-score-line-1 = RESULTADO DE
+team-score-line-2 = EQUIPA
 
 # Configuração
 none-selected = Nenhum Selecionado

--- a/refbox/translations/th-TH/refbox.ftl
+++ b/refbox/translations/th-TH/refbox.ftl
@@ -39,6 +39,8 @@ team-warning = การเตือน
     ทีม
 team-warning-line-1 = การเตือน
 team-warning-line-2 = ทีม
+team-score-line-1 = คะแนน
+team-score-line-2 = ทีม
 
 # การตั้งค่า
 none-selected = ไม่ได้เลือก

--- a/refbox/translations/tl-PH/refbox.ftl
+++ b/refbox/translations/tl-PH/refbox.ftl
@@ -39,6 +39,8 @@ team-warning = BABALA NG
     KOPONAN
 team-warning-line-1 = BABALA NG
 team-warning-line-2 = KOPONAN
+team-score-line-1 = PUNTOS NG
+team-score-line-2 = KOPONAN
 
 # Configuration
 none-selected = Wala na Pinili

--- a/refbox/translations/tr-TR/refbox.ftl
+++ b/refbox/translations/tr-TR/refbox.ftl
@@ -39,6 +39,8 @@ team-warning = TAKIM
     UYARISI
 team-warning-line-1 = TAKIM
 team-warning-line-2 = UYARISI
+team-score-line-1 = TAKIM
+team-score-line-2 = SKORU
 
 # Yapılandırma
 none-selected = Seçim Yok

--- a/refbox/translations/zh-CN/refbox.ftl
+++ b/refbox/translations/zh-CN/refbox.ftl
@@ -39,6 +39,8 @@ team-warning = 队伍
     警告
 team-warning-line-1 = 队伍
 team-warning-line-2 = 警告
+team-score-line-1 = 队伍
+team-score-line-2 = 比分
 
 # 设置
 none-selected = 未选择


### PR DESCRIPTION
## What changed

Two changes to the number keypad that appears when the operator records a goal, foul, warning or penalty.

**1. A TEAM SCORE button on the score page.**

The score page now shows three buttons across the top — BLACK, TEAM SCORE, WHITE — with the team
option in the middle, matching where TEAM WARNING sits. TEAM WARNING has been moved to the middle of
the warnings page too, so both pages read the same way.

DONE is now greyed out until the operator either picks a player number or taps TEAM SCORE.
Previously, DONE would save the goal whenever no number was selected, and the goal was quietly filed
as a team goal. That meant a forgotten scorer looked identical to a deliberate team goal in the
records. Attributing a goal to the team is now a deliberate tap rather than a hidden default.

Tapping TEAM SCORE greys the player panel and clears any number already entered, so what is on
screen always matches what gets recorded.

**2. A dash instead of a misleading number.**

The value at the top right of the keypad panel now shows `-` whenever no individual player is named.
Before, those pages showed `0`, which looks like a player number but is not — no team uses cap
number 0. Pages that are not about a player (timeouts per half, game number, portal login code) still
show real digits including `0`, because `0` is a legitimate value there.

Nothing about how goals are scored or stored has changed. The scoring code already treated "no
player" as a team goal; this only makes that state visible and deliberate.

## Why

At the last event a goal was recorded against the team rather than the scorer simply because the
operator tapped DONE before choosing a number. There was no way to tell afterwards whether that was
intentional. The operator now has to say which they mean, and the panel stops showing `0` as if it
were somebody's cap number.

The human's ruling on the extra tap this costs at events with no roster loaded: *"an additional tap
for accuracy is ok."*

## Scope

Changes are limited to the `refbox` crate:

- `refbox/src/app/view_builders/keypad_pages/` — the score page, the warnings page row order, and the
  panel readout
- `refbox/src/app/message.rs` and `refbox/src/app/mod.rs` — carrying the team-score choice and
  handling the toggle
- `refbox/translations/` — one new two-line label added to all 15 languages

No changes to `uwh-common`, the wire format, the game clock, or the scoring logic itself.

## How to verify

`just check` passes: 571 tests, no lint warnings, security scan clean.

Two new tests cover the rules directly, and would have failed before this change:

- `score_needs_a_player_or_an_explicit_team_choice` — DONE stays disabled with nothing chosen,
  and is enabled either by a player number or by TEAM SCORE
- `panel_value_shows_a_dash_where_no_player_is_named` — `-` on player pages with nothing entered,
  real digits everywhere else

To see it in the running app, open the score page and check, in order:

1. BLACK / TEAM SCORE / WHITE across the top, TEAM SCORE not selected, DONE greyed out
2. Tap a player number → DONE turns green and the readout shows that number
3. Tap the same number again to deselect → DONE greys again, readout returns to `-`
4. Tap TEAM SCORE → the player panel greys, readout shows `-`, DONE turns green
5. On the warnings and penalty pages, the readout is `-` rather than `0` before a number is entered
6. On the warnings page, TEAM WARNING now sits between BLACK and WHITE

Steps 1–6 were walked through locally against a mock portal before this PR was opened.

### Known limitation, not introduced here

In German, the two-line team buttons (TEAM WARNING and now TEAM SCORE) do not fit — `MANNSCHAFT`
is wider than the button, so it wraps and the second line is pushed out of view entirely. This
already affects TEAM WARNING on `master` and is being fixed separately by making button text shrink
to fit, which covers all 31 places that use two-line buttons at once. Deliberately not patched here.
