### PR TITLE
docs(refbox): record the keypad backlog notes

### DIFF
--- a/docs/backlog/auto-fit-button-text/NOTE.md
+++ b/docs/backlog/auto-fit-button-text/NOTE.md
@@ -1,0 +1,76 @@
+# Backlog: auto-fit button text (shrink to fit, keep the line split)
+
+**Status:** Approved in principle, not started. Next branch after
+`2026-08-10-team-score-button-and-dash-readout`.
+**Surfaced:** 2026-08-10, after rendering the warnings page in German.
+**Raised by:** the user — *"would it be a major project to center justify all button text and allow
+the text to resize to fit? I still want to keep the separate lines like we have, but the text size
+should adjust (equally for both lines if applicable) if needed."*
+
+**Supersedes** `../translation-fit-audit/NOTE.md` for buttons: this fixes the class of bug rather
+than auditing instances of it, and would have prevented the German defect entirely.
+
+## The bug it fixes (measured, not inferred)
+
+Rendered with `./target/debug/refbox --language de-DE`, warnings page:
+
+- `team-warning-line-1` = `MANNSCHAFT` is **wider than the button**, so iced word-wraps it: line 1
+  shows `MANNSCHAF`, the orphaned `T` drops to line 2.
+- `team-warning-line-2` = `VERWARNUNG` is pushed out of the 89px button and **never renders**.
+- The wrapped text renders left-aligned, because `Length::Shrink` expands to the full width once it
+  wraps, defeating the `container(t).center_x(Length::Fill)` centring in
+  `make_multi_label_button` (`refbox/src/app/view_builders/shared_elements.rs:1093`).
+
+Note the centring is therefore **already correct** for non-wrapping text — `make_button` and
+`make_small_button` both centre. The visible left-alignment in German is a *symptom of the wrap*.
+Fixing alignment alone fixes nothing.
+
+## Why this is tractable — and cheaper than the old prototype assumed
+
+**No new dependency.** iced 0.13 already exposes text measurement:
+`iced::advanced::text::Paragraph::with_text(...)` plus `.min_bounds() -> Size`
+(`iced_core-0.13.2/src/text/paragraph.rs:12,34`). The stalled prototype at
+`docs/backlog/dynamic-font-sizing/` used `fontdue` and was blocked on approving that dependency
+(project rule: no new deps without discussion). That blocker is gone — use iced's own measurement.
+
+**The prototype has the right algorithm**: measure the string, step the size down, stop at a floor
+(it used `MIN_FONT_SIZE = 12.0`). Reuse the approach, not the code — its `GameInfoCell` enum
+targets a screen that has since been rebuilt as `game_info_table.rs`.
+
+**One helper covers 31 call sites.** `make_multi_label_button` alone has 31 callers, so fixing the
+helper fixes every current button and every future locale.
+
+## Design sketch
+
+Measurement needs a `Renderer`, which is **not** available in the declarative view function — only
+inside a widget's `layout()`. So this needs a small custom widget rather than a plain helper.
+
+Split it so the interesting part is testable without a renderer:
+
+```rust
+/// Largest size from `candidates` (descending) whose measured bounds fit `max`.
+/// Falls back to the smallest candidate rather than overflowing.
+fn fit_size(measure: impl Fn(f32) -> Size, max: Size, candidates: &[f32]) -> f32
+```
+
+`fit_size` is pure and unit-testable with a fake `measure` closure — no renderer, no font. The
+custom widget supplies the real measurement in `layout()` and caches the chosen size for `draw()`.
+The old prototype had no tests; this design is the reason to rewrite rather than port.
+
+Apply the **same** chosen size to both lines, per the user: *"equally for both lines if
+applicable."*
+
+## Scope when picked up
+
+Own branch, own Scope Card and plan.
+
+- Fold in the centring tweak (`align_x(Horizontal::Left)` → centre in `make_multi_label_button`)
+  since wrapped-text alignment and sizing belong together.
+- Decide whether `make_button` / `make_small_button` also get auto-fit, or only the two-line
+  variant. The single-line buttons have their own overflow risk (`num-tos-per-half` is near the
+  edge **in English**) but a wider blast radius.
+- Watch the interaction with iced's layout/draw lifecycle — the size picked in `layout()` must
+  reach `draw()`.
+- **Verify by rendering**, not arithmetic, across the worst cases: de-DE and es (long words), th-TH
+  (needs the Thai font subset — see the CJK/font-subset memory), and ja-JP / zh-CN (wide glyphs, so
+  character count is a poor proxy for width). Do not claim a fit from an English screenshot.

