### PR TITLE
fix(refbox): stop the game clock vanishing from the banner

### DIFF
--- a/docs/backlog/portal-login-page-overflow/NOTE.md
+++ b/docs/backlog/portal-login-page-overflow/NOTE.md
@@ -1,0 +1,70 @@
+# Backlog: the portal login page overflows and eats its own buttons
+
+**Status:** Diagnosed, not fixed. Pre-existing — **not** introduced by the auto-fit work.
+**Surfaced:** 2026-08-11, while render-checking `feat/refbox/fit-clock-and-keypad-title`.
+**Confirmed against:** `master` @ `d09ff701`, built and rendered side by side with the branch. The
+defect is identical in both, so it predates PR #2063 as well.
+
+## What the operator sees
+
+UWR or UWH, **German**, game parameters → `UWHPORTAL VERWENDEN` → the login/token page:
+
+- `ABBRECHEN` (cancel) and `FERTIG` (done) collapse to **thin red and green stripes with no text**.
+  They are still there and still pressable, but unreadable and only a few pixels tall.
+- The instruction text is also **cut off mid-sentence** — it ends at "*Drücken Sie Fertig, sobald
+  Sie den Code*" with the rest missing.
+
+Both symptoms have the same cause, and the truncated text is the more important clue: the page
+simply has more content than height.
+
+## Mechanism
+
+`refbox/src/app/view_builders/keypad_pages/portal_login.rs:13-38`:
+
+```rust
+column![
+    text(fl!("portal-login-instructions", ...)).width(Length::Fill),
+    vertical_space(),
+    row![ make_button(cancel), make_button(done) ].spacing(SPACING),
+]
+```
+
+There is **no scrolling anywhere on this page**. iced's flex lays out non-`Fill` children first,
+giving each what it asks for, and hands the remainder to the `Fill` ones. The instruction text is
+laid out first at its full natural height; in German that consumes the column. The button row's
+children have a fixed 89px height, but `Limits::resolve` clamps to the space that is left — which by
+then is nearly zero — so they render as stripes.
+
+English fits, which is why this has survived.
+
+## Why auto-fit does not fix it
+
+Worth stating plainly so nobody assumes the fitting work covers it: shrinking the **button labels**
+would change nothing. The buttons are not too small for their text; they have been given almost no
+height. The text is what needs to yield.
+
+## Sketch of the options
+
+Not decided — needs its own design pass:
+
+- Make the **instructions** the flexible part: put them in a `scrollable`, so the page can never
+  push its own controls out. Probably the most robust, and matches "the buttons must always be
+  reachable".
+- Or reserve the button row's height **before** the text is laid out, so the text gets the remainder
+  and is clipped or scrolled instead.
+- Or shrink the instruction text to fit, which keeps everything visible but may end up unreadably
+  small in the longest locales — the instructions are a paragraph, not a label.
+- Shortening the German string is a workaround, not a fix: the next long translation reintroduces it.
+
+## Repro
+
+```
+mode = "Rugby"   # or "Hockey6V6"; both affected
+WAYLAND_DISPLAY= UWH_PORTAL_URL_OVERRIDE=http://localhost:8090 \
+  ./target/debug/refbox --allow-http --language de-DE
+```
+
+Game parameters → `UWHPORTAL VERWENDEN` → the token page.
+
+Related: `../auto-fit-button-text/` (merged, PR #2063) fixed label fitting inside buttons; this is
+the complementary case where a *container* denies its children the space they were promised.

--- a/docs/superpowers/specs/2026-08-11-fit-clock-and-keypad-title-design.md
+++ b/docs/superpowers/specs/2026-08-11-fit-clock-and-keypad-title-design.md
@@ -1,0 +1,196 @@
+# Design: fit the game-time banner and the keypad title row
+
+**Date:** 2026-08-11
+**Branch:** `feat/refbox/fit-clock-and-keypad-title` (off `master` @ `d09ff701`)
+**Follows:** `2026-08-11-auto-fit-button-text-design.md` (PR #2063, merged), which deliberately left
+these two slots alone.
+
+---
+
+## Goal
+
+The game clock stops disappearing from the banner, and the keypad page title row stops crowding its
+value.
+
+## The bug, measured
+
+**Baseline captured on `d09ff701`, before any change.** Main page, German unless noted:
+
+| Configuration | Baseline result |
+|---|---|
+| UWH, timeout running | Period wrapped to two lines, **no game clock at all** |
+| UWH, timeout running, Spanish | Clock clipped to `14:5` |
+| UWR **without** portal tile, timeout | **No game clock at all** |
+| UWR **with** portal tile, **no timeout** | **No game clock at all** |
+| UWR with portal tile, between games | **No clock**, `NÄCHSTES SPIEL` wrapped |
+| UWR with portal tile, timeout | Works — period small and wrapped, clock present at `14:58` |
+
+### Why the clock vanishes rather than merely clipping
+
+The tall banner is `HEALTH_TILE_SIZE + PADDING + SMALL_PLUS_TEXT` = 126px, and its button adds
+`.padding(PADDING)`, leaving **110px** inside. The column stacks the period above the clock: at full
+size that is ~37.7px + ~85.8px = ~123.5px of line boxes, which renders correctly only because line
+height includes leading the glyphs do not use. **One wrap of the period name adds ~37.7px**, reaching
+~161px, and the clock is pushed out and never drawn.
+
+So the trigger for catastrophe is a *wrap*, not a size.
+
+### Two independent causes of crowding, not one
+
+The banner's width depends on how many fixed side tiles squeeze it:
+
+| Side tiles | Configuration | Banner width |
+|---|---|---|
+| 0 | UWH, no portal | Widest |
+| 1 | UWH + portal | ~317px |
+| **2** | **UWR + portal tile *and* play/pause button** | **~222px** |
+
+A timeout then halves whichever applies. The existing rule combined these wrongly:
+
+```rust
+let compact = portal_indicator.is_some() && mode == Mode::Rugby && snapshot.timeout.is_some();
+//                                     ^^ "two side tiles"   ^^^                        ^^^ "a timeout"
+```
+
+Two independent causes, `AND`-ed as though both were required — which is why five of the six baseline
+configurations were broken and only the sixth, where both happened to hold, worked.
+
+## What shipped
+
+Sizing depends only on **how many readouts share the banner**, which is the thing that actually
+determines the space. No mode checks, no tile checks, no `compact`.
+
+| | One readout (game clock alone) | Two readouts (game + timeout) |
+|---|---|---|
+| Columns | One, full width | Two, equal halves |
+| Label | One line, **never wraps**, shrinks to fit | **May wrap to two lines**, shrinks to fit |
+| Label starting size | `SMALL_PLUS_TEXT` | `SMALL_TEXT` |
+| Label size | Its own | **Shared** — both labels take one size |
+| Time starting size | `LARGE_TEXT` | `BANNER_TWO_TIME_TEXT` (46px) |
+| Time | Never wraps, shrinks to fit | Never wraps, **shared** with the other time |
+
+Three details carry the design, and each exists for a measured reason:
+
+**The one-readout label never wraps.** A second line there is what deleted the clock. It shrinks
+instead, down to a floor of 14px — below the 19px that suits buttons, because in the narrowest
+banner a long German period name needs to come down that far to stay on one line, and a small label
+is a far better outcome than a missing clock.
+
+**The two-readout label starts small.** A label wrapping to two lines *at full size* plus a time
+exceeds the 110px, which is the original failure. Starting at `SMALL_TEXT` means two wrapped lines
+(~49px) always fit beside a time capped at 46px (~60px).
+
+**46px is derived, not chosen by eye.** 110px minus a two-line label at `SMALL_TEXT` leaves ~60.6px,
+so 60.6 / 1.3 = 46px. Anything larger and a wrapped label pushes the time out.
+
+**Sizes are shared, not fitted independently.** Both labels take one size and both times take
+another, each the largest that fits *every* string in its group. Without this a short timeout label
+(`SCH AUS`) renders at full size beside a shrunken period name and the two stop looking like a pair.
+
+**Times are fitted, not pinned.** The two modes do not offer the same half-width, so a single fixed
+size would render UWH at the size UWR needs.
+
+## CJK line breaking
+
+Found while verifying: the alarm button's hint was clipped at both ends in Japanese. The wording
+shown when the clock is stopped is 13 full-width glyphs — wider than its button at `SMALL_TEXT`, and
+`SMALL_TEXT` is also the floor, so it had nowhere to go.
+
+The cause was general: `best_split` only broke at spaces, tabs and `/`, and **CJK has no spaces**, so
+those scripts had no break opportunities at all and could only ever shrink. `best_split` now also
+breaks **between CJK characters**, which is how those scripts wrap, with an abridged form of the
+Japanese kinsoku rules so a line never begins with closing punctuation or a long-vowel mark.
+
+This completes the wrap-first-shrink-second rule shipped in PR #2063 rather than changing it: Latin
+still breaks only at spaces (pinned by a test), and every CJK label in the app can now wrap instead
+of shrinking — so those locales should render *larger*, not differently.
+
+The alternative was a per-call-site floor override for that one hint. Rejected on the human's point
+that bespoke text sizes should not accumulate when a general rule will do.
+
+## Scope
+
+**In scope:**
+
+| File | Change |
+|---|---|
+| `fit_text.rs` | `style` (colour), `no_wrap`, `min_size`, `shared_with`; CJK break opportunities |
+| `shared_elements.rs` | Both banner layouts fit their text; `compact` deleted |
+| `keypad_pages/mod.rs` | `make_panel_label` uses the label/value share pattern |
+| `main_view.rs` | Nothing — the alarm hint fix needed no call-site change once CJK breaking existed |
+
+**Not doing:**
+
+- `make_delay_line` and the behind-schedule layout — **verified untouched**: zero lines of it appear
+  in the diff, so it needs no rendered regression check.
+- Translation text, the abbreviated period names, what the banner displays, when it shows a timeout
+  column, its colours, or any timing behaviour.
+- The portal login page, whose CANCEL and APPLY buttons collapse in German. Confirmed pre-existing
+  against `master` and filed at `docs/backlog/portal-login-page-overflow/NOTE.md`. Auto-fit cannot
+  fix it — those buttons are not too small for their text, they are given almost no height.
+
+## Rejected designs
+
+Recorded because each was rejected on evidence, and the reasoning is most of the value here.
+
+| Design | Why rejected |
+|---|---|
+| Swap in `FitText` with colour support as step one | The human pointed out the elements and colours were already correct — this is a sizing problem. Sent us to check the cheaper fix first, which was right to do even though it did not survive. |
+| Width-only change, no shrinking | The baseline killed it: 2.5px of headroom means a wider column makes a wrap *less likely* but nothing makes it *impossible*, and one wrap deletes the clock. |
+| Stacked rows instead of columns | Proposed to match the behind-schedule layout. Rejected: a row makes label and clock compete for the same width, yielding a *smaller* clock (~38px vs ~50px). Columns let the label eat cheap vertical space. |
+| Dynamic height fitting with a common scale factor | The height budget is already over-subscribed at full size and works only because of leading, so a strict height rule would "correct" the wide banner that renders fine today. Preventing the wrap is sufficient. |
+| Widen the `compact` trigger to `(two tiles) \|\| (timeout)` | Covers everything observed, in one line. Rejected because the condition re-derives banner width from mode and tile presence, and three configurations had already been found by rendering — each one a clause somebody had to think to add. That is how the original bug was written. |
+| A lower floor for the alarm hint | Fixed one symptom with a bespoke number. CJK breaking fixes the class. |
+
+## Testing
+
+21 unit tests in `fit_text.rs`, driven by a fake ruler — no window, no fonts, no renderer. The 17
+from PR #2063 pass **unchanged** except for `size_ladder` gaining a floor argument; their assertions
+are untouched, which is the guard on the merged button behaviour.
+
+New: a lower floor reaches sizes the default cannot; Japanese splits between characters; a line never
+begins with closing punctuation; Latin still breaks only at spaces.
+
+**What tests cannot cover:** every defect in this branch was found by rendering, not by CI — the
+missing clock, the mismatched label sizes, the clipped Japanese hint. Full-green CI coexisted with a
+banner that silently dropped the clock.
+
+## Verification — by rendering, against the captured baseline
+
+Completed 2026-08-11:
+
+- **UWH and UWR, German**, timeout and no timeout: clock present in every case, labels matching,
+  times matching.
+- **Spanish**: the `14:5` clipping resolved.
+- **Thai**: shrinks cleanly with no wrapping available; no missing glyphs from the font subset.
+- **Japanese and Chinese**: full-width glyphs handled; the alarm hint now wraps to two lines at full
+  size rather than clipping.
+- **Keypad title row**: label and value both complete.
+- **Short banner without a timeout**, against the shot captured before the change.
+- **Short banner with a timeout** — German, black team timeout, the warnings page. Both readouts
+  complete: `ERSTE HALBZEIT 14:58` beside `AUSZEIT SCHWARZ 0:40`. This is the widest label pair the
+  banner ever shows, because the short banner uses the *full* timeout wording rather than `SCH AUS`
+  and does not abbreviate the period name. Labels settled on one shared size and times on another,
+  with nothing clipped at either end. No baseline shot was captured for this configuration, so it was
+  judged against the rule rather than against `master`.
+
+**Reasoned, not rendered:** an overtime period name (`ZWEITE VERLÄNGERUNGSHÄLFTE`, 26 characters) on
+the short banner during a timeout. It cannot reproduce the original failure, which needed the
+*stacked* layout where a second label line pushes the clock down and out of the button. The short
+banner lays the label *beside* the clock, so a wrap grows into vertical slack instead — about 13px of
+the 73px inner height went unused in the rendered case — and the label shrinks, taking the timeout
+label with it by the shared-size rule. Reaching it live needs a tied game played into overtime.
+
+**Reproducing the UWR + portal tile configuration:** set `mode = "Rugby"` in
+`~/.config/refbox/default-config.toml` **and** make `~/.config/refbox/portal_link.json` name the same
+mode with a recent `last_active` — otherwise the link is parked as stale/cross-portal and the tile
+never appears. Both were backed up as `*.bak-rugby-baseline` and restored afterwards.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| The clock ends up smaller than today somewhere | Every baseline configuration was re-rendered and compared; the one that previously worked came out no smaller. |
+| CJK breaking changes labels across the app | It only ever allows wrapping where previously only shrinking was possible, so CJK text should come out larger. Latin behaviour is pinned by a test. |
+| A future translation defeats the 14px floor | It would clip rather than lose the clock — a visible, attributable failure rather than a silent one. |
+| A new element on the banner reintroduces crowding | Sizing depends on the number of readouts, not on mode or tiles, so there is no condition to forget to update. |

--- a/refbox/src/app/view_builders/fit_text.rs
+++ b/refbox/src/app/view_builders/fit_text.rs
@@ -41,6 +41,48 @@ use std::borrow::Cow;
 /// legible on the refbox screen.
 pub(super) const MIN_FIT_TEXT: f32 = 19.0;
 
+/// Whether a line may end after this character.
+///
+/// True for the CJK scripts, where breaking between characters is how wrapping
+/// normally works. Kana, ideographs, Hangul syllables and full-width forms all
+/// qualify; anything else (Latin, Thai, digits, punctuation) does not, so those
+/// still break only at spaces.
+fn breaks_after(character: char) -> bool {
+    matches!(
+        character as u32,
+        0x3040..=0x30FF     // hiragana and katakana
+        | 0x3400..=0x4DBF   // CJK extension A
+        | 0x4E00..=0x9FFF   // CJK unified ideographs
+        | 0xF900..=0xFAFF   // CJK compatibility ideographs
+        | 0xAC00..=0xD7AF   // Hangul syllables
+        | 0xFF00..=0xFF60 // full-width forms
+    )
+}
+
+/// Whether a line may begin with this character.
+///
+/// An abridged form of the Japanese kinsoku rules: a line must not start with
+/// closing punctuation or a long-vowel mark, which would read as a typo.
+fn breaks_before(character: char) -> bool {
+    breaks_after(character)
+        && !matches!(
+            character,
+            '、' | '。'
+                | '，'
+                | '．'
+                | '）'
+                | '」'
+                | '』'
+                | '】'
+                | '〕'
+                | '！'
+                | '？'
+                | 'ー'
+                | '・'
+                | 'ｰ'
+        )
+}
+
 /// Splits `line` in two at the break point that leaves the wider half as narrow
 /// as possible. `None` when there is nowhere to break, i.e. a single long word,
 /// which can only be shrunk.
@@ -52,14 +94,27 @@ pub(super) const MIN_FIT_TEXT: f32 = 19.0;
 /// like `15:00` must stay whole.
 fn best_split(measure: impl Fn(&str) -> f32, line: &str) -> Option<(String, String)> {
     let mut best: Option<(f32, &str, &str)> = None;
+    let mut previous: Option<char> = None;
 
     for (index, character) in line.char_indices() {
-        // Both are single-byte, so these slice boundaries are always valid.
+        // ' ', '\t' and '/' are single-byte, so those boundaries are valid; the
+        // CJK case slices at `index`, which is a char boundary by construction.
         let (first, second) = match character {
             ' ' | '\t' => (&line[..index], &line[index + 1..]),
             '/' => (&line[..index + 1], &line[index + 1..]),
-            _ => continue,
+            // Between two CJK characters, which is how those scripts are broken:
+            // they have no spaces, so without this a long Japanese or Chinese
+            // label has nowhere to wrap and can only shrink -- to the floor and
+            // then to clipping.
+            _ if previous.is_some_and(breaks_after) && breaks_before(character) => {
+                (&line[..index], &line[index..])
+            }
+            _ => {
+                previous = Some(character);
+                continue;
+            }
         };
+        previous = Some(character);
 
         let (first, second) = (first.trim(), second.trim());
         if first.is_empty() || second.is_empty() {
@@ -120,29 +175,72 @@ fn line_left(align: Horizontal, box_width: f32, line_width: f32) -> f32 {
     }
 }
 
-/// Sizes to try, largest first: whole pixels from `max_size` down to the floor.
-fn size_ladder(max_size: f32) -> Vec<f32> {
-    let min = MIN_FIT_TEXT as i32;
+/// Index of the first (largest) candidate at which **every** string in `shared`
+/// fits `max_width`.
+///
+/// This is how separate widgets agree on one size. The game-time banner draws the
+/// period label and the timeout label in different columns, but they must look
+/// like a pair, so each is fitted against both strings and the longer one governs.
+/// Returns the last index when nothing fits, so the caller still gets a ladder.
+fn shared_start(
+    measure: impl Fn(&str, f32) -> f32,
+    max_width: f32,
+    candidates: &[f32],
+    shared: &[String],
+    wrap: bool,
+) -> usize {
+    // A shared string "fits" on the same terms the drawn one does: on one line,
+    // or -- when wrapping is allowed -- split in two with its wider half fitting.
+    // Judging shared strings as single lines only would force everything down to
+    // the size the longest one needs unsplit, which is not what it will be drawn at.
+    let fits = |line: &str, size: f32| {
+        if measure(line, size) <= max_width {
+            return true;
+        }
+        wrap && best_split(|part| measure(part, size), line).is_some_and(|(first, second)| {
+            measure(&first, size).max(measure(&second, size)) <= max_width
+        })
+    };
+
+    candidates
+        .iter()
+        .position(|&size| shared.iter().all(|line| fits(line, size)))
+        .unwrap_or(candidates.len().saturating_sub(1))
+}
+
+/// Sizes to try, largest first: whole pixels from `max_size` down to `min_size`.
+fn size_ladder(max_size: f32, min_size: f32) -> Vec<f32> {
+    let min = min_size.round().max(1.0) as i32;
     let max = (max_size.round() as i32).max(min);
     (min..=max).rev().map(|size| size as f32).collect()
 }
 
 /// A label drawn centred, wrapped at word gaps if needed, and shrunk only if
 /// wrapping still leaves it too wide. Every line shares one size.
-pub(super) struct FitText<'a> {
+pub(super) struct FitText<'a, Theme> {
     lines: Vec<Cow<'a, str>>,
     /// `None` means "the app's default text size", matching what a plain
     /// `text()` widget would use.
     max_size: Option<f32>,
+    /// Smallest size to shrink to. Defaults to `MIN_FIT_TEXT`, which suits
+    /// buttons; the game-time banner sets its own, lower, floor because losing
+    /// the clock is far worse than a small period label.
+    min_size: f32,
     /// Whether a single line may be re-wrapped at word gaps. Off when the caller
-    /// supplied the line break itself, so its choice is never second-guessed.
+    /// supplied the line break itself, or where a second line would push a
+    /// neighbouring readout out of its box.
     wrap: bool,
     width: Length,
     height: Length,
     align: Horizontal,
+    /// Optional state-dependent colour. `None` inherits, as a plain `text()` does.
+    style: Option<fn(&Theme) -> TextStyle>,
+    /// Strings that are measured but not drawn, so that several widgets showing
+    /// related values settle on one size instead of each fitting alone.
+    shared: Vec<String>,
 }
 
-impl FitText<'_> {
+impl<Theme> FitText<'_, Theme> {
     /// Sets the size the label starts at before any shrinking.
     pub(super) fn size(mut self, max_size: f32) -> Self {
         self.max_size = Some(max_size);
@@ -172,6 +270,42 @@ impl FitText<'_> {
         self.align = align;
         self
     }
+
+    /// Shrinks rather than wrapping at word gaps.
+    ///
+    /// The default suits buttons, which have room for a second line. It is wrong
+    /// in the game-time banner, where the period label sits above the clock in a
+    /// box with no spare height: a second line there pushes the clock out of the
+    /// banner and it is not drawn at all.
+    pub(super) fn no_wrap(mut self) -> Self {
+        self.wrap = false;
+        self
+    }
+
+    /// Sets the smallest size to shrink to, overriding `MIN_FIT_TEXT`.
+    pub(super) fn min_size(mut self, min_size: f32) -> Self {
+        self.min_size = min_size;
+        self
+    }
+
+    /// Sets a state-dependent colour, as the game-time banner needs: the period
+    /// and clock are green, yellow or red depending on the state of play.
+    pub(super) fn style(mut self, style: fn(&Theme) -> TextStyle) -> Self {
+        self.style = Some(style);
+        self
+    }
+
+    /// Sizes this label so that every string in `shared` would also fit, then
+    /// draws only its own text.
+    ///
+    /// Use it to keep related readouts consistent: the game-time banner's period
+    /// label and timeout label live in separate columns of equal width, and
+    /// without this the short one renders at full size next to a shrunken long
+    /// one, so the two stop looking like a pair. The longest string governs.
+    pub(super) fn shared_with(mut self, shared: Vec<String>) -> Self {
+        self.shared = shared;
+        self
+    }
 }
 
 /// A label that shrinks to fit, wrapping at word gaps first.
@@ -179,7 +313,7 @@ impl FitText<'_> {
 /// A translation may carry its own line breaks — several `.ftl` entries are
 /// written across two lines deliberately. Those win: the label is split on them
 /// and never re-wrapped, so a translator's choice is not second-guessed.
-pub(super) fn fit_text<'a>(line: impl IntoFragment<'a>) -> FitText<'a> {
+pub(super) fn fit_text<'a, Theme>(line: impl IntoFragment<'a>) -> FitText<'a, Theme> {
     let fragment = line.into_fragment();
     let lines: Vec<Cow<'a, str>> = if fragment.contains('\n') {
         fragment
@@ -194,26 +328,32 @@ pub(super) fn fit_text<'a>(line: impl IntoFragment<'a>) -> FitText<'a> {
     FitText {
         lines,
         max_size: None,
+        min_size: MIN_FIT_TEXT,
         wrap,
         width: Length::Fill,
         height: Length::Fill,
         align: Horizontal::Center,
+        style: None,
+        shared: Vec::new(),
     }
 }
 
 /// Two caller-chosen lines that shrink together, both at the same size. The
 /// split is the caller's and is never re-wrapped.
