### PR TITLE
fix(refbox): log why the portal refused an upload

### DIFF
--- a/refbox/src/portal_manager/health.rs
+++ b/refbox/src/portal_manager/health.rs
@@ -224,8 +224,15 @@ async fn run_task(
                                     .send(PortalEvent::ItemResolved(item.id.clone()))
                                     .await;
                             }
-                            Err(_) => {
+                            Err(e) => {
                                 // Stays stats-pending; no escalation, no loop.
+                                // Logged for the same reason as the first
+                                // attempt: a manual retry that fails again
+                                // otherwise reports nothing at all.
+                                log::warn!(
+                                    "stats retry for game {}: {e}",
+                                    item.id.game_number
+                                );
                                 let _ = event_tx.send(PortalEvent::ItemUpdated).await;
                             }
                         }
@@ -255,7 +262,15 @@ async fn attempt_item(
     event_tx: &mpsc::Sender<PortalEvent>,
 ) -> bool {
     let score_result = io.post_scores(item).await;
-    if score_result.is_err() {
+    if let Err(e) = score_result {
+        // The portal's own words are the only thing separating a rejected
+        // upload from an unreachable one, and the error already carries them
+        // (`classify_error` puts the response body in `Failed`). Discarding it
+        // here left the operator with a red item and nothing to diagnose from.
+        // Wording note: `PortalCallError` already renders its own
+        // "portal call failed:" / "portal unreachable:" prefix, so this message
+        // supplies only what was being sent and for which game.
+        log::warn!("score upload for game {}: {e}", item.id.game_number);
         let _ = event_tx.send(PortalEvent::ItemUpdated).await;
         return false;
     }
@@ -266,11 +281,19 @@ async fn attempt_item(
                 .await;
             true
         }
-        Err(_) => {
+        Err(e) => {
             // Score is up but stats failed (e.g. an event that does not
             // require unique cap numbers rejects all stats). Mark the
             // item stats-pending; the portal is reachable, so return
             // `true` to suppress the cadence `verify_token`.
+            //
+            // Logged because the reason is not otherwise recoverable: the row
+            // only ever says "Stats not sent", and the several causes the
+            // portal distinguishes are indistinguishable from the UI.
+            log::warn!(
+                "stats upload for game {} (score already accepted): {e}",
+                item.id.game_number
+            );
             let _ = event_tx
                 .send(PortalEvent::ScoreSentStatsPending(item.id.clone()))
                 .await;
@@ -283,6 +306,28 @@ async fn attempt_item(
 mod tests {
     use super::super::ItemId;
     use super::*;
+
+    /// The reason the portal gave reaches the log only through this error's own
+    /// text, which the upload-failure `warn!`s print verbatim. Nothing else
+    /// asserts that, so if `Display` ever stopped including `msg` the logs would
+    /// go quiet again — the exact defect those `warn!`s were added to fix — with
+    /// every other test still green.
+    #[test]
+    fn error_text_carries_the_reason_the_portal_gave() {
+        let reason = r#"{"reason":"This event does not require unique cap numbers."}"#;
+        assert!(
+            PortalCallError::Failed(reason.to_string())
+                .to_string()
+                .contains(reason),
+            "a rejected upload must keep the portal's wording"
+        );
+        assert!(
+            PortalCallError::Unreachable("dns failure".to_string())
+                .to_string()
+                .contains("dns failure"),
+            "an unreachable portal must keep the transport detail"
+        );
+    }
 
     fn mk_queue_item(attempts: u32) -> QueuedItem {
         QueuedItem {


### PR DESCRIPTION
## What changed

When the UWH Portal refuses to accept a game's results, it replies with a short sentence saying why —
for example *"This event does not require unique cap numbers."* refbox was throwing that sentence away.
It now writes it to the log file.

This covers all three places a refusal was previously discarded: a refused score upload, a refused
statistics upload, and a statistics upload refused again after tapping the row to retry.

Nothing else changes. The queue behaviour, the retry timing, the indicator colours and the
"Stats not sent, tap to retry" row all behave exactly as before — the only difference is that the
explanation is now recorded instead of dropped.

## Why

When statistics don't reach the portal, the operator sees "Stats not sent" and nothing else. Several
completely unrelated causes look identical from the outside: the event's cap-number setting, an expired
portal login, a clash with results already on the portal, a portal outage, and the network dropping.

On one occasion, working out which of those it actually was took about an hour of digging. The portal
had said so plainly the whole time; refbox just wasn't writing it down. During a live event that hour
isn't available.

## Scope

One file, `refbox/src/portal_manager/health.rs`. No other crate is touched, and nothing is asked of the
portal — the explanation was already arriving; it simply wasn't recorded.

## How to verify

`just check` passes: 575 tests, no lint warnings, formatting clean, security scan unchanged.

A new test, `error_text_carries_the_reason_the_portal_gave`, guards the thing that actually matters:
the portal's wording reaches the log **only** through the error's own text, and nothing previously
asserted that. If that text ever stopped carrying the reason, these log lines would silently go quiet
again — the exact defect being fixed — while every other test stayed green. Proven by deliberately
breaking it: dropping the reason from the error text fails the test, restoring it passes.

**What is not proven here, honestly:** there is no automated test asserting the log lines themselves,
because capturing log output requires installing a process-wide logger and would be unreliable with
tests running in parallel. Nor was this demonstrated against a live refusal — that needs a game played
to completion against an event the portal rejects, and the local queue was empty.

So the observable proof is deferred to the next real refusal, where the log will read:

```
WARN refbox::portal_manager::health] stats upload for game 3 (score already accepted): portal call failed: {"reason":"This event does not require unique cap numbers."}
```

If a refusal happens and the log still says nothing, this change did not work.

### A note on wording

`PortalCallError` already renders its own "portal call failed:" or "portal unreachable:" prefix, so
these messages deliberately supply only what was being sent and for which game. Writing "portal stats
upload failed" would have produced "…failed for game 3: portal call failed: …".