--- a/docs/backlog/team-coloured-grid-cells/NOTE.md
+++ b/docs/backlog/team-coloured-grid-cells/NOTE.md
@@ -1,0 +1,69 @@
+# Backlog: colour the player-number grid cells to match the selected team
+
+**Status: IMPLEMENTED 2026-08-10** — PR #2015 on `feat/refbox/team-coloured-grid-cells`, open for
+review. Kept for the reasoning; the outstanding-work framing below is historical.
+
+Outcomes that settled the open questions in this note:
+
+- **"Judge by eye before accepting" — done, and solid white was confirmed.** Walked through locally
+  with the light team's grid deliberately filled to all 12 cells, i.e. the brightest case 6v6 can
+  produce. The human's ruling: solid white is fine, keep it. The grey fallback was NOT applied.
+- **The Rugby worry in that section was wrong.** Rugby's rows are height-constrained, so its 15 cells
+  come out ~70px tall against 89 wide — about 93,500 px² of fill against 6v6's 95,100. Rugby is
+  marginally *less* coloured area, not more, so it needs no separate brightness decision.
+- **High Contrast needs no check by eye after all.** The code answers it: `black_button` and
+  `blue_button` produce an identical style in that mode, and `white_button` gives `HC_DARK_GREY`. High
+  Contrast discards button colour by design, so the dark team's grid is unchanged there and the light
+  team's is slightly lighter grey. Nothing was special-cased, so #1912's selection work is untouched.
+- **Dark display mode was never viewed** — the one visual gap left. Lower risk than Light, because
+  Dark's `white()` is `rgb8(207,207,207)` rather than pure white.
+
+The estimate held: the change is `cell_style` plus a threaded `PanelRole`, in one file.
+**Surfaced:** 2026-08-10, during the TEAM SCORE walkthrough.
+**Raised by:** the user — *"changing the color of the player number buttons to match the team
+selection. that way there is a more clear difference between the number pad (black/white) and the
+keypad (blue)."*
+
+## The idea
+
+The player-number grid's cells are currently `blue_button`, the same as the digit keypad. Colour
+them to match the team whose roster is shown — black cells with white numbers for the dark team,
+white cells with black numbers for the light team — leaving the digit keypad blue.
+
+Two benefits: the operator can see *whose* roster it is without glancing at the team buttons in the
+corner, and the grid becomes instantly distinguishable from the keypad when toggling between a team
+that has a roster and one that does not.
+
+## Why it is small (verified 2026-08-10)
+
+- **Selection is a border, not a colour.** Every `*_selected_button` in
+  `refbox/src/app/theme/button.rs` is its base style plus `border.width = BORDER_WIDTH` and
+  `select_in_high_contrast(...)`. So a coloured cell does not collide with showing which cell is
+  selected. `black_selected_button` (line 161) and `white_selected_button` (line 134) already exist.
+- **High Contrast is already handled centrally** by `select_in_high_contrast` /
+  `outline_in_high_contrast`, the same helpers every other button uses, with an existing
+  `high_contrast_tests` module. This does not reopen the HC selection work from #1912.
+- **Empty cells keep their look for free.** `black_button` at `Status::Disabled` falls back to
+  `window_background()`, exactly as `blue_button` does, so the leftover `None` cells and the greyed
+  panel render as they do today with no extra code.
+
+Estimated ~20 lines: thread the team `GameColor` into `make_player_grid` → `make_grid_cell` (both in
+`refbox/src/app/view_builders/keypad_pages/player_grid.rs`) and pick the style pair from it. The
+colour is always available where a grid is built — `build_keypad_page` only builds one for
+`PanelRole::Player(color)`.
+
+## Judge by eye before accepting
+
+**A 4×3 block of solid white is much brighter than a single WHITE button.** Twelve of them (or
+fifteen in Rugby) is a different proposition from the one team-select button, especially outdoors on
+the Pi. May need toning down — a lighter grey fill, or white with an outline instead of a solid
+fill. This cannot be judged from the code.
+
+Also check High Contrast mode by eye, since black-on-black and white-on-white are exactly the cases
+that mode exists to fix.
+
+## Scope when picked up
+
+Own branch, own Scope Card. Deliberately **not** added to
+`feat/refbox/player-number-grid`, even though it belongs to that feature conceptually: that branch
+has already been walkthrough-verified, and this would change the very thing that was verified.