-pub(super) fn fit_text_lines<'a>(
+pub(super) fn fit_text_lines<'a, Theme>(
     first: impl IntoFragment<'a>,
     second: impl IntoFragment<'a>,
-) -> FitText<'a> {
+) -> FitText<'a, Theme> {
     FitText {
         lines: vec![first.into_fragment(), second.into_fragment()],
         max_size: None,
+        min_size: MIN_FIT_TEXT,
         wrap: false,
         width: Length::Fill,
         height: Length::Fill,
         align: Horizontal::Center,
+        style: None,
+        shared: Vec::new(),
     }
 }
 
@@ -233,11 +373,12 @@ struct State<P: Paragraph> {
 #[derive(PartialEq)]
 struct CacheKey {
     lines: Vec<String>,
+    shared: Vec<String>,
     available_width: f32,
     max_size: f32,
 }
 
-impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer> for FitText<'_>
+impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer> for FitText<'_, Theme>
 where
     Renderer: text::Renderer,
 {
@@ -274,6 +415,7 @@ where
 
         let key = CacheKey {
             lines: self.lines.iter().map(|line| line.to_string()).collect(),
+            shared: self.shared.clone(),
             available_width: available.width,
             max_size,
         };
@@ -305,8 +447,13 @@ where
                 }
             }
 
