### PR TITLE
feat(refbox): colour the player number grid cells by team

### DIFF
--- a/refbox/src/app/view_builders/keypad_pages/mod.rs
+++ b/refbox/src/app/view_builders/keypad_pages/mod.rs
@@ -105,6 +105,7 @@ pub(in super::super) fn build_keypad_page<'a>(
             container(if show_grid(panel_numbers, mode, player_num) {
                 make_player_grid(
                     make_panel_label(&page, role, player_num),
+                    role,
                     panel_numbers,
                     mode,
                     player_num,

--- a/refbox/src/app/view_builders/keypad_pages/player_grid.rs
+++ b/refbox/src/app/view_builders/keypad_pages/player_grid.rs
@@ -2,9 +2,17 @@
 // constants, styles and `Message` — mirror `foul_add.rs`, do not re-import them.
 use super::*;
 use iced::{
-    Length,
-    widget::{column, row, vertical_space},
+    Length, Theme,
+    widget::{
+        button::{Status, Style},
+        column, row, vertical_space,
+    },
 };
+use uwh_common::color::Color as GameColor;
+
+/// A button style function, as iced's `.style()` takes. Mirrors the alias in
+/// `score_add.rs`.
+type StyleFn = fn(&Theme, Status) -> Style;
 
 /// Columns in the player-number grid. The grid is read left to right, then
 /// top to bottom, so this is fixed rather than derived from the roster.
@@ -107,6 +115,8 @@ pub(super) fn show_grid(numbers: &[u8], mode: Mode, current: u32) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::app::theme::{DisplayMode, black, blue, set_display_mode, white};
+    use iced::Background;
 
     #[test]
     fn cells_per_mode() {
@@ -217,6 +227,62 @@ mod tests {
             );
         }
     }
+
+    /// A cell wears its team's colour, so the operator can see whose roster is on
+    /// screen without checking the team buttons.
+    ///
+    /// The display mode is pinned to Light: in High Contrast `white_button`
+    /// renders as dark grey with white text, which is deliberate (see the spec)
+    /// but would make these assertions fail. The mode is global state shared
+    /// across tests, hence the lock.
+    #[test]
+    fn grid_cells_wear_their_team_colour() {
+        let _guard = crate::app::theme::DISPLAY_MODE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        set_display_mode(DisplayMode::Light);
+
+        let dark = cell_style(PanelRole::Player(GameColor::Black), false)(
+            &Theme::default(),
+            Status::Active,
+        );
+        assert_eq!(dark.background, Some(Background::Color(black())));
+        assert_eq!(dark.text_color, white());
+
+        let light = cell_style(PanelRole::Player(GameColor::White), false)(
+            &Theme::default(),
+            Status::Active,
+        );
+        assert_eq!(light.background, Some(Background::Color(white())));
+        assert_eq!(light.text_color, black());
+
+        set_display_mode(DisplayMode::Light);
+    }
+
+    /// A page that names no team keeps the digit keypad's blue and must never
+    /// wear a team's colour. Currently unreachable — those roles get an empty
+    /// roster, so no grid is built — but it is the invariant the fallback exists
+    /// for, so it is pinned rather than left to a future caller to rediscover.
+    #[test]
+    fn a_page_naming_no_team_stays_blue() {
+        let _guard = crate::app::theme::DISPLAY_MODE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        set_display_mode(DisplayMode::Light);
+
+        for role in [PanelRole::TeamEntry, PanelRole::NotPlayer] {
+            for selected in [false, true] {
+                let style = cell_style(role, selected)(&Theme::default(), Status::Active);
+                assert_eq!(
+                    style.background,
+                    Some(Background::Color(blue())),
+                    "{role:?} selected={selected} must stay blue"
+                );
+            }
+        }
+
+        set_display_mode(DisplayMode::Light);
+    }
 }
 
 /// One row of three cells per grid row. A cell with a number is tappable
@@ -230,6 +296,7 @@ mod tests {
 /// vanishes when the operator toggles to a team whose grid cannot be shown.
 pub(super) fn make_player_grid<'a>(
     label: Element<'a, Message>,
+    role: PanelRole,
     numbers: &[u8],
     mode: Mode,
     selected: u32,
@@ -251,7 +318,7 @@ pub(super) fn make_player_grid<'a>(
             line = line.height(Length::Fill);
         }
         for cell in cells {
-            line = line.push(make_grid_cell(cell, selected, enabled, fills_height));
+            line = line.push(make_grid_cell(cell, role, selected, enabled, fills_height));
         }
         grid = grid.push(line);
     }