--- a/docs/backlog/team-score-button-and-dash-readout/NOTE.md
+++ b/docs/backlog/team-score-button-and-dash-readout/NOTE.md
@@ -1,0 +1,104 @@
+# Backlog: TEAM SCORE button + `-` readout on the keypad panel
+
+**Status: SHIPPED 2026-08-10** — PR #1998, merged to master as `732d04e2`. Nothing left to do here;
+this note is kept for the reasoning behind the decisions, not as outstanding work.
+
+The one open question below (§4, symbol vs. word for the team button) was **decided: words.** TEAM
+SCORE and TEAM WARNING are two-line text labels with dedicated keys in all 15 locales. That leaves
+the German fit problem live — `MANNSCHAFT` is wider than the button — which is deliberately left to
+the auto-fit branch rather than patched here. See `../auto-fit-button-text/NOTE.md`.
+**Surfaced:** 2026-08-10, during the player-number-grid walkthrough.
+**Supersedes:** the earlier `panel-team-value-translation` note (deleted). That note proposed
+translating the hardcoded English `"TEAM"` value and redesigning the title row to stop it
+overflowing. The user's design below removes the need for both.
+
+## What was wrong
+
+Two things, both made newly visible by the player-number grid (the grid had no title before, so
+these only ever showed on the number pad):
+
+1. The title row's value is a hardcoded English `"TEAM"` (three arms of `make_panel_label` in
+   `refbox/src/app/view_builders/keypad_pages/mod.rs`) — untranslated for every non-English
+   operator, and long translations overflow the fixed 283px row.
+2. On the penalty, foul and warning pages the value reads `0` when nothing is chosen. `0` is not a
+   value there — `penalty_edit_can_commit` / `foul_add_can_commit` / `warning_add_can_commit` all
+   require `player_num > 0` — so it is an empty field wearing a digit.
+
+## The approved design
+
+### 1. Readout becomes `-`
+
+Replace the value with a literal `-` wherever no individual player is named. One glyph, no locale,
+cannot overflow any row. **This removes the need for a translated "TEAM" value entirely.**
+
+Applies to: team goal (`AddScore` with `player_num == 0`), team warning (`WarningAdd` with
+`team_warning`), equal foul (`FoulAdd` with `color == None`), and the not-yet-entered state on the
+penalty / foul / warning pages.
+
+**Does NOT apply to** the `PanelRole::NotPlayer` pages — timeouts-per-half (`0` is a legitimate
+value) and portal login (a code may legitimately begin with `0`). Those keep showing real digits.
+
+### 2. TEAM SCORE button on the score page
+
+Mirror the warnings page: a three-button row of `TEAM SCORE` / `BLACK` / `WHITE`. Selecting TEAM
+SCORE disables the grid/pad, exactly as `TEAM WARNING` does via `PanelRole::TeamEntry`.
+
+Covers the real cases the user named: the scorer is unknown, or a penalty goal where no individual
+is credited.
+
+**User decisions — implement these literally:**
+- **TEAM SCORE is NOT the default.** The page opens with it off and the grid live.
+- **DONE is disabled** unless either a player number is provided or TEAM SCORE is selected. This is
+  a change from today, where `score_add.rs` has an unconditional
+  `.on_press(Message::AddScoreComplete { canceled: false })`.
+- Claude raised that this costs a mandatory extra tap per goal at no-roster events, where every
+  goal is a team goal. The user's ruling: **"an additional tap for accuracy is ok."** Do not
+  re-litigate this.
+- **The three-button row moves to the top** of the score page. Today `score_add.rs` centres
+  BLACK/WHITE with `vertical_space()` above and below; the warnings page has its row at the top.
+- **The team option goes BETWEEN black and white**, i.e. `BLACK / TEAM SCORE / WHITE`. The user
+  confirmed this by eye from the foul page, whose `=` button already sits in the middle, and wants
+  it consistent across pages. **This also means moving the existing `TEAM WARNING` button** on the
+  warnings page from the left to the middle — a layout change to an established page, so it is in
+  this branch's blast radius even though its behaviour does not change.
+
+### 4. OPEN QUESTION — should the team button be a symbol instead of a word?
+
+Not decided. Raised because the foul page's middle button is a bare `=` glyph at `LARGE_TEXT` with
+**no translation at all** (`refbox/src/app/view_builders/keypad_pages/foul_add.rs`, the
+`ChangeColor(None)` button — note `equal = EQUAL` exists in the locale files but this button does
+not use it).
+
+If TEAM SCORE / TEAM WARNING became glyphs, the two new keys and the German fit risk both vanish,
+the same trick that `-` pulls for the readout. Against it: `=` reads naturally as "both teams
+equally", but "one team, no individual" has no obvious symbol, and `TEAM WARNING` is a control
+operators have already learned to read. Ask the user before assuming either way.
+
+### 3. Translation cost
+
+The button needs **two** new keys, `team-score-line-1` / `team-score-line-2`, following the
+existing `team-warning-line-1` / `team-warning-line-2` pattern, in all 15 locales.
+
+**It cannot be composed from a generic "TEAM" plus "SCORE".** Romance languages reverse the
+modifier — "TEAM WARNING" is fr "AVERT. D'ÉQUIPE", es "AVISO DE EQUIPO" — so a composed label
+would be grammatically wrong in fr/es/pt-PT. `dark-score-line-1` does already carry a standalone
+word for score in every locale (SCORE / PUNTUACIÓN / TORE / 得点) but the line-1 slot needs the
+*team* word, which no existing key provides reusably (`team-warning-line-1` is fr "AVERT.", es
+"AVISO" — those mean *warning*, not *team*).
+
+**Check fit before shipping** — German "TEAM WARNING" already does not fit on the warnings page
+today, so a German "TEAM SCORE" is at similar risk. See
+[../translation-fit-audit/NOTE.md]. Do not assume an English screenshot proves the fit.
+
+## Scope when picked up
+
+Own branch, own Scope Card and brainstorming pass — it was deliberately kept off
+`feat/refbox/player-number-grid`, which was code-complete and green when this was designed.
+
+- `make_panel_label` (the `-` change) touches every keypad page, so the number pad on the game
+  number, timeouts and portal login pages is in the blast radius even though their behaviour must
+  not change.
+- Needs a DONE-gate test mirroring `penalty_gate_depends_only_on_the_player_number` in
+  `penalty_edit.rs`, since the score page's gate becomes conditional.
+- A new `BoolGameParameter`-style toggle for TEAM SCORE, mirroring
+  `BoolGameParameter::TeamWarning`'s handling in `mod.rs`.