-            let (index, size) =
-                fit_layout(measure, available.width, &size_ladder(max_size), &line_sets);
+            // Begin the ladder at the largest size where every shared string
+            // fits, so related readouts settle on one size rather than each
+            // fitting alone.
+            let ladder = size_ladder(max_size, self.min_size);
+            let start = shared_start(measure, available.width, &ladder, &key.shared, self.wrap);
+
+            let (index, size) = fit_layout(measure, available.width, &ladder[start..], &line_sets);
 
             state.lines = line_sets.swap_remove(index);
             state.chosen = size;
@@ -386,13 +533,20 @@ where
         &self,
         tree: &Tree,
         renderer: &mut Renderer,
-        _theme: &Theme,
+        theme: &Theme,
         defaults: &renderer::Style,
         layout: Layout<'_>,
         _cursor: mouse::Cursor,
         viewport: &Rectangle,
     ) {
         let state = tree.state.downcast_ref::<State<Renderer::Paragraph>>();
+
+        // No style set means inherit, which is what a plain `text()` inside a
+        // button does and what keeps every button's own colours working.
+        let appearance = match self.style {
+            Some(style) => style(theme),
+            None => TextStyle { color: None },
+        };
 
         // Clip to our own bounds so a label still too wide at the floor is
         // trimmed rather than spilling onto the neighbouring button.
@@ -401,25 +555,19 @@ where
         };
 
         for (paragraph, line) in state.paragraphs.iter().zip(layout.children()) {
-            draw_text(
-                renderer,
-                defaults,
-                line,
-                paragraph.raw(),
-                TextStyle { color: None },
-                &clip,
-            );
+            draw_text(renderer, defaults, line, paragraph.raw(), appearance, &clip);
         }
     }
 }
 