@@ -279,11 +346,53 @@ pub(super) fn make_player_grid<'a>(
         .into()
 }
 
+/// The style a grid cell wears: its team's colour, or the keypad's blue where the
+/// panel names no team. `selected` picks the bordered variant.
+///
+/// Colouring by team lets the operator see whose roster is on screen without
+/// checking the team buttons, and keeps a team that has a roster visibly distinct
+/// from one that falls back to the blue digit keypad.
+///
+/// Selection stays legible on every fill because it is drawn as a border, not a
+/// fill: each `*_selected_button` is its base style plus `BORDER_WIDTH`, and
+/// `BORDER_COLOR` is blue.
+///
+/// The `TeamEntry` / `NotPlayer` arm is currently unreachable — `build_keypad_page`
+/// maps those roles to an empty roster, so `show_grid` is false and no grid is
+/// built. It is kept and tested rather than made a panic: a page that names no
+/// team must never wear a team's colour.
+fn cell_style(role: PanelRole, selected: bool) -> StyleFn {
+    match role {
+        PanelRole::Player(GameColor::Black) => {
+            if selected {
+                black_selected_button
+            } else {
+                black_button
+            }
+        }
+        PanelRole::Player(GameColor::White) => {
+            if selected {
+                white_selected_button
+            } else {
+                white_button
+            }
+        }
+        PanelRole::TeamEntry | PanelRole::NotPlayer => {
+            if selected {
+                blue_selected_button
+            } else {
+                blue_button
+            }
+        }
+    }
+}
+
 /// Reuses `make_small_button` from `shared_elements.rs` (text centred inside
 /// a filled container inside a fixed-size button), overriding its size to
 /// `GRID_BUTTON_SIZE`.
 fn make_grid_cell<'a>(
     cell: Option<u8>,
+    role: PanelRole,
     selected: u32,
     enabled: bool,
     fills_height: bool,
@@ -318,14 +427,11 @@ fn make_grid_cell<'a>(
                 // condition that greys the panel without emptying the roster.
                 cell_button
             };
-            cell_button
-                .style(if is_selected {
-                    blue_selected_button
-                } else {
-                    blue_button
-                })
-                .into()
+            cell_button.style(cell_style(role, is_selected)).into()
         }
-        None => cell_button.style(blue_button).into(),
+        // A leftover cell has no `on_press`, so iced renders it
+        // `Status::Disabled`, which every one of these styles paints as window
+        // background — the same grey as today, whichever team it belongs to.
+        None => cell_button.style(cell_style(role, false)).into(),
     }
 }

--- a/refbox/src/app/view_builders/keypad_pages/player_grid.rs
+++ b/refbox/src/app/view_builders/keypad_pages/player_grid.rs
@@ -115,7 +115,7 @@ pub(super) fn show_grid(numbers: &[u8], mode: Mode, current: u32) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::app::theme::{DisplayMode, black, blue, set_display_mode, white};
+    use crate::app::theme::{BORDER_WIDTH, DisplayMode, black, blue, set_display_mode, white};
     use iced::Background;
 
     #[test]
@@ -283,12 +283,44 @@ mod tests {
 
         set_display_mode(DisplayMode::Light);
     }
+
+    /// `*_selected_button` differs from its base only in border width, so the
+    /// border is what pins the `selected` half of the table. Without this test,
+    /// code that dropped the `if selected` in `cell_style` and returned the base
+    /// style for every arm would leave every other test in this module green —
+    /// and would remove the operator's only indication of which number they had
+    /// tapped.
+    #[test]
+    fn selection_is_pinned_by_the_border_not_the_fill() {
+        let _guard = crate::app::theme::DISPLAY_MODE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        set_display_mode(DisplayMode::Light);
+
+        for (role, fill) in [
+            (PanelRole::Player(GameColor::Black), black()),
+            (PanelRole::Player(GameColor::White), white()),
+            (PanelRole::TeamEntry, blue()),
+        ] {
+            let plain = cell_style(role, false)(&Theme::default(), Status::Active);
+            let picked = cell_style(role, true)(&Theme::default(), Status::Active);
+            assert_eq!(plain.background, Some(Background::Color(fill)));
+            assert_eq!(picked.background, Some(Background::Color(fill)));
+            assert_eq!(plain.border.width, 0.0, "{role:?} unselected: no border");
+            assert_eq!(
+                picked.border.width, BORDER_WIDTH,
+                "{role:?} selected: bordered"
+            );
+        }
+
+        set_display_mode(DisplayMode::Light);
+    }
 }
 
 /// One row of three cells per grid row. A cell with a number is tappable
 /// unless the panel is disabled; a leftover cell (`None`), or any cell while
 /// disabled, has no `on_press`, which iced renders in `Status::Disabled` and