--- a/docs/backlog/translation-fit-audit/NOTE.md
+++ b/docs/backlog/translation-fit-audit/NOTE.md
@@ -1,0 +1,68 @@
+# Backlog: audit all 15 locales for text that does not fit its button or row
+
+> **LARGELY SUPERSEDED for buttons** by `../auto-fit-button-text/NOTE.md`, approved 2026-08-10.
+> Auto-fitting button text fixes this class of bug at the helper level (31 call sites) rather than
+> auditing instances, and needs no new dependency. What remains for THIS audit afterwards is the
+> non-button slots — chiefly the keypad panel's fixed 283px title row. Do this one second, and only
+> for whatever auto-fit does not already cover.
+>
+> The German case below has since been **reproduced and characterised**: `MANNSCHAFT` is too wide,
+> so iced word-wraps it and pushes `VERWARNUNG` out of the button entirely. Details in the auto-fit
+> note.
+
+**Status:** Idea. Not started. Not on any branch.
+**Surfaced:** 2026-08-10, during the player-number-grid walkthrough.
+**Raised by:** the user, from direct observation — **German "TEAM WARNING" does not currently fit**
+on the warnings page. This is a pre-existing defect on `master`, not something the grid branch
+introduced.
+
+## The problem
+
+Translations are longer than English in most European languages, and several UI slots are sized
+around the English string. Nobody has systematically checked the other 14 locales against the
+actual rendered widths, so overflow is discovered by accident — if at all, since the operator
+running the event usually reads English.
+
+**Known instance:** `team-warning-line-1` / `team-warning-line-2` on the warnings page.
+- en-US: `TEAM` / `WARNING` — fits.
+- de-DE: `MANNSCHAFT` / `VERWARNUNG` — **does not fit** (observed).
+- fr: `AVERT.` / `D'ÉQUIPE`, es: `AVISO` / `DE EQUIPO` — unchecked.
+
+## Why a systematic audit, not a one-off fix
+
+Two things make this worth doing properly rather than patching the German string:
+
+**1. Fixed-width slots are everywhere.** The keypad panel's title row is
+`3 * MIN_BUTTON_SIZE + 2 * SPACING = 283px` and holds a label plus a value; buttons across the app
+use `MIN_BUTTON_SIZE` multiples. Any of them can clip a long translation. `num-tos-per-half`
+("NUM OF TEAM / T/Os PER HALF:") is already near the edge **in English**.
+
+**2. Word order differs, so per-word reuse is unsafe.** Romance languages reverse the modifier:
+"TEAM WARNING" becomes "AVERT. D'ÉQUIPE" (warning of-team). Any fix that composes a label from a
+generic "TEAM" plus a noun will produce wrong grammar in fr/es/pt-PT. Two-line labels must stay
+dedicated `*-line-1` / `*-line-2` key pairs, which is what the existing keys correctly do.
+
+## Scope when picked up
+
+- Enumerate every fixed-width text slot (buttons via `make_button` / `make_multi_label_button` /
+  `make_small_button`, and the keypad title row) and every key that fills one.
+- For each of the 15 locales, determine whether the string fits at its slot's width and text size.
+  Font metrics make this hard to compute reliably — **prefer rendering** over arithmetic. Setting
+  the language in Settings and walking the pages is the honest method; a screenshot per locale per
+  affected page is the deliverable.
+- Decide a remedy per overflow: shorter translation (ask a speaker — do not invent abbreviations
+  in a language the user cannot check), smaller text size for that slot, or a wider slot.
+- Consider whether a rendered-width test is feasible in CI so this cannot regress silently.
+
+## Explicitly NOT part of this
+
+The `-` readout decision (see [../team-score-button-and-dash-readout/NOTE.md]) already removes the
+worst offender — the title row's `"TEAM"` value — by replacing it with a single locale-neutral
+glyph. This audit is about the remaining slots, which that change does not touch.
+
+## Caution for whoever picks this up
+
+Do not trust an English screenshot as evidence that a slot is safe. During the 2026-08-10 session
+Claude claimed the warnings page's three-button row "proves the fit is safe" on the basis of an
+English screenshot; the user immediately corrected it with the German counter-example. Render the
+locale you are making a claim about.