-impl<'a, Message, Theme, Renderer> From<FitText<'a>> for Element<'a, Message, Theme, Renderer>
+impl<'a, Message, Theme, Renderer> From<FitText<'a, Theme>>
+    for Element<'a, Message, Theme, Renderer>
 where
     Message: 'a,
     Theme: 'a,
     Renderer: text::Renderer + 'a,
 {
-    fn from(widget: FitText<'a>) -> Self {
+    fn from(widget: FitText<'a, Theme>) -> Self {
         Self::new(widget)
     }
 }
@@ -430,7 +578,7 @@ mod tests {
 
     /// The ladder used by the full-width buttons: 29px down to 19px.
     fn candidates() -> Vec<f32> {
-        size_ladder(29.0)
+        size_ladder(29.0, MIN_FIT_TEXT)
     }
 
     /// A fake ruler: every character is half the font size wide. Real
@@ -445,7 +593,7 @@ mod tests {
 
     #[test]
     fn ladder_runs_from_the_starting_size_down_to_the_floor() {
-        let ladder = size_ladder(29.0);
+        let ladder = size_ladder(29.0, MIN_FIT_TEXT);
         assert_eq!(ladder.first(), Some(&29.0));
         assert_eq!(ladder.last(), Some(&MIN_FIT_TEXT));
         assert_eq!(ladder.len(), 11);
@@ -453,7 +601,7 @@ mod tests {
 
     #[test]
     fn a_starting_size_below_the_floor_still_yields_one_candidate() {
-        assert_eq!(size_ladder(10.0), vec![MIN_FIT_TEXT]);
+        assert_eq!(size_ladder(10.0, MIN_FIT_TEXT), vec![MIN_FIT_TEXT]);
     }
 
     #[test]
@@ -571,9 +719,58 @@ mod tests {
     }
 
     #[test]
+    fn a_lower_floor_lets_a_label_shrink_further_rather_than_stop() {
+        // The game-time banner needs this: on one line, "ERSTE HALBZEIT" (14
+        // characters) needs 7 * size, so 100px of width demands ~14px — below the
+        // 19px floor that suits buttons. With the button floor it would stop at 19
+        // and overflow; with a lower floor it shrinks and fits.
+        let sets = vec![vec!["ERSTE HALBZEIT".to_string()]];
+        assert_eq!(
+            fit_layout(ruler, 100.0, &size_ladder(29.0, MIN_FIT_TEXT), &sets),
+            (0, MIN_FIT_TEXT)
+        );
+        assert_eq!(
+            fit_layout(ruler, 100.0, &size_ladder(29.0, 12.0), &sets),
+            (0, 14.0)
+        );
+    }
+
+    #[test]
     fn a_time_is_never_split_at_its_colon() {
         let measure = |line: &str| line.chars().count() as f32;
         assert_eq!(best_split(measure, "15:00"), None);
+    }
+
+    #[test]
+    fn japanese_splits_between_characters_having_no_spaces() {
+        // The alarm hint. Thirteen full-width glyphs with nowhere to wrap could
+        // only shrink, and at its starting size it was wider than its button, so
+        // it clipped at both ends. Breaking between characters is how these
+        // scripts wrap.
+        let measure = |line: &str| line.chars().count() as f32;
+        assert_eq!(
+            best_split(measure, "またはスペースキーを長押し"),
+            Some(("またはスペー".to_string(), "スキーを長押し".to_string()))
+        );
+    }
+
+    #[test]
+    fn a_line_never_begins_with_closing_punctuation() {
+        // Abridged kinsoku: breaking before 。 would strand it at the start of a
+        // line, which reads as a typo. The only other gap here is before 気.
+        let measure = |line: &str| line.chars().count() as f32;
+        assert_eq!(
+            best_split(measure, "元気。"),
+            Some(("元".to_string(), "気。".to_string()))
+        );
+    }
+
+    #[test]
+    fn latin_still_breaks_only_at_spaces() {
+        // The CJK rule must not leak into Latin: "HALBZEIT" has no space, so it
+        // stays unsplittable and shrinks instead.
+        let measure = |line: &str| line.chars().count() as f32;
+        assert_eq!(best_split(measure, "HALBZEIT"), None);
     }
 
     #[test]

--- a/refbox/src/app/view_builders/keypad_pages/mod.rs
+++ b/refbox/src/app/view_builders/keypad_pages/mod.rs
@@ -1,4 +1,5 @@
 use super::{
+    fit_text::fit_text,
     theme::{MEDIUM_TEXT, MIN_BUTTON_SIZE, PADDING, SPACING},
     *,
 };
@@ -6,7 +7,7 @@ use iced::{
     Length,
     alignment::{Horizontal, Vertical},
     widget::{
-        Space, button,
+        button,
         button::Button,
         column, container, row,
         svg::{self, Svg},
@@ -294,9 +295,19 @@ fn make_panel_label<'a>(
     player_num: u32,
 ) -> Element<'a, Message> {
     row![
-        text(page.text()).align_x(Horizontal::Left),
-        Space::with_width(Length::Fill),
-        text(panel_value(role, player_num)).size(MEDIUM_TEXT),
+        // Label and value each get a guaranteed share of the fixed 283px width.
+        // Letting either take what it wants first starves the other, and this row
+        // is one line tall (`MEDIUM_TEXT * 1.2`), so an overflowing plain `text()`
+        // wraps and is then clipped -- shrinking is the only thing that helps.
+        fit_text(page.text())
+            .align_x(Horizontal::Left)
+            .width(Length::FillPortion(3))
+            .height(Length::Shrink),
+        fit_text(panel_value(role, player_num))
+            .size(MEDIUM_TEXT)
+            .align_x(Horizontal::Right)
+            .width(Length::FillPortion(2))
+            .height(Length::Shrink),
     ]
     .width(Length::Fixed(3.0 * MIN_BUTTON_SIZE + 2.0 * SPACING))
     .into()

--- a/refbox/src/app/view_builders/shared_elements.rs
+++ b/refbox/src/app/view_builders/shared_elements.rs
@@ -536,6 +536,29 @@ pub(super) fn make_health_tile<'a>(
     .into()
 }
 
+/// Floor for the banner's own text, below the `MIN_FIT_TEXT` that suits buttons.
+///
+/// The period label and the clock share a box with no spare height, so the label
+/// must shrink rather than wrap. In the tightest configuration -- UWR with both
+/// side tiles and a timeout, leaving the column about 103px wide -- a long
+/// German period name needs to come down this far to stay on one line. A small
+/// label is a much better outcome than a missing clock.
+const BANNER_MIN_TEXT: f32 = 14.0;
+
+/// Largest time size to use when two readouts share the banner.
+///
+/// Derived from the vertical budget rather than picked by eye. The banner button
+/// leaves 126 - 2*PADDING = 110px inside. A label wrapped onto two lines at
+/// `SMALL_TEXT` takes 2 * 19 * 1.3 = 49.4px of that, leaving 60.6px, which allows
+/// a time of 60.6 / 1.3 = 46px. Larger than that and a wrapped label would push
+/// the time out of the banner -- which is exactly how the clock used to vanish.
+///
+/// The times are fitted rather than pinned to this, because the two modes do not
+/// give the banner the same width: UWR carries a play/pause button as well as the
+/// portal tile, so its halves are narrower. Pinning one size would render UWH at
+/// the size UWR needs.
+const BANNER_TWO_TIME_TEXT: f32 = 46.0;
+
 pub(super) fn make_game_time_button<'a>(
     snapshot: &GameSnapshot,
     tall: bool,
@@ -614,48 +637,97 @@ pub(super) fn make_game_time_button<'a>(
         };
     }
 
-    let make_time_view_row = |period_text, time_text, style: fn(&Theme) -> TextStyle| {
-        // Wrap period text in a right-aligned container so the text widget uses
-        // width(Shrink). This ensures iced's damage region starts from the text's
-        // actual left edge, preventing old glyph pixels from bleeding through when
-        // the period name changes (iced 0.13 damage tracking bug with aligned text).
-        let per = container(
-            text(period_text)
-                .style(style)
-                .width(Length::Shrink)
-                .align_y(Vertical::Center),
-        )
-        .width(Length::Fill)
-        .align_x(Horizontal::Right)
-        .align_y(Vertical::Center);
-        let time = text(time_text)
+    // Neither banner text may wrap. The period label sits above (or beside) the
+    // clock in a box with no spare height, so a second line pushes the clock out
+    // of the banner and it is not drawn at all -- the clock simply vanishes. They
+    // shrink to fit instead.
+    //
+    // This replaces a hand-tuned `compact` rule that dropped both to fixed
+    // smaller sizes. It fired only in UWR + portal mode *and* during a timeout,
+    // so every other crowded configuration lost the clock: Hockey with a timeout,
+    // UWR without the portal tile, and UWR with both side tiles even with no
+    // timeout at all. Crowding does not depend on the mode or on which side tiles
+    // happen to be present, so nothing is triggered on state any more.
+    //
+    // `FitText` anchors its paragraphs top-left and places each line itself,
+    // which is also why the right-aligned `container` workaround this row used to
+    // need (for the iced 0.13 repaint bug with aligned text) is gone.
+    // How a readout is sized depends on whether it has the banner to itself.
+    //
+    // One readout (the game clock alone) keeps the full width and the big clock,
+    // and its label stays on one line -- a second line there would push the clock
+    // out of the banner, which is how the clock used to vanish entirely.
+    //
+    // Two readouts split the width equally. The time then has a known space, so
+    // its size is fixed rather than fitted; the label is the part that varies by
+    // language, so it may wrap to two lines and shrinks to fit its half. Starting
+    // the label at the smaller size is what guarantees two wrapped lines still fit
+    // beside the time.
+    //
+    // `labels` lists every label across the banner so both settle on one size:
+    // otherwise a short timeout label renders full-size beside a shrunken period
+    // name and the two stop looking like a pair.
+    struct Sizes {
+        label: f32,
+        time: f32,
+    }
+    let sizes = if snapshot.timeout.is_some() {
+        Sizes {
+            label: SMALL_TEXT,
+            time: BANNER_TWO_TIME_TEXT,
+        }
+    } else {
+        Sizes {
+            label: SMALL_PLUS_TEXT,
+            time: LARGE_TEXT,
+        }
+    };
+    let wraps = snapshot.timeout.is_some();
+
+    let make_time_view_row = |period_text,
+                              time_text,
+                              style: fn(&Theme) -> TextStyle,
+                              labels: &[String],
+                              times: &[String]| {
+        let per = fit_text(period_text)
+            .size(sizes.label)
+            .min_size(BANNER_MIN_TEXT)
+            .shared_with(labels.to_vec())
             .style(style)
-            .size(LARGE_TEXT)
-            .width(Length::Fill)
-            .align_y(Vertical::Center)
-            .align_x(Horizontal::Left);
+            .align_x(Horizontal::Right)
+            .height(Length::Shrink);
+        let per = if wraps { per } else { per.no_wrap() };
+        let time = fit_text(time_text)
+            .no_wrap()
+            .size(sizes.time)
+            .min_size(BANNER_MIN_TEXT)
+            .shared_with(times.to_vec())
+            .style(style)
+            .align_x(Horizontal::Left)
+            .height(Length::Shrink);
         let r = row![].spacing(SPACING);
         make_time_view!(r, per, time).align_y(Alignment::Center)
     };
 
-    // The banner is "tight" only in UWR + portal mode (both side tiles present)
-    // AND when a timeout column is also competing for width. In that case the
-    // period label and clock shrink so everything fits; every other banner keeps
-    // the big full-size clock for poolside readability. The behind-schedule DELAY
-    // figure no longer competes for width here -- when it shows it drops to its
-    // own line below the clock (see the `overrun_label` branch further down).
-    let compact = portal_indicator.is_some() && mode == Mode::Rugby && snapshot.timeout.is_some();
-
-    let make_time_view_col = |period_text, time_text, style| {
-        let per = if compact {
-            text(period_text).style(style).size(SMALL_TEXT)
-        } else {
-            text(period_text).style(style)
-        };
-        let time =
-            text(time_text)
-                .style(style)
-                .size(if compact { MEDIUM_TEXT } else { LARGE_TEXT });
+    let make_time_view_col = |period_text,
+                              time_text,
+                              style: fn(&Theme) -> TextStyle,
+                              labels: &[String],
+                              times: &[String]| {
+        let per = fit_text(period_text)
+            .size(sizes.label)
+            .min_size(BANNER_MIN_TEXT)
+            .shared_with(labels.to_vec())
+            .style(style)
+            .height(Length::Shrink);
+        let per = if wraps { per } else { per.no_wrap() };
+        let time = fit_text(time_text)
+            .no_wrap()
+            .size(sizes.time)
+            .min_size(BANNER_MIN_TEXT)
+            .shared_with(times.to_vec())
+            .style(style)
+            .height(Length::Shrink);
         let c = column![];
         make_time_view!(c, per, time).align_x(Alignment::Center)
     };
@@ -737,23 +809,59 @@ pub(super) fn make_game_time_button<'a>(
         .spacing(SPACING)
         .align_x(Alignment::Center);
         content = content.push(block);
-    } else if tall {
-        content = content.push(make_time_view_col(period_text, time_text, period_color));
-        if let Some((timeout_text, timeout_color)) = timeout_info {
-            content = content.push(make_time_view_col(
-                timeout_text,
-                timeout_time_string(snapshot),
-                timeout_color,
-            ));
-        }
     } else {
-        content = content.push(make_time_view_row(period_text, time_text, period_color));
-        if let Some((timeout_text, timeout_color)) = timeout_info {
-            content = content.push(make_time_view_row(
-                timeout_text,
-                timeout_time_string(snapshot),
-                timeout_color,
+        // Collect every label and every time the banner is about to show, so both
+        // readouts are fitted against the same strings and come out matching.
+        let timeout_time = timeout_info.as_ref().map(|_| timeout_time_string(snapshot));
+        let times: Vec<String> = [Some(time_text.clone()), timeout_time.clone()]
+            .into_iter()
+            .flatten()
+            .collect();
+        let labels: Vec<String> = [
+            Some(period_text.clone()),
+            timeout_info.as_ref().map(|(t, _)| t.clone()),
+        ]
+        .into_iter()
+        .flatten()
+        .collect();
+        if tall {
+            content = content.push(make_time_view_col(
+                period_text,
+                time_text,
+                period_color,
+                &labels,
+                &times,
             ));
+            if let Some(((timeout_text, timeout_color), timeout_time)) =
+                timeout_info.zip(timeout_time)
+            {
+                content = content.push(make_time_view_col(
+                    timeout_text,
+                    timeout_time,
+                    timeout_color,
+                    &labels,
+                    &times,
+                ));
+            }
+        } else {
+            content = content.push(make_time_view_row(
+                period_text,
+                time_text,
+                period_color,
+                &labels,
+                &times,
+            ));
+            if let Some(((timeout_text, timeout_color), timeout_time)) =
+                timeout_info.zip(timeout_time)
+            {
+                content = content.push(make_time_view_row(
+                    timeout_text,
+                    timeout_time,
+                    timeout_color,
+                    &labels,
+                    &times,
+                ));
+            }
         }
     }
 


### PR DESCRIPTION
## What changed

**The game clock no longer disappears from the grey banner at the top of the screen.** Before this
change, in several ordinary situations the clock was not merely small or cut off — it was *absent*.
In German, with a timeout running, the operator had no game clock on screen at all.

The banner now decides its text sizes from one thing only: **how many readouts it has to show.**

- **Game clock alone** — full width, big clock, and the period name stays on one line, shrinking if
  it has to. A second line of period name is precisely what used to push the clock out of the banner.
- **Game clock plus a timeout** — the banner splits into equal halves. The period name may wrap onto
  two lines at a smaller starting size, and the two clocks are capped at a size that leaves room for
  that. Both labels take one shared size and both clocks take another, so the two readouts look like
  a matched pair instead of one shrunken and one full-size.

**The keypad page title row no longer crowds its value** — the same label-and-value sizing is applied
there.

**Japanese, Chinese and Korean labels can now wrap onto a second line instead of only shrinking.**
The text fitter previously broke lines at spaces, and those languages do not use spaces between
words, so those labels had no way to wrap and could only get smaller. This was found while checking
this work: the alarm button's hint was cut off at both ends in Japanese. Those languages should now
render *larger*, not differently. European languages are unaffected, and a test pins that.

## Why

The disappearing clock is the serious problem here. The old rule for deciding "is this banner
crowded?" required three things to be true at the same time — Rugby mode, *and* a portal event
linked, *and* a timeout running. But crowding has two independent causes: how many fixed tiles are
squeezing the banner from the sides, and whether a timeout is competing for the width. Requiring both
at once meant the fix fired almost never. Of six configurations captured before the change, **five
were broken** — including with no timeout at all — and the only one that worked was the single case
where all three conditions happened to hold.

Sizing now depends on the number of readouts, which is the thing that actually determines the space
available. There is no mode check and no tile check, so adding something new to the banner in future
cannot quietly reintroduce this.

## Scope

Changes are limited to the `refbox` crate:

- `refbox/src/app/view_builders/fit_text.rs` — the text fitter gains text colour, a lower size floor,
  shared sizing across several labels, and line breaks between CJK characters
- `refbox/src/app/view_builders/shared_elements.rs` — both banner layouts fit their text; the old
  three-condition rule is deleted
- `refbox/src/app/view_builders/keypad_pages/mod.rs` — the title row uses the same label/value sizing
- `docs/` — the design record and a note about a separate, pre-existing problem (below)

No shared types, no wire format, no firmware, no LED panel or stream overlay code is touched.

**Deliberately not fixed here:** the portal login page, whose CANCEL and DONE buttons collapse to
stripes in German. That is pre-existing on `master`, and automatic text fitting cannot help — those
buttons are not too small for their text, they are given almost no height. Filed at
`docs/backlog/portal-login-page-overflow/NOTE.md`.

## How to verify

Automated: `just check` is green — 596 tests pass, including 21 unit tests for the text fitter. The 17
tests that came with the earlier auto-fit work (#2063) pass with their assertions untouched, which is
the guard that this change did not alter the merged button behaviour.

By eye, which is how every defect in this work was actually found — full-green tests coexisted with a
banner that silently dropped the clock:

1. Start the refbox in German (`--language de-DE`).
2. On the main page, start the clock and call a **black team timeout**. The banner should show the
   period name above the game clock on the left, and `SCH AUS` above the timeout clock on the right.
   **Both clocks must be present** — on `master` the game clock is missing here.
3. While the timeout runs, tap **VERWARNUNGEN**. The shorter banner shows the same two readouts side
   by side, with the longer wording `AUSZEIT SCHWARZ`. Nothing should be cut off, and the two labels
   should be the same size as each other, as should the two clocks.
4. In Spanish, check the game clock reads a full time such as `14:58` rather than `14:5`.
5. In Japanese, check the hint under the alarm button on the main page reads completely, wrapping to
   two lines rather than being clipped at both ends.

The design record, including the six alternatives that were rejected and why, is committed at
`docs/superpowers/specs/2026-08-11-fit-clock-and-keypad-title-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