-/// `blue_button` paints as window background with grayed text — the
+/// the cell's own style paints as window background with grayed text — the
 /// greyed-out look, with no extra style needed.
 ///
 /// `label` is the panel's title row, built by `make_panel_label` and identical
@@ -430,8 +462,10 @@ fn make_grid_cell<'a>(
             cell_button.style(cell_style(role, is_selected)).into()
         }
         // A leftover cell has no `on_press`, so iced renders it
-        // `Status::Disabled`, which every one of these styles paints as window
-        // background — the same grey as today, whichever team it belongs to.
+        // `Status::Disabled`, where no team colour shows through: Light and Dark
+        // paint all three of these styles as window background, and in High
+        // Contrast the light team's take `HC_WHITE_DISABLED` — a deliberately
+        // distinguishable dark grey (see its doc comment), not the team's white.
         None => cell_button.style(cell_style(role, false)).into(),
     }
 }


### PR DESCRIPTION
## What changed

The player number cells on the keypad now take the colour of the team whose roster is showing:
black cells with white numbers for the dark team, white cells with black numbers for the light team.
The plain digit keypad — the one shown when a team has no roster loaded — stays blue.

Everything else about the grid is unchanged: the tapped cell still carries its blue outline, the
leftover cells past the end of a short roster still look grey, and nothing moved or changed size.

This affects every page that shows the grid: recording a goal, a foul, a warning, or a penalty.

## Why

The grid's cells were the same blue as the digit keypad, which made two things harder than they
needed to be. The operator had to glance up at the team buttons to confirm whose roster they were
looking at, and a team with a roster looked much like a team without one when toggling between them.

Colouring the cells by team answers both at a glance.

## Scope

Changes are limited to one file, `refbox/src/app/view_builders/keypad_pages/player_grid.rs`, plus a
single argument added at its one call site in `keypad_pages/mod.rs`.

No new dependency, no new colour added to the theme, and no new text — so no translation work. All
four team colour styles already existed and are the same ones the BLACK and WHITE buttons above the
grid use.

## How to verify

`just check` passes: 574 tests, no lint warnings, formatting clean, security scan unchanged.

Three tests cover the colour rule, and each would have failed before this change:

- `grid_cells_wear_their_team_colour` — dark team paints black with white numbers, light team white
  with black numbers
- `a_page_naming_no_team_stays_blue` — a page that names no team keeps the keypad's blue and never
  borrows a team colour
- `selection_is_pinned_by_the_border_not_the_fill` — the tapped cell gets its outline. This one
  exists because a review caught that the first two could not detect a change that removed the
  selection outline entirely: a "selected" style differs from its plain one *only* in the outline, and
  both tests asserted only the fill colour. Proven by deliberately breaking it first.

To see it in the running app, open the goal page with a roster loaded:

1. Dark team selected → cells black, numbers white
2. Tap WHITE at the top → cells white, numbers black
3. Tap a number → the blue outline is clearly visible on either colour
4. On a team whose roster is shorter than the grid, the leftover cells stay grey
5. A team with no roster still shows the blue digit keypad
6. Foul, warning and penalty pages are coloured the same way

Steps 1–4 and 6 were walked through locally against a mock portal before opening this PR, with the
light team's grid deliberately filled to all 12 cells so the brightest possible case was the one
judged. Step 5 was not re-checked on screen in that run — both teams had rosters so the two colours
could be compared — but it cannot have regressed: the code that builds the digit keypad is untouched,
and the only edit at the call site sits inside the other branch of the same condition.

### Note on High Contrast mode

This change is deliberately almost invisible in High Contrast. That mode discards button colour to
stay readable in bright sun, so the dark team's grid looks exactly as it does today and the light
team's is a slightly lighter grey. The benefit here is a Light/Dark-mode benefit. Nothing was
special-cased for High Contrast, which would have meant reopening the selection-indicator work from
#1912.

Dark mode has not been viewed on screen. The risk is lower than Light's, since Dark's white is a
muted grey-white rather than pure white.