### PR DESCRIPTION
## What changed

Adds four notes under `docs/backlog/`, recording keypad work that came out of the player-number-grid
sessions. No code changes — documents only.

| Note | What it covers |
|---|---|
| `team-score-button-and-dash-readout/` | **Shipped** in #1998. Kept for the reasoning behind the decisions. |
| `team-coloured-grid-cells/` | **Implemented** in #2015. Records what the on-screen check settled. |
| `auto-fit-button-text/` | Not started. Make button text shrink to fit, so long translations stop being cut off. |
| `translation-fit-audit/` | Mostly superseded by the note above; only the non-button slots remain. |

## Why

Three of these decisions were made verbally during a working session and existed nowhere but a chat
log and a local file. The two that shipped record *why* a choice was made — for example, why the team
button ended up as words rather than a symbol, and why the light team's cells are solid white rather
than grey. The two that haven't shipped are the roadmap for what comes next, including a measured
description of the German text-clipping bug and why a previous attempt at fixing it stalled.

Without this, the reasoning is lost and the same questions get re-litigated.

## Scope

`docs/backlog/` only — four new files, nothing else. No crate is touched, so no behaviour changes and
nothing to build.

The implementation plans and design specs under `docs/superpowers/` are deliberately **not** included;
those have been kept local in this repo, and only the forward-looking backlog notes are being recorded
here.

## How to verify

Nothing to run — these are documents. `just check` passes, and the pre-commit formatting check passed
on the commit.

To review the content, read the four notes. Each states its own status at the top, so the first line
tells you whether it is finished work or outstanding work. Two things worth confirming as a reader:

1. The two shipped notes are labelled as shipped, with their PR numbers, so neither reads as
   outstanding work.
2. The `auto-fit-button-text` note is the one that describes real remaining work, and it should be
   understandable without having been in the session that produced it.
