### PR TITLE
chore(refbox): remove 32 unreferenced translation keys

### DIFF
--- a/refbox/translations/de-DE/refbox.ftl
+++ b/refbox/translations/de-DE/refbox.ftl
@@ -12,7 +12,6 @@ cancel = ABBRECHEN
 delete = LÖSCHEN
 back = ZURÜCK
 apply = ANWENDEN
-save = SPEICHERN
 user-options = BENUTZEROPTIONEN
 new = NEU
 
@@ -35,8 +34,6 @@ team-timeout-count = AUSZEIT
     ANZAHL:
 
 # Verwarnung hinzufügen
-team-warning = MANNSCHAFT
-    VERWARNUNG
 team-warning-line-1 = MANNSCHAFT
 team-warning-line-2 = VERWARNUNG
 team-score-line-1 = MANNSCHAFT
@@ -81,8 +78,6 @@ audible-countdown-for-last-10-seconds = AKUSTISCHER COUNTDOWN
     10 SEKUNDEN
 delay = VERZÖGERUNG
 court = FELD:
-single-half = EINZELNE
-    HALBZEIT:
 half-length-full = HALBZEITDAUER:
 game-length = SPIELDAUER:
 overtime-allowed = VERLÄNGERUNG
@@ -95,8 +90,6 @@ pre-ot-break-length = PAUSE VOR
     VERLÄNGERUNG:
 pre-sd-break-length = PAUSE VOR
     PLÖTZL. TOD:
-nominal-break-between-games = NOMINALE PAUSE
-    ZWISCHEN SPIELEN:
 ot-half-length = VERLÄNGERUNGS-
     HALBZEITDAUER:
 timeouts-counted-per = AUSZEITEN
@@ -151,13 +144,11 @@ half-length = HALBZ. DAUER
 length-of-half-during-regular-play = Die Dauer einer Halbzeit während des regulären Spiels
 half-time-lenght = HALBZEITPAUSE DAUER
 length-of-half-time-period = Die Dauer der Halbzeitpause
-nom-break = NOM. PAUSE
 game-block = SPIELBLOCK
 game-block-full = SPIELBLOCK:
 game-block-help = Zeit vom Beginn eines Spiels bis zum Beginn des nächsten
 game-block-too-short = Zu kurz für das Spiel plus die Mindestpause
 game-block-tight = Knapp — Auszeiten könnten die Spiele über ihren Zeitslot hinausschieben
-system-will-keep-game-times-spaced = Das System versucht, die Spielstartzeiten gleichmäßig zu verteilen. Die Gesamtzeit von einem Start zum nächsten beträgt 2 × [Halbzeitdauer] + [Halbzeitpausendauer] + [Nominale Spielpause] (Beispiel: bei [Halbzeitdauer] = 15 Min, [Halbzeitpausendauer] = 3 Min und [Nominale Spielpause] = 12 Min beträgt die Zeit von Spielstart zu Spielstart 45 Min. Auszeiten oder andere Spielunterbrechungen verkürzen die 12 Min bis zur minimalen Pause zwischen Spielen).
 min-break = MIN. PAUSE
 min-time-btwn-games = Wenn ein Spiel länger dauert als geplant, ist dies die minimale Pause zwischen Spielen, die das System einplant. Bei Rückstand holt das System bei nachfolgenden Spielen auf und hält dabei stets diese Mindestpause ein.
 pre-ot-break-abreviated = PAUSE VOR VERLÄNGERUNG
@@ -169,7 +160,6 @@ len-of-overtime-halftime = Die Dauer der Verlängerungspause
 pre-sd-break = PAUSE VOR PLÖTZL. TOD
 pre-sd-len = Die Dauer der Pause zwischen dem vorherigen Spielabschnitt und dem Plötzlichen Tod
 language = SPRACHE
-this-language = DEUTSCH
 portal-login-code = CODE
 portal-login-instructions = Gehen Sie zu { $portal } Portal >> Veranstaltungsverwaltung >> Schiedsrichterverwaltung, klicken Sie auf die + Schaltfläche, um eine neue Refbox hinzuzufügen, und geben Sie diese Refbox-ID ein:
     { $id }
@@ -177,7 +167,6 @@ portal-login-instructions = Gehen Sie zu { $portal } Portal >> Veranstaltungsver
     Das { $portal } Portal stellt Ihnen dann einen Bestätigungscode bereit, den Sie links über das Nummernfeld eingeben.
     Drücken Sie Fertig, sobald Sie den Code eingegeben haben
 
-help = HILFE:
 
 # Bestätigung
 game-configuration-can-not-be-changed = Die Spielkonfiguration kann während eines laufenden Spiels nicht geändert werden.
@@ -214,24 +203,6 @@ refresh = AKTUALISIEREN
 refreshing = WIRD AKTUALISIERT...
 settings = EINSTELLUNGEN
 none = Keine
-game-number-error = Fehler ({ $game_number })
-next-game-number-error = Fehler ({ $next_game_number })
-last-game-next-game = Letztes Spiel: { $prev_game },
-    Nächstes Spiel: { $next_game }
-black-team-white-team = Schwarze Mannschaft: { $black_team }
-    Weiße Mannschaft: { $white_team }
-game-length-ot-allowed = Halbzeitdauer: { $half_length }
-         Halbzeitpausendauer: { $half_time_length }
-         Verlängerung Erlaubt: { $overtime }
-overtime-details = Pause vor Verlängerung: { $pre_overtime }
-             Halbzeitdauer Verlängerung: { $overtime_len }
-             Halbzeitpausendauer Verlängerung: { $overtime_half_time_len }
-sd-allowed = Plötzlicher Tod Erlaubt: { $sd }
-pre-sd = Pause vor Plötzlichem Tod: { $pre_sd_len }
-team-to-len = Mannschafts-Auszeit Dauer: { $to_len }
-time-btwn-games = Nominale Spielpause: { $time_btwn }
-game-block-info = Spielblock: { $game_block }
-min-brk-btwn-games = Minimale Spielpause: { $min_brk_time }
 
 
 # Listenauswahl
@@ -312,21 +283,8 @@ infraction = Verstoß: {$infraction}
 error = Fehler ({ $number })
 two-games = Letztes Spiel: { $prev_game },  Nächstes Spiel: { $next_game }
 one-game = Spiel: { $game }
-teams = { -dark-team-name } Mannschaft: { $dark_team }
-    { -light-team-name } Mannschaft: { $light_team }
-game-config = Halbzeitdauer: { $half_len },  Halbzeitpausendauer: { $half_time_len }
-    Plötzlicher Tod Erlaubt: { $sd_allowed },  Verlängerung Erlaubt: { $ot_allowed }
-team-timeouts = Mannschafts-Auszeiten: { $value }
 team-timeouts-label = MANNSCHAFTS-
     AUSZEITEN:
-stop-clock-last-2 = Uhr in den letzten 2 Minuten stoppen: { $stop_clock }
-ref-list = Hauptschiedsrichter: { $chief_ref }
-    Zeitnehmer: { $timer }
-    Wasserschiedsrichter 1: { $water_ref_1 }
-    Wasserschiedsrichter 2: { $water_ref_2 }
-    Wasserschiedsrichter 3: { $water_ref_3 }
-team-ref-list = Schiedsrichter: { $ref_team }
-    Zeitnehmer/Anschreiber: { $ts_keeper_team }
 unknown = Unbekannt
 select-infraction = Bitte auswählen
 ## Spielzeit-Schaltfläche
@@ -392,7 +350,6 @@ rugby = RUGBY
 beep-test = BEEP TEST
 
 # Beep-test screen
-beep-test-pre = VOR
 beep-test-top-time-label = ZEIT
 beep-test-top-level-label = STUFE
 beep-test-top-lap-label = RUNDE
@@ -400,9 +357,6 @@ beep-test-start = START
 beep-test-pause = PAUSE
 beep-test-resume = FORTSETZEN
 beep-test-reset = ZURÜCKSETZEN
-beep-test-column-level = STUFE
-beep-test-column-count = ANZAHL
-beep-test-column-duration = DAUER
 beep-test-edit-selected = Stufe { $level }
 beep-test-edit-time = ZEIT
 beep-test-edit-count = ANZAHL
@@ -447,12 +401,6 @@ two-halves = 2 HALBZEITEN
 one-period = 1 PERIODE
 game-len = SPIELDAUER
 length-of-game-during-regular-play = Die Spieldauer während des regulären Spiels
-
-# Single-period (1 Period) info variants — Game Length, no half-time line
-game-config-single-half = Spieldauer: { $half_len }
-    Plötzlicher Tod Erlaubt: { $sd_allowed },  Verlängerung Erlaubt: { $ot_allowed }
-game-length-ot-allowed-single-half = Spieldauer: { $half_length }
-         Verlängerung Erlaubt: { $overtime }
 
 # Self-update / Updates page
 check-version = Version prüfen

--- a/refbox/translations/en-US/refbox.ftl
+++ b/refbox/translations/en-US/refbox.ftl
@@ -11,7 +11,6 @@ cancel = CANCEL
 delete = DELETE
 back = BACK
 apply = APPLY
-save = SAVE
 user-options = USER OPTIONS
 new = NEW
 
@@ -34,8 +33,6 @@ team-timeout-count = TEAM TIMEOUT
     COUNT:
 
 # Warning Add
-team-warning = TEAM
-    WARNING
 team-warning-line-1 = TEAM
 team-warning-line-2 = WARNING
 team-score-line-1 = TEAM
@@ -80,8 +77,6 @@ audible-countdown-for-last-10-seconds = AUDIBLE COUNTDOWN
     FOR LAST 10 SECONDS
 delay = DELAY
 court = COURT:
-single-half = SINGLE
-    HALF:
 half-length-full = HALF LENGTH:
 game-length = GAME LENGTH:
 overtime-allowed = OVERTIME 
@@ -94,8 +89,6 @@ pre-ot-break-length = PRE OT
     BREAK LENGTH:
 pre-sd-break-length = PRE SD
     BREAK LENGTH:
-nominal-break-between-games = NOMINAL BRK
-    BTWN GAMES:
 ot-half-length = OT HALF
     LENGTH:
 timeouts-counted-per = TIMEOUTS
@@ -150,19 +143,11 @@ half-length = HALF LEN
 length-of-half-during-regular-play = The length of a half during regular play
 half-time-lenght = HALF TIME LEN
 length-of-half-time-period = The length of the Half Time period
-nom-break = NOM BREAK
 game-block = GAME BLOCK
 game-block-full = GAME BLOCK:
 game-block-help = Time from the start of one game to the start of the next
 game-block-too-short = Too short to fit the game plus the minimum break
 game-block-tight = Tight — team timeouts could push games past their slot
-system-will-keep-game-times-spaced = The system will try to keep the game start times evenly spaced, with the
-    total time from one start to the next being 2 * [Half Length] + [Half Time
-    Length] + [Nominal Time Between Games] (example: if games have [Half
-    Length] = 15m, [Half Time Length] = 3m, and [Nominal Time Between Games] =
-    12m, the time from the start of one game to the next will be 45m. Any
-    timeouts taken, or other clock stoppages, will reduce the 12m time down
-    until the minimum time between game value is reached).
 min-break = MIN BREAK
 min-time-btwn-games = If a game runs longer than scheduled, this is the minimum time between
             games that the system will allot. If the games fall behind, the system will
@@ -178,7 +163,6 @@ len-of-overtime-halftime = The length of Overtime Half Time
 pre-sd-break = PRE SD BREAK
 pre-sd-len = The length of the break between the preceeding play period and Sudden Death
 language = LANGUAGE
-this-language = ENGLISH
 portal-login-code = CODE
 portal-login-instructions = Please go to the { $portal } Portal >> Event Management >> Referee Management, click on the + button to add a new Refbox, and enter this Refbox ID:
     { $id }
@@ -186,7 +170,6 @@ portal-login-instructions = Please go to the { $portal } Portal >> Event Managem
     The { $portal } Portal will then provide a confirmation code for you to enter to the left using the number pad.
     Press done once you have entered the code
 
-help = HELP: 
 
 # Confirmation
 game-configuration-can-not-be-changed = The game configuration can not be changed while a game is in progress.
@@ -223,24 +206,6 @@ refresh = REFRESH
 refreshing = REFRESHING...
 settings = SETTINGS 
 none = None
-game-number-error = Error ({ $game_number })
-next-game-number-error = Error ({ $next_game_number })
-last-game-next-game = Last Game: { $prev_game },
-    Next Game: { $next_game }
-black-team-white-team = Black Team: { $black_team }
-    White Team: { $white_team }
-game-length-ot-allowed = Half Length: { $half_length }
-         Half Time Length: { $half_time_length }
-         Overtime Allowed: { $overtime }
-overtime-details = Pre-Overtime Break Length: { $pre_overtime }
-             Overtime Half Length: { $overtime_len }
-             Overtime Half Time Length: { $overtime_half_time_len }
-sd-allowed = Sudden Death Allowed: { $sd }
-pre-sd = Pre-Sudden-Death Break Length: { $pre_sd_len }
-team-to-len = Team Timeout Duration: { $to_len }
-time-btwn-games = Nominal Time Between Games: { $time_btwn }
-game-block-info = Game Block: { $game_block }
-min-brk-btwn-games = Minimum Time Between Games: { $min_brk_time }
 
 # Game-info table labels
 gi-prior-game = Prior Game
@@ -349,21 +314,8 @@ infraction = Infraction: {$infraction}
 error = Error ({ $number })
 two-games = Last Game: { $prev_game },  Next Game: { $next_game }
 one-game = Game: { $game }
-teams = { -dark-team-name } Team: { $dark_team }
-    { -light-team-name } Team: { $light_team }
-game-config = Half Length: { $half_len },  Half Time Length: { $half_time_len }
-    Sudden Death Allowed: { $sd_allowed },  Overtime Allowed: { $ot_allowed }
-team-timeouts = Team Timeouts: { $value }
 team-timeouts-label = TEAM
     TIMEOUTS:
-stop-clock-last-2 = Stop Clock in Last 2 Minutes: { $stop_clock }
-ref-list = Chief Ref: { $chief_ref }
-    Timer: { $timer }
-    Water Ref 1: { $water_ref_1 }
-    Water Ref 2: { $water_ref_2 }
-    Water Ref 3: { $water_ref_3 }
-team-ref-list = Referees: { $ref_team }
-    T/S Keeper: { $ts_keeper_team }
 unknown = Unknown
 select-infraction = Make selection
 ## Game time button
@@ -429,7 +381,6 @@ rugby = RUGBY
 beep-test = BEEP TEST
 
 # Beep-test screen
-beep-test-pre = PRE
 beep-test-top-time-label = TIME
 beep-test-top-level-label = LEVEL
 beep-test-top-lap-label = LAP
@@ -437,9 +388,6 @@ beep-test-start = START
 beep-test-pause = PAUSE
 beep-test-resume = RESUME
 beep-test-reset = RESET
-beep-test-column-level = LEVEL
-beep-test-column-count = COUNT
-beep-test-column-duration = DURATION
 beep-test-edit-selected = Level { $level }
 beep-test-edit-time = TIME
 beep-test-edit-count = COUNT
@@ -483,12 +431,6 @@ two-halves = 2 HALVES
 one-period = 1 PERIOD
 game-len = GAME LEN
 length-of-game-during-regular-play = The length of the game during regular play
-
-# Single-period (1 Period) info variants — Game Length, no half-time line
-game-config-single-half = Game Length: { $half_len }
-    Sudden Death Allowed: { $sd_allowed },  Overtime Allowed: { $ot_allowed }
-game-length-ot-allowed-single-half = Game Length: { $half_length }
-         Overtime Allowed: { $overtime }
 
 # Self-update / Updates page
 check-version = Check Version

--- a/refbox/translations/es/refbox.ftl
+++ b/refbox/translations/es/refbox.ftl
@@ -11,7 +11,6 @@ cancel = CANCELAR
 delete = ELIMINAR
 back = ATRÁS
 apply = APLICAR
-save = GUARDAR
 user-options = OPCIONES DE USUARIO
 new = NUEVO
 
@@ -34,8 +33,6 @@ team-timeout-count = NÚMERO DE
     TIEMPOS DE ESPERA:
 
 # Warning Add
-team-warning = AVISO
-    DE EQUIPO
 team-warning-line-1 = AVISO
 team-warning-line-2 = DE EQUIPO
 team-score-line-1 = PUNTUACIÓN
@@ -80,7 +77,6 @@ audible-countdown-for-last-10-seconds = CUENTA ATRÁS SONORA
 delay = RETRASO
 event = EVENTO:
 court = CANCHA:
-single-half = UNA SOLA MITAD:
 half-length-full = DURACIÓN DE
     UNA MITAD:
 game-length = DURACIÓN DEL
@@ -95,8 +91,6 @@ pre-ot-break-length = DURACIÓN
     PREVIA AL T/E:
 pre-sd-break-length = DURACIÓN PREVIA
     A LA M/S:
-nominal-break-between-games = DESCANSO
-    ENTRE JUEGOS:
 ot-half-length = DURACIÓN DE LA
     MITAD DEL T/M:
 timeouts-counted-per = TIEMPOS MUERTOS
@@ -153,13 +147,11 @@ length-of-half-during-regular-play = La duración de una mitad durante el juego 
 half-time-lenght = DURACIÓN DEL
     MEDIO TIEMPO
 length-of-half-time-period = La duración del período de medio tiempo
-nom-break = DESCANSO NOMINAL
 game-block = BLOQUE DE JUEGO
 game-block-full = BLOQUE DE JUEGO:
 game-block-help = Tiempo desde el inicio de un partido hasta el inicio del siguiente
 game-block-too-short = Demasiado corto para el partido más la pausa mínima
 game-block-tight = Ajustado — los tiempos muertos podrían retrasar los partidos fuera de su franja
-system-will-keep-game-times-spaced = El sistema intentará mantener los tiempos de inicio de los juegos espaciados uniformemente, con el tiempo total de un juego al siguiente siendo 2 * [Duración de la Mitad] + [Duración del Medio Tiempo] + [Tiempo Nominal Entre Juegos] (ejemplo: si los juegos tienen [Duración de la Mitad] = 15m, [Duración del Medio Tiempo] = 3m, y [Tiempo Nominal Entre Juegos] = 12m, el tiempo desde el inicio de un juego al siguiente será de 45m. Cualquier tiempo de espera tomado, u otras paradas de reloj, reducirán el tiempo de 12m hasta alcanzar el tiempo mínimo entre juegos).
 min-break = DESCANSO MÍNIMO
 min-time-btwn-games = Si un juego dura más de lo programado, este es el tiempo mínimo entre juegos que el sistema asignará. Si los juegos se retrasan, el sistema intentará automáticamente reajustarse después de los juegos subsecuentes, siempre respetando este tiempo mínimo entre juegos.
 pre-ot-break-abreviated = DESCANSO PREVIO
@@ -175,7 +167,6 @@ pre-sd-break = DESCANSO PREVIO
     A MUERTE SÚBITA
 pre-sd-len = La duración del descanso entre el período de juego precedente y la muerte súbita
 language = IDIOMA
-this-language = ESPAÑOL
 ### Check
 portal-login-code = Código de inicio de sesión
 ### Check
@@ -185,7 +176,6 @@ portal-login-instructions = Por favor, vaya a { $portal } Portal >> Gestión de 
     El { $portal } Portal proporcionará un código de confirmación que deberá introducir a la izquierda utilizando el teclado numérico.
     Presione HECHO una vez que haya introducido el código.
 
-help = AYUDA:
 
 # Confirmation
 game-configuration-can-not-be-changed = La configuración del juego no se puede cambiar mientras un juego está en progreso.
@@ -224,24 +214,6 @@ refresh = RECARGAR
 refreshing = RECARGANDO...
 settings = CONFIGURACIÓN
 none = Ninguno
-game-number-error = Error ({ $game_number })
-next-game-number-error = Error ({ $next_game_number })
-last-game-next-game = Último partido: { $prev_game },
-    Próximo Juego: { $next_game }
-black-team-white-team = Equipo Negro: { $black_team }
-    Equipo Blanco: { $white_team }
-game-length-ot-allowed = Duración de una mitad: { $half_length }
-         Duración del medio tiempo: { $half_time_length }
-         Tiempo extra habilitado: { $overtime }
-overtime-details = Duración del descanso previo al tiempo extra: { $pre_overtime }
-             Duración de la mitad del tiempo extra: { $overtime_len }
-             Duración del medio tiempo extra: { $overtime_half_time_len }
-sd-allowed = Muerte súbita habilitada: { $sd }
-pre-sd = Duración del descanso previo a la muerte súbita: { $pre_sd_len }
-team-to-len = Duración del tiempo muerto de equipo: { $to_len }
-time-btwn-games = Tiempo nominal entre partidos: { $time_btwn }
-game-block-info = Bloque de Juego: { $game_block }
-min-brk-btwn-games = Tiempo mínimo entre partidos: { $min_brk_time }
 
 
 # List Selecters
@@ -323,21 +295,8 @@ infraction = Infracción: {$infraction}
 error = Error ({ $number })
 two-games = Último partido: { $prev_game }, Próximo partido: { $next_game }
 one-game = Juego: { $game }
-teams = { -dark-team-name } Equipo: { $dark_team }
-    { -light-team-name } Equipo: { $light_team }
-game-config = Duración de la mitad: { $half_len },  Duración del medio tiempo: { $half_time_len }
-    Muerte súbita permitida: { $sd_allowed },  Tiempo Extra Permitido: { $ot_allowed }
-team-timeouts = Tiempos muertos de equipo: { $value }
 team-timeouts-label = TIEMPOS MUERTOS
     DE EQUIPO:
-stop-clock-last-2 = Detener reloj en los Últimos 2 minutos: { $stop_clock }
-ref-list = Árbitro principal: { $chief_ref }
-    Timer: { $timer }
-    Árbitro de agua 1: { $water_ref_1 }
-    Árbitro de agua 2: { $water_ref_2 }
-    Árbitro de agua 3: { $water_ref_3 }
-team-ref-list = Árbitros: { $ref_team }
-    Cronometrador/Marcador: { $ts_keeper_team }
 unknown = Desconocido
 select-infraction = Seleccione una opción
 ## Game time button
@@ -403,7 +362,6 @@ rugby = RUGBY
 beep-test = PRUEBA DE PITIDOS
 
 # Pantalla de prueba de pitidos
-beep-test-pre = PRE
 beep-test-top-time-label = TIEMPO
 beep-test-top-level-label = NIVEL
 beep-test-top-lap-label = VUELTA
@@ -411,9 +369,6 @@ beep-test-start = INICIAR
 beep-test-pause = PAUSAR
 beep-test-resume = REANUDAR
 beep-test-reset = REINICIAR
-beep-test-column-level = NIVEL
-beep-test-column-count = CANTIDAD
-beep-test-column-duration = DURACIÓN
 beep-test-edit-selected = Nivel { $level }
 beep-test-edit-time = TIEMPO
 beep-test-edit-count = CANTIDAD
@@ -458,12 +413,6 @@ two-halves = 2 MITADES
 one-period = 1 PERIODO
 game-len = DURACIÓN DEL JUEGO
 length-of-game-during-regular-play = La duración del juego durante el juego regular
-
-# Single-period (1 Period) info variants — Game Length, no half-time line
-game-config-single-half = Duración del juego: { $half_len }
-    Muerte súbita permitida: { $sd_allowed },  Tiempo Extra Permitido: { $ot_allowed }
-game-length-ot-allowed-single-half = Duración del juego: { $half_length }
-         Tiempo extra habilitado: { $overtime }
 
 # Self-update / Updates page
 check-version = Comprobar versión

--- a/refbox/translations/fr/refbox.ftl
+++ b/refbox/translations/fr/refbox.ftl
@@ -11,7 +11,6 @@ cancel = ANNULER
 delete = SUPPRIMER
 back = RETOUR
 apply = APPLIQUER
-save = ENREGISTRER
 user-options = OPTIONS UTILISATEUR
 new = NOUVEAU
 
@@ -33,7 +32,6 @@ team-timeout-count = NOMBRE DE
     TEMPS MORTS:
 
 # Warning Add
-team-warning = AVERT. D'ÉQUIPE
 team-warning-line-1 = AVERT.
 team-warning-line-2 = D'ÉQUIPE
 team-score-line-1 = SCORE
@@ -78,7 +76,6 @@ audible-countdown-for-last-10-seconds = COMPTE À REBOURS
 delay = RETARD
 event = EVÉNEMENT:
 court = TERRAIN:
-single-half = UNE SEULE PÉRIODE:
 half-length-full = DURÉE DE LA
     PÉRIODE:
 game-length = DURÉE DU
@@ -93,8 +90,6 @@ pre-ot-break-length = PAUSE AVANT
     PROLONGATIONS:
 pre-sd-break-length = PAUSE AVANT
     MORT SUBITE:
-nominal-break-between-games = PAUSE ENTRE
-    LES MATCHS:
 ot-half-length = PÉRIODE DE
     PROLONGATION:
 timeouts-counted-per = TEMPS MORTS
@@ -149,13 +144,11 @@ half-length = DURÉE PÉRIODE
 length-of-half-during-regular-play = La durée d'une période pendant le match régulier
 half-time-lenght = DURÉE MI-TEMPS
 length-of-half-time-period = La durée de la mi-temps
-nom-break = PAUSE NOMINALE
 game-block = BLOC DE JEU
 game-block-full = BLOC DE JEU:
 game-block-help = Temps entre le début d'un match et le début du suivant
 game-block-too-short = Trop court pour contenir le match et la pause minimale
 game-block-tight = Serré — les temps morts pourraient faire déborder les matchs de leur créneau
-system-will-keep-game-times-spaced = Le système essaiera de maintenir les heures de début des matchs régulièrement espacées, avec un temps total de 2 * [Durée de la mi-temps] + [Durée de la mi-temps] + [Pause nominale entre les matchs] (exemple: si les matchs ont [Durée de la mi-temps] = 15m, [Durée de la mi-temps] = 3m, et [Pause nominale entre les matchs] = 12m, le temps entre le début d'un match et le suivant sera de 45m. Tout temps mort pris, ou autre arrêt de l'horloge, réduira le temps de 12m jusqu'à ce que la valeur de la pause minimale entre les matchs soit atteinte).
 min-break = PAUSE MINIMUM
 min-time-btwn-games = Si un match dure plus longtemps que prévu, ceci est le temps minimum entre les matchs que le système allouera. Si les matchs prennent du retard, le système essaiera automatiquement de rattraper après les matchs suivants, en respectant toujours ce temps minimum entre les matchs.
 pre-ot-break-abreviated = P. PRÉ PROL.
@@ -167,7 +160,6 @@ len-of-overtime-halftime = La durée de la mi-temps des prolongations
 pre-sd-break = PAUSE PRÉ M/S
 pre-sd-len = La durée de la pause entre la période de match précédente et la mort subite
 language = LANGUE
-this-language = FRANÇAIS
 ### Check
 portal-login-code = Code de connexion
 ### Check
@@ -177,7 +169,6 @@ portal-login-instructions = Veuillez aller sur le Portail { $portal } >> Gestion
     Le Portail { $portal } fournira ensuite un code de confirmation que vous devrez entrer à gauche en utilisant le pavé numérique.
     Appuyez sur Terminé une fois que vous avez entré le code.
 
-help = AIDE: 
 
 # Confirmation
 game-configuration-can-not-be-changed = La configuration du match ne peut pas être modifiée pendant qu'un match est en cours.
@@ -216,24 +207,6 @@ refresh = RAFRAÎCHIR
 refreshing = RAFRAÎCHISSANT...
 settings = PARAMÈTRES 
 none = Aucun
-game-number-error = Erreur ({ $game_number })
-next-game-number-error = Erreur ({ $next_game_number })
-last-game-next-game = Dernier Match: { $prev_game },
-    Prochain Match: { $next_game }
-black-team-white-team = Équipe Noire: { $black_team }
-    Équipe Blanche: { $white_team }
-game-length-ot-allowed = Durée de la période: { $half_length }
-         Durée de la mi-temps: { $half_time_length }
-         Prolongations Autorisées: { $overtime }
-overtime-details = Durée de la pause avant les prolongations: { $pre_overtime }
-             Durée de la période des prolongations: { $overtime_len }
-             Durée de la mi-temps des prolongations: { $overtime_half_time_len }
-sd-allowed = Mort Subite Autorisée: { $sd }
-pre-sd = Durée de la pause avant la mort subite: { $pre_sd_len }
-team-to-len = Durée du Temps Mort d'Équipe: { $to_len }
-time-btwn-games = Temps Entre les Matchs: { $time_btwn }
-game-block-info = Bloc de Jeu: { $game_block }
-min-brk-btwn-games = Temps Minimum Entre les Matchs: { $min_brk_time }
 
 # List Selecters
 select-event = SÉLECTIONNER LE EVÉNEMENT
@@ -314,21 +287,8 @@ infraction = Faute: {$infraction}
 error = Erreur ({ $number })
 two-games = Dernier Match: { $prev_game },  Prochain Match: { $next_game }
 one-game = Match: { $game }
-teams = Équipe { -dark-team-name }: { $dark_team }
-    Équipe { -light-team-name }: { $light_team }
-game-config = Durée de la Pér.: { $half_len },  Mi-temps: { $half_time_len }
-    Mort Subite: { $sd_allowed },  Prolongations: { $ot_allowed }
-team-timeouts = Temps Morts d'Équipe: { $value }
 team-timeouts-label = TEMPS MORTS
     D'ÉQUIPE:
-stop-clock-last-2 = Arrêter le temps dans les 2 dernières minutes: { $stop_clock }
-ref-list = Arbitre en Chef: { $chief_ref }
-    Chronométreur: { $timer }
-    Arbitre Aquatique 1: { $water_ref_1 }
-    Arbitre Aquatique 2: { $water_ref_2 }
-    Arbitre Aquatique 3: { $water_ref_3 }
-team-ref-list = Arbitres: { $ref_team }
-    Chronométreur/Marqueur: { $ts_keeper_team }
 unknown = Inconnu
 select-infraction = Faire une sélection
 ## Game time button
@@ -394,7 +354,6 @@ rugby = Rugby
 beep-test = TEST DE BIP
 
 # Écran de test de bip
-beep-test-pre = PRÉ
 beep-test-top-time-label = TEMPS
 beep-test-top-level-label = NIVEAU
 beep-test-top-lap-label = TOUR
@@ -402,9 +361,6 @@ beep-test-start = DÉMARRER
 beep-test-pause = PAUSE
 beep-test-resume = REPRENDRE
 beep-test-reset = RÉINITIALISER
-beep-test-column-level = NIVEAU
-beep-test-column-count = NOMBRE
-beep-test-column-duration = DURÉE
 beep-test-edit-selected = Niveau { $level }
 beep-test-edit-time = TEMPS
 beep-test-edit-count = NOMBRE
@@ -449,12 +405,6 @@ two-halves = 2 PÉRIODES
 one-period = 1 PÉRIODE
 game-len = DURÉE DU MATCH
 length-of-game-during-regular-play = La durée du jeu pendant le match régulier
-
-# Single-period (1 Period) info variants — Game Length, no half-time line
-game-config-single-half = Durée du match: { $half_len }
-    Mort Subite: { $sd_allowed },  Prolongations: { $ot_allowed }
-game-length-ot-allowed-single-half = Durée du match: { $half_length }
-         Prolongations Autorisées: { $overtime }
 
 # Self-update / Updates page
 check-version = Vérifier la version

--- a/refbox/translations/id-ID/refbox.ftl
+++ b/refbox/translations/id-ID/refbox.ftl
@@ -12,7 +12,6 @@ cancel = BATAL
 delete = HAPUS
 back = KEMBALI
 apply = TERAPKAN
-save = SIMPAN
 user-options = OPSI PENGGUNA
 new = BARU
 
@@ -35,8 +34,6 @@ team-timeout-count = JUMLAH
     TIME-OUT TIM:
 
 # Tambah Peringatan
-team-warning = PERINGATAN
-    TIM
 team-warning-line-1 = PERINGATAN
 team-warning-line-2 = TIM
 team-score-line-1 = SKOR
@@ -81,8 +78,6 @@ audible-countdown-for-last-10-seconds = HITUNG MUNDUR SUARA
     10 DETIK
 delay = TERLAMBAT
 court = LAPANGAN:
-single-half = BABAK
-    TUNGGAL:
 half-length-full = DURASI BABAK:
 game-length = DURASI PERTANDINGAN:
 overtime-allowed = PERPANJANGAN WAKTU
@@ -95,8 +90,6 @@ pre-ot-break-length = DURASI JEDA
     SEBELUM PW:
 pre-sd-break-length = DURASI JEDA
     SEBELUM SD:
-nominal-break-between-games = JEDA NOMINAL
-    ANTAR PERTANDINGAN:
 ot-half-length = DURASI BABAK
     PERPANJANGAN:
 timeouts-counted-per = TIME-OUT
@@ -151,13 +144,11 @@ half-length = DUR BABAK
 length-of-half-during-regular-play = Durasi satu babak selama pertandingan reguler
 half-time-lenght = DUR JEDA BABAK
 length-of-half-time-period = Durasi periode jeda babak
-nom-break = JEDA NOMINAL
 game-block = BLOK PERTANDINGAN
 game-block-full = BLOK PERTANDINGAN:
 game-block-help = Waktu dari awal satu pertandingan hingga awal pertandingan berikutnya
 game-block-too-short = Terlalu singkat untuk pertandingan ditambah jeda minimum
 game-block-tight = Terlalu ketat — time-out tim bisa membuat pertandingan melewati slot mereka
-system-will-keep-game-times-spaced = Sistem akan mencoba menjaga waktu mulai pertandingan agar merata, dengan total waktu dari satu mulai ke mulai berikutnya adalah 2 × [Durasi Babak] + [Durasi Jeda Babak] + [Waktu Nominal Antar Pertandingan] (contoh: jika [Durasi Babak] = 15 menit, [Durasi Jeda Babak] = 3 menit, dan [Waktu Nominal Antar Pertandingan] = 12 menit, waktu dari mulai satu pertandingan ke berikutnya adalah 45 menit. Setiap time-out yang diambil, atau penghentian jam lainnya, akan mengurangi waktu 12 menit tersebut hingga mencapai nilai waktu minimum antar pertandingan).
 min-break = JEDA MINIMUM
 min-time-btwn-games = Jika suatu pertandingan berjalan lebih lama dari jadwal, ini adalah waktu minimum antar pertandingan yang akan dialokasikan oleh sistem. Jika pertandingan tertunda, sistem akan secara otomatis mencoba mengejar pada pertandingan berikutnya, selalu menghormati waktu minimum antar pertandingan ini.
 pre-ot-break-abreviated = JEDA SEBELUM PW
@@ -169,7 +160,6 @@ len-of-overtime-halftime = Durasi jeda babak perpanjangan waktu
 pre-sd-break = JEDA SEBELUM SD
 pre-sd-len = Durasi jeda antara periode permainan sebelumnya dan Sudden Death
 language = BAHASA
-this-language = INDONESIA
 portal-login-code = KODE
 portal-login-instructions = Silakan buka { $portal } Portal >> Manajemen Acara >> Manajemen Wasit, klik tombol + untuk menambahkan Refbox baru, dan masukkan ID Refbox ini:
     { $id }
@@ -177,7 +167,6 @@ portal-login-instructions = Silakan buka { $portal } Portal >> Manajemen Acara >
     { $portal } Portal kemudian akan memberikan kode konfirmasi untuk dimasukkan di sebelah kiri menggunakan papan angka.
     Tekan Selesai setelah Anda memasukkan kode
 
-help = BANTUAN:
 
 # Konfirmasi
 game-configuration-can-not-be-changed = Konfigurasi pertandingan tidak dapat diubah saat pertandingan sedang berlangsung.
@@ -214,24 +203,6 @@ refresh = SEGARKAN
 refreshing = MENYEGARKAN...
 settings = PENGATURAN
 none = Tidak Ada
-game-number-error = Galat ({ $game_number })
-next-game-number-error = Galat ({ $next_game_number })
-last-game-next-game = Pertandingan Terakhir: { $prev_game },
-    Pertandingan Berikutnya: { $next_game }
-black-team-white-team = Tim Hitam: { $black_team }
-    Tim Putih: { $white_team }
-game-length-ot-allowed = Durasi Babak: { $half_length }
-         Durasi Jeda Babak: { $half_time_length }
-         Perpanjangan Waktu Diizinkan: { $overtime }
-overtime-details = Durasi Jeda Sebelum Perpanjangan Waktu: { $pre_overtime }
-             Durasi Babak Perpanjangan Waktu: { $overtime_len }
-             Durasi Jeda Perpanjangan Waktu: { $overtime_half_time_len }
-sd-allowed = Sudden Death Diizinkan: { $sd }
-pre-sd = Durasi Jeda Sebelum Sudden Death: { $pre_sd_len }
-team-to-len = Durasi Time-out Tim: { $to_len }
-time-btwn-games = Waktu Nominal Antar Pertandingan: { $time_btwn }
-game-block-info = Blok Permainan: { $game_block }
-min-brk-btwn-games = Waktu Minimum Antar Pertandingan: { $min_brk_time }
 
 
 # Pemilih Daftar
@@ -312,21 +283,8 @@ infraction = Pelanggaran: {$infraction}
 error = Galat ({ $number })
 two-games = Pertandingan Terakhir: { $prev_game },  Pertandingan Berikutnya: { $next_game }
 one-game = Pertandingan: { $game }
-teams = Tim { -dark-team-name }: { $dark_team }
-    Tim { -light-team-name }: { $light_team }
-game-config = Durasi Babak: { $half_len },  Durasi Jeda Babak: { $half_time_len }
-    Sudden Death Diizinkan: { $sd_allowed },  Perpanjangan Waktu Diizinkan: { $ot_allowed }
-team-timeouts = Time-out Tim: { $value }
 team-timeouts-label = TIME-OUT
     TIM:
-stop-clock-last-2 = Hentikan Jam di 2 Menit Terakhir: { $stop_clock }
-ref-list = Wasit Kepala: { $chief_ref }
-    Pencatat Waktu: { $timer }
-    Wasit Air 1: { $water_ref_1 }
-    Wasit Air 2: { $water_ref_2 }
-    Wasit Air 3: { $water_ref_3 }
-team-ref-list = Wasit: { $ref_team }
-    Pencatat Waktu/Skor: { $ts_keeper_team }
 unknown = Tidak Diketahui
 select-infraction = Pilih salah satu
 ## Tombol waktu pertandingan
@@ -392,7 +350,6 @@ rugby = RUGBY
 beep-test = BEEP TEST
 
 # Beep-test screen
-beep-test-pre = PRA
 beep-test-top-time-label = WAKTU
 beep-test-top-level-label = LEVEL
 beep-test-top-lap-label = PUTARAN
@@ -400,9 +357,6 @@ beep-test-start = MULAI
 beep-test-pause = JEDA
 beep-test-resume = LANJUTKAN
 beep-test-reset = ATUR ULANG
-beep-test-column-level = LEVEL
-beep-test-column-count = JUMLAH
-beep-test-column-duration = DURASI
 beep-test-edit-selected = Level { $level }
 beep-test-edit-time = WAKTU
 beep-test-edit-count = JUMLAH
@@ -447,12 +401,6 @@ two-halves = 2 BABAK
 one-period = 1 PERIODE
 game-len = DURASI PERTANDINGAN
 length-of-game-during-regular-play = Durasi permainan selama pertandingan reguler
-
-# Single-period (1 Period) info variants — Game Length, no half-time line
-game-config-single-half = Durasi Pertandingan: { $half_len }
-    Sudden Death Diizinkan: { $sd_allowed },  Perpanjangan Waktu Diizinkan: { $ot_allowed }
-game-length-ot-allowed-single-half = Durasi Pertandingan: { $half_length }
-         Perpanjangan Waktu Diizinkan: { $overtime }
 
 # Self-update / Updates page
 check-version = Periksa Versi

--- a/refbox/translations/it-IT/refbox.ftl
+++ b/refbox/translations/it-IT/refbox.ftl
@@ -12,7 +12,6 @@ cancel = ANNULLA
 delete = ELIMINA
 back = INDIETRO
 apply = APPLICA
-save = SALVA
 user-options = OPZIONI UTENTE
 new = NUOVO
 
@@ -35,8 +34,6 @@ team-timeout-count = NUMERO DI
     TIME-OUT:
 
 # Aggiunta Ammonizione
-team-warning = AMMONIZIONE
-    DI SQUADRA
 team-warning-line-1 = AMMONIZIONE
 team-warning-line-2 = DI SQUADRA
 team-score-line-1 = PUNTEGGIO
@@ -81,8 +78,6 @@ audible-countdown-for-last-10-seconds = CONTO ALLA ROVESCIA
     SONORO 10 S
 delay = RITARDO
 court = CAMPO:
-single-half = SINGOLO
-    TEMPO:
 half-length-full = DURATA TEMPO:
 game-length = DURATA PARTITA:
 overtime-allowed = TEMPI SUPPL.
@@ -95,8 +90,6 @@ pre-ot-break-length = PAUSA PRE
     SUPPLEMENTARI:
 pre-sd-break-length = PAUSA PRE
     MORTE IMPROVVISA:
-nominal-break-between-games = PAUSA NOMINALE
-    FRA PARTITE:
 ot-half-length = DURATA TEMPO
     SUPPLEMENTARE:
 timeouts-counted-per = TIME-OUT
@@ -151,13 +144,11 @@ half-length = DUR TEMPO
 length-of-half-during-regular-play = La durata di un tempo durante il gioco regolare
 half-time-lenght = DUR INTERVALLO
 length-of-half-time-period = La durata del periodo di intervallo
-nom-break = PAUSA NOM
 game-block = BLOCCO PARTITA
 game-block-full = BLOCCO PARTITA:
 game-block-help = Tempo dall'inizio di una partita all'inizio della successiva
 game-block-too-short = Troppo breve per contenere la partita più la pausa minima
 game-block-tight = Stretto — i timeout potrebbero far sforare le partite dal loro slot
-system-will-keep-game-times-spaced = Il sistema cercherà di mantenere i tempi di inizio partita equamente distanziati, con il tempo totale da un inizio all'altro pari a 2 × [Durata Tempo] + [Durata Intervallo] + [Tempo Nominale fra Partite] (esempio: se [Durata Tempo] = 15 min, [Durata Intervallo] = 3 min e [Tempo Nominale fra Partite] = 12 min, il tempo da inizio a inizio sarà 45 min. Eventuali time-out o altre interruzioni ridurranno i 12 min fino al raggiungimento del tempo minimo fra partite).
 min-break = PAUSA MIN
 min-time-btwn-games = Se una partita dura più del previsto, questo è il tempo minimo fra le partite che il sistema assegnerà. Se le partite accumulano ritardo, il sistema cercherà di recuperare nelle partite successive, rispettando sempre questo tempo minimo.
 pre-ot-break-abreviated = PAUSA PRE SUPPL.
@@ -169,7 +160,6 @@ len-of-overtime-halftime = La durata dell'intervallo supplementare
 pre-sd-break = PAUSA PRE MORTE IMM.
 pre-sd-len = La durata della pausa fra il periodo di gioco precedente e la Morte Improvvisa
 language = LINGUA
-this-language = ITALIANO
 portal-login-code = CODICE
 portal-login-instructions = Vai su { $portal } Portal >> Gestione Evento >> Gestione Arbitri, clicca sul pulsante + per aggiungere un nuovo Refbox e inserisci questo ID Refbox:
     { $id }
@@ -177,7 +167,6 @@ portal-login-instructions = Vai su { $portal } Portal >> Gestione Evento >> Gest
     Il Portale { $portal } fornirà quindi un codice di conferma da inserire a sinistra usando il tastierino numerico.
     Premi Fine una volta inserito il codice
 
-help = AIUTO:
 
 # Conferma
 game-configuration-can-not-be-changed = La configurazione della partita non può essere modificata mentre una partita è in corso.
@@ -214,24 +203,6 @@ refresh = AGGIORNA
 refreshing = AGGIORNAMENTO...
 settings = IMPOSTAZIONI
 none = Nessuno
-game-number-error = Errore ({ $game_number })
-next-game-number-error = Errore ({ $next_game_number })
-last-game-next-game = Ultima Partita: { $prev_game },
-    Prossima Partita: { $next_game }
-black-team-white-team = Squadra Nera: { $black_team }
-    Squadra Bianca: { $white_team }
-game-length-ot-allowed = Durata Tempo: { $half_length }
-         Durata Intervallo: { $half_time_length }
-         Tempi Suppl. Consentiti: { $overtime }
-overtime-details = Durata Pausa Pre-Supplementari: { $pre_overtime }
-             Durata Tempo Supplementare: { $overtime_len }
-             Durata Intervallo Supplementare: { $overtime_half_time_len }
-sd-allowed = Morte Improvvisa Consentita: { $sd }
-pre-sd = Durata Pausa Pre-Morte Improvvisa: { $pre_sd_len }
-team-to-len = Durata Time-out di Squadra: { $to_len }
-time-btwn-games = Tempo Nominale fra Partite: { $time_btwn }
-game-block-info = Blocco di Gioco: { $game_block }
-min-brk-btwn-games = Tempo Minimo fra Partite: { $min_brk_time }
 
 
 # Selettori Lista
@@ -312,21 +283,8 @@ infraction = Infrazione: {$infraction}
 error = Errore ({ $number })
 two-games = Ultima Partita: { $prev_game },  Prossima Partita: { $next_game }
 one-game = Partita: { $game }
-teams = Squadra { -dark-team-name }: { $dark_team }
-    Squadra { -light-team-name }: { $light_team }
-game-config = Durata Tempo: { $half_len },  Durata Intervallo: { $half_time_len }
-    Morte Improvvisa Consentita: { $sd_allowed },  Tempi Suppl. Consentiti: { $ot_allowed }
-team-timeouts = Time-out di Squadra: { $value }
 team-timeouts-label = TIME-OUT DI
     SQUADRA:
-stop-clock-last-2 = Ferma Orologio negli Ultimi 2 Minuti: { $stop_clock }
-ref-list = Capo Arbitro: { $chief_ref }
-    Cronometrista: { $timer }
-    Arbitro di Vasca 1: { $water_ref_1 }
-    Arbitro di Vasca 2: { $water_ref_2 }
-    Arbitro di Vasca 3: { $water_ref_3 }
-team-ref-list = Arbitri: { $ref_team }
-    Cronometrista/Segnapunti: { $ts_keeper_team }
 unknown = Sconosciuto
 select-infraction = Effettua una scelta
 ## Pulsante tempo di gioco
@@ -392,7 +350,6 @@ rugby = RUGBY
 beep-test = BEEP TEST
 
 # Beep-test screen
-beep-test-pre = PRE
 beep-test-top-time-label = TEMPO
 beep-test-top-level-label = LIVELLO
 beep-test-top-lap-label = GIRO
@@ -400,9 +357,6 @@ beep-test-start = AVVIA
 beep-test-pause = PAUSA
 beep-test-resume = RIPRENDI
 beep-test-reset = AZZERA
-beep-test-column-level = LIVELLO
-beep-test-column-count = NUMERO
-beep-test-column-duration = DURATA
 beep-test-edit-selected = Livello { $level }
 beep-test-edit-time = TEMPO
 beep-test-edit-count = NUMERO
@@ -447,12 +401,6 @@ two-halves = 2 TEMPI
 one-period = 1 PERIODO
 game-len = DURATA PARTITA
 length-of-game-during-regular-play = La durata della partita durante il gioco regolare
-
-# Single-period (1 Period) info variants — Game Length, no half-time line
-game-config-single-half = Durata Partita: { $half_len }
-    Morte Improvvisa Consentita: { $sd_allowed },  Tempi Suppl. Consentiti: { $ot_allowed }
-game-length-ot-allowed-single-half = Durata Partita: { $half_length }
-         Tempi Suppl. Consentiti: { $overtime }
 
 # Self-update / Updates page
 check-version = Controlla versione

--- a/refbox/translations/ja-JP/refbox.ftl
+++ b/refbox/translations/ja-JP/refbox.ftl
@@ -12,7 +12,6 @@ cancel = キャンセル
 delete = 削除
 back = 戻る
 apply = 適用
-save = 保存
 user-options = ユーザー設定
 new = 新規
 
@@ -35,8 +34,6 @@ team-timeout-count = チームタイムアウト
     回数:
 
 # 警告追加
-team-warning = チーム
-    警告
 team-warning-line-1 = チーム
 team-warning-line-2 = 警告
 team-score-line-1 = チーム
@@ -81,8 +78,6 @@ audible-countdown-for-last-10-seconds = 残り10秒の音声
     カウントダウン
 delay = 遅延
 court = コート:
-single-half = 単一
-    ハーフ:
 half-length-full = ハーフ時間:
 game-length = 試合時間:
 overtime-allowed = 延長戦
@@ -95,8 +90,6 @@ pre-ot-break-length = 延長前
     休憩時間:
 pre-sd-break-length = SD前
     休憩時間:
-nominal-break-between-games = 試合間
-    基準休憩:
 ot-half-length = 延長ハーフ
     時間:
 timeouts-counted-per = タイムアウト
@@ -151,13 +144,11 @@ half-length = ハーフ時間
 length-of-half-during-regular-play = 通常試合中のハーフの長さ
 half-time-lenght = ハーフタイム時間
 length-of-half-time-period = ハーフタイムの長さ
-nom-break = 基準休憩
 game-block = ゲームブロック
 game-block-full = ゲームブロック:
 game-block-help = ある試合の開始から次の試合の開始までの時間
 game-block-too-short = 試合と最短休憩を収めるには短すぎます
 game-block-tight = タイト — チームタイムアウトにより試合が枠を超える可能性があります
-system-will-keep-game-times-spaced = システムは試合開始時刻を均等に保つよう努めます。1試合の開始から次の試合の開始までの合計時間は、2 × [ハーフ時間] + [ハーフタイム時間] + [試合間基準時間] となります（例：[ハーフ時間] = 15分、[ハーフタイム時間] = 3分、[試合間基準時間] = 12分の場合、1試合の開始から次の試合まで45分。タイムアウトやその他のクロック停止があると、最小試合間時間に達するまで12分が短縮されます）。
 min-break = 最小休憩
 min-time-btwn-games = 試合が予定より長引いた場合、システムが確保する試合間の最小時間です。試合が遅れた場合、システムは後続の試合で自動的に追いつきを試みますが、常にこの最小試合間時間を守ります。
 pre-ot-break-abreviated = 延長前休憩
@@ -169,7 +160,6 @@ len-of-overtime-halftime = 延長ハーフタイムの長さ
 pre-sd-break = SD前休憩
 pre-sd-len = 直前のプレー期間とサドンデスの間の休憩時間
 language = 言語
-this-language = 日本語
 portal-login-code = コード
 portal-login-instructions = { $portal }ポータル >> 大会管理 >> 審判管理 へ進み、＋ボタンをクリックして新しいRefboxを追加し、このRefbox IDを入力してください:
     { $id }
@@ -177,7 +167,6 @@ portal-login-instructions = { $portal }ポータル >> 大会管理 >> 審判管
     { $portal }ポータルから確認コードが発行されますので、左の数字パッドで入力してください。
     コードを入力したら完了を押してください
 
-help = ヘルプ:
 
 # 確認
 game-configuration-can-not-be-changed = 試合進行中は試合設定を変更できません。
@@ -214,24 +203,6 @@ refresh = 更新
 refreshing = 更新中...
 settings = 設定
 none = なし
-game-number-error = エラー ({ $game_number })
-next-game-number-error = エラー ({ $next_game_number })
-last-game-next-game = 前の試合: { $prev_game },
-    次の試合: { $next_game }
-black-team-white-team = 黒チーム: { $black_team }
-    白チーム: { $white_team }
-game-length-ot-allowed = ハーフ時間: { $half_length }
-         ハーフタイム時間: { $half_time_length }
-         延長戦許可: { $overtime }
-overtime-details = 延長前休憩時間: { $pre_overtime }
-             延長ハーフ時間: { $overtime_len }
-             延長ハーフタイム時間: { $overtime_half_time_len }
-sd-allowed = サドンデス許可: { $sd }
-pre-sd = サドンデス前休憩時間: { $pre_sd_len }
-team-to-len = チームタイムアウト時間: { $to_len }
-time-btwn-games = 試合間基準時間: { $time_btwn }
-game-block-info = ゲームブロック: { $game_block }
-min-brk-btwn-games = 試合間最小時間: { $min_brk_time }
 
 
 # リスト選択
@@ -312,21 +283,8 @@ infraction = 反則: {$infraction}
 error = エラー ({ $number })
 two-games = 前の試合: { $prev_game },  次の試合: { $next_game }
 one-game = 試合: { $game }
-teams = { -dark-team-name }チーム: { $dark_team }
-    { -light-team-name }チーム: { $light_team }
-game-config = ハーフ時間: { $half_len },  ハーフタイム時間: { $half_time_len }
-    サドンデス許可: { $sd_allowed },  延長戦許可: { $ot_allowed }
-team-timeouts = チームタイムアウト: { $value }
 team-timeouts-label = チーム
     タイムアウト:
-stop-clock-last-2 = 残り2分でクロック停止: { $stop_clock }
-ref-list = 主審: { $chief_ref }
-    タイムキーパー: { $timer }
-    水中審判1: { $water_ref_1 }
-    水中審判2: { $water_ref_2 }
-    水中審判3: { $water_ref_3 }
-team-ref-list = 審判員: { $ref_team }
-    記録員: { $ts_keeper_team }
 unknown = 不明
 select-infraction = 選択してください
 ## 試合時間ボタン
@@ -392,7 +350,6 @@ rugby = ラグビー
 beep-test = ビープテスト
 
 # Beep-test screen
-beep-test-pre = 準備
 beep-test-top-time-label = 時間
 beep-test-top-level-label = レベル
 beep-test-top-lap-label = 周回
@@ -400,9 +357,6 @@ beep-test-start = スタート
 beep-test-pause = 一時停止
 beep-test-resume = 再開
 beep-test-reset = リセット
-beep-test-column-level = レベル
-beep-test-column-count = 回数
-beep-test-column-duration = 時間
 beep-test-edit-selected = レベル { $level }
 beep-test-edit-time = 時間
 beep-test-edit-count = 回数
@@ -447,12 +401,6 @@ two-halves = 2ハーフ
 one-period = 1ピリオド
 game-len = 試合時間
 length-of-game-during-regular-play = 通常試合中の試合全体の長さ
-
-# Single-period (1 Period) info variants — Game Length, no half-time line
-game-config-single-half = 試合時間: { $half_len }
-    サドンデス許可: { $sd_allowed },  延長戦許可: { $ot_allowed }
-game-length-ot-allowed-single-half = 試合時間: { $half_length }
-         延長戦許可: { $overtime }
 
 # Self-update / Updates page
 check-version = バージョン確認

--- a/refbox/translations/ko-KR/refbox.ftl
+++ b/refbox/translations/ko-KR/refbox.ftl
@@ -14,7 +14,6 @@ cancel = 취소
 delete = 삭제
 back = 뒤로
 apply = 적용
-save = 저장
 user-options = 사용자 옵션
 new = 새로
 
@@ -37,8 +36,6 @@ team-timeout-count = 팀 타임아웃
     횟수:
 
 # 경고 추가
-team-warning = 팀
-    경고
 team-warning-line-1 = 팀
 team-warning-line-2 = 경고
 team-score-line-1 = 팀
@@ -83,8 +80,6 @@ audible-countdown-for-last-10-seconds = 마지막 10초 음성
     카운트다운
 delay = 지연
 court = 코트:
-single-half = 단일
-    전반:
 half-length-full = 전반 시간:
 game-length = 경기 시간:
 overtime-allowed = 연장전
@@ -97,8 +92,6 @@ pre-ot-break-length = 연장전 전
     휴식 시간:
 pre-sd-break-length = 서든 데스 전
     휴식 시간:
-nominal-break-between-games = 경기 간
-    기준 휴식:
 ot-half-length = 연장 전반
     시간:
 timeouts-counted-per = 타임아웃
@@ -153,13 +146,11 @@ half-length = 전반 시간
 length-of-half-during-regular-play = 정규 경기 중 전반의 시간
 half-time-lenght = 하프타임 시간
 length-of-half-time-period = 하프타임 기간의 시간
-nom-break = 기준 휴식
 game-block = 게임 블록
 game-block-full = 게임 블록:
 game-block-help = 한 경기 시작부터 다음 경기 시작까지의 시간
 game-block-too-short = 경기와 최소 휴식을 담기에 너무 짧습니다
 game-block-tight = 빡빡함 — 팀 타임아웃으로 경기가 슬롯을 초과할 수 있습니다
-system-will-keep-game-times-spaced = 시스템은 경기 시작 시간을 균등하게 유지하려 합니다. 한 경기 시작부터 다음 경기 시작까지의 총 시간은 2 × [전반 시간] + [하프타임 시간] + [경기 간 기준 시간]입니다 (예: [전반 시간] = 15분, [하프타임 시간] = 3분, [경기 간 기준 시간] = 12분이면 한 경기 시작부터 다음 경기까지 45분. 타임아웃이나 기타 시계 정지 시 최소 경기 간 시간에 도달할 때까지 12분이 줄어듭니다).
 min-break = 최소 휴식
 min-time-btwn-games = 경기가 예정보다 길어질 경우, 시스템이 할당하는 경기 간 최소 시간입니다. 경기가 지연되면 시스템이 이후 경기에서 자동으로 따라잡으며 항상 이 최소 경기 간 시간을 준수합니다.
 pre-ot-break-abreviated = 연장전 전 휴식
@@ -171,7 +162,6 @@ len-of-overtime-halftime = 연장전 하프타임의 시간
 pre-sd-break = 서든 데스 전 휴식
 pre-sd-len = 이전 경기 기간과 서든 데스 사이의 휴식 시간
 language = 언어
-this-language = 한국어
 portal-login-code = 코드
 portal-login-instructions = { $portal } Portal >> 대회 관리 >> 심판 관리로 이동하여 + 버튼을 클릭해 새 Refbox를 추가하고 이 Refbox ID를 입력하세요:
     { $id }
@@ -179,7 +169,6 @@ portal-login-instructions = { $portal } Portal >> 대회 관리 >> 심판 관리
     그러면 { $portal } Portal에서 확인 코드를 제공합니다. 왼쪽 숫자 패드로 코드를 입력하세요.
     코드를 입력한 후 완료를 누르세요
 
-help = 도움말:
 
 # 확인
 game-configuration-can-not-be-changed = 경기 진행 중에는 경기 설정을 변경할 수 없습니다.
@@ -216,24 +205,6 @@ refresh = 새로고침
 refreshing = 새로고침 중...
 settings = 설정
 none = 없음
-game-number-error = 오류 ({ $game_number })
-next-game-number-error = 오류 ({ $next_game_number })
-last-game-next-game = 이전 경기: { $prev_game },
-    다음 경기: { $next_game }
-black-team-white-team = 검정 팀: { $black_team }
-    흰 팀: { $white_team }
-game-length-ot-allowed = 전반 시간: { $half_length }
-         하프타임 시간: { $half_time_length }
-         연장전 허용: { $overtime }
-overtime-details = 연장전 전 휴식 시간: { $pre_overtime }
-             연장 전반 시간: { $overtime_len }
-             연장 하프타임 시간: { $overtime_half_time_len }
-sd-allowed = 서든 데스 허용: { $sd }
-pre-sd = 서든 데스 전 휴식 시간: { $pre_sd_len }
-team-to-len = 팀 타임아웃 시간: { $to_len }
-time-btwn-games = 경기 간 기준 시간: { $time_btwn }
-game-block-info = 게임 블록: { $game_block }
-min-brk-btwn-games = 경기 간 최소 시간: { $min_brk_time }
 
 
 # 목록 선택기
@@ -314,21 +285,8 @@ infraction = 위반: {$infraction}
 error = 오류 ({ $number })
 two-games = 이전 경기: { $prev_game },  다음 경기: { $next_game }
 one-game = 경기: { $game }
-teams = { -dark-team-name } 팀: { $dark_team }
-    { -light-team-name } 팀: { $light_team }
-game-config = 전반 시간: { $half_len },  하프타임 시간: { $half_time_len }
-    서든 데스 허용: { $sd_allowed },  연장전 허용: { $ot_allowed }
-team-timeouts = 팀 타임아웃: { $value }
 team-timeouts-label = 팀
     타임아웃:
-stop-clock-last-2 = 마지막 2분 시계 정지: { $stop_clock }
-ref-list = 주심: { $chief_ref }
-    계시원: { $timer }
-    수중 심판 1: { $water_ref_1 }
-    수중 심판 2: { $water_ref_2 }
-    수중 심판 3: { $water_ref_3 }
-team-ref-list = 심판: { $ref_team }
-    기록원/계시원: { $ts_keeper_team }
 unknown = 알 수 없음
 select-infraction = 선택하세요
 ## 경기 시간 버튼
@@ -394,7 +352,6 @@ rugby = 럭비
 beep-test = 비프 테스트
 
 # Beep-test screen
-beep-test-pre = 준비
 beep-test-top-time-label = 시간
 beep-test-top-level-label = 레벨
 beep-test-top-lap-label = 랩
@@ -402,9 +359,6 @@ beep-test-start = 시작
 beep-test-pause = 일시정지
 beep-test-resume = 재개
 beep-test-reset = 리셋
-beep-test-column-level = 레벨
-beep-test-column-count = 카운트
-beep-test-column-duration = 시간
 beep-test-edit-selected = 레벨 { $level }
 beep-test-edit-time = 시간
 beep-test-edit-count = 카운트
@@ -449,12 +403,6 @@ two-halves = 2 하프
 one-period = 1 피리어드
 game-len = 경기 시간
 length-of-game-during-regular-play = 정규 경기 중 전체 경기 시간
-
-# Single-period (1 Period) info variants — Game Length, no half-time line
-game-config-single-half = 경기 시간: { $half_len }
-    서든 데스 허용: { $sd_allowed },  연장전 허용: { $ot_allowed }
-game-length-ot-allowed-single-half = 경기 시간: { $half_length }
-         연장전 허용: { $overtime }
 
 # Self-update / Updates page
 check-version = 버전 확인

--- a/refbox/translations/ms-MY/refbox.ftl
+++ b/refbox/translations/ms-MY/refbox.ftl
@@ -12,7 +12,6 @@ cancel = BATAL
 delete = PADAM
 back = KEMBALI
 apply = GUNA
-save = SIMPAN
 user-options = PILIHAN PENGGUNA
 new = BARU
 
@@ -35,8 +34,6 @@ team-timeout-count = BILANGAN
     MASA REHAT:
 
 # Tambah Amaran
-team-warning = AMARAN
-    PASUKAN
 team-warning-line-1 = AMARAN
 team-warning-line-2 = PASUKAN
 team-score-line-1 = MARKAH
@@ -81,8 +78,6 @@ audible-countdown-for-last-10-seconds = KIRA DETIK BUNYI
     10 SAAT
 delay = LEWAT
 court = GELANGGANG:
-single-half = SEPARUH
-    TUNGGAL:
 half-length-full = PANJANG SEPARUH:
 game-length = PANJANG PERLAWANAN:
 overtime-allowed = MASA TAMBAHAN
@@ -95,8 +90,6 @@ pre-ot-break-length = PANJANG REHAT
     PRA-MASA TAMBAHAN:
 pre-sd-break-length = PANJANG REHAT
     PRA-SUDDEN DEATH:
-nominal-break-between-games = REHAT NOMINAL
-    ANTARA PERLAWANAN:
 ot-half-length = PANJANG SEPARUH
     MASA TAMBAHAN:
 timeouts-counted-per = MASA REHAT
@@ -151,13 +144,11 @@ half-length = PANJANG SEPARUH
 length-of-half-during-regular-play = Panjang separuh semasa permainan biasa
 half-time-lenght = PANJANG REHAT SEPARUH MASA
 length-of-half-time-period = Panjang tempoh rehat separuh masa
-nom-break = REHAT NOMINAL
 game-block = BLOK PERLAWANAN
 game-block-full = BLOK PERLAWANAN:
 game-block-help = Masa dari permulaan satu perlawanan hingga permulaan perlawanan berikutnya
 game-block-too-short = Terlalu singkat untuk memuatkan perlawanan ditambah rehat minimum
 game-block-tight = Ketat — masa rehat pasukan boleh menyebabkan perlawanan melebihi slot mereka
-system-will-keep-game-times-spaced = Sistem akan cuba mengekalkan masa mula perlawanan secara sekata, dengan jumlah masa dari satu permulaan ke permulaan berikutnya ialah 2 × [Panjang Separuh] + [Panjang Rehat Separuh Masa] + [Masa Nominal Antara Perlawanan] (contoh: jika perlawanan mempunyai [Panjang Separuh] = 15m, [Panjang Rehat Separuh Masa] = 3m, dan [Masa Nominal Antara Perlawanan] = 12m, masa dari mula satu perlawanan ke perlawanan berikutnya ialah 45m. Sebarang masa rehat yang diambil, atau penghentian jam yang lain, akan mengurangkan masa 12m itu sehingga nilai masa minimum antara perlawanan dicapai).
 min-break = REHAT MINIMUM
 min-time-btwn-games = Jika perlawanan berjalan lebih lama daripada yang dijadualkan, ini adalah masa minimum antara perlawanan yang akan diperuntukkan oleh sistem. Jika perlawanan tertangguh, sistem akan cuba mengejar secara automatik selepas perlawanan seterusnya, sentiasa mematuhi masa minimum antara perlawanan ini.
 pre-ot-break-abreviated = REHAT PRA-MASA TAMBAHAN
@@ -169,7 +160,6 @@ len-of-overtime-halftime = Panjang rehat separuh masa tambahan
 pre-sd-break = REHAT PRA-SUDDEN DEATH
 pre-sd-len = Panjang rehat antara tempoh permainan sebelumnya dan Sudden Death
 language = BAHASA
-this-language = BAHASA MELAYU
 portal-login-code = KOD
 portal-login-instructions = Sila pergi ke { $portal } Portal >> Pengurusan Acara >> Pengurusan Pengadil, klik butang + untuk menambah Refbox baharu, dan masukkan ID Refbox ini:
     { $id }
@@ -177,7 +167,6 @@ portal-login-instructions = Sila pergi ke { $portal } Portal >> Pengurusan Acara
     { $portal } Portal kemudiannya akan memberikan kod pengesahan untuk anda masukkan di sebelah kiri menggunakan pad nombor.
     Tekan selesai setelah anda memasukkan kod
 
-help = BANTUAN:
 
 # Pengesahan
 game-configuration-can-not-be-changed = Konfigurasi perlawanan tidak boleh diubah semasa perlawanan sedang berlangsung.
@@ -214,24 +203,6 @@ refresh = MUAT SEMULA
 refreshing = MEMUAT SEMULA...
 settings = TETAPAN
 none = Tiada
-game-number-error = Ralat ({ $game_number })
-next-game-number-error = Ralat ({ $next_game_number })
-last-game-next-game = Perlawanan Lepas: { $prev_game },
-    Perlawanan Seterusnya: { $next_game }
-black-team-white-team = Pasukan Hitam: { $black_team }
-    Pasukan Putih: { $white_team }
-game-length-ot-allowed = Panjang Separuh: { $half_length }
-         Panjang Rehat Separuh Masa: { $half_time_length }
-         Masa Tambahan Dibenarkan: { $overtime }
-overtime-details = Panjang Rehat Pra-Masa Tambahan: { $pre_overtime }
-             Panjang Separuh Masa Tambahan: { $overtime_len }
-             Panjang Rehat Separuh Masa Tambahan: { $overtime_half_time_len }
-sd-allowed = Sudden Death Dibenarkan: { $sd }
-pre-sd = Panjang Rehat Pra-Sudden Death: { $pre_sd_len }
-team-to-len = Tempoh Masa Rehat Pasukan: { $to_len }
-time-btwn-games = Masa Nominal Antara Perlawanan: { $time_btwn }
-game-block-info = Blok Permainan: { $game_block }
-min-brk-btwn-games = Masa Minimum Antara Perlawanan: { $min_brk_time }
 
 
 # Pemilih Senarai
@@ -312,21 +283,8 @@ infraction = Pelanggaran: {$infraction}
 error = Ralat ({ $number })
 two-games = Perlawanan Lepas: { $prev_game },  Perlawanan Seterusnya: { $next_game }
 one-game = Perlawanan: { $game }
-teams = Pasukan { -dark-team-name }: { $dark_team }
-    Pasukan { -light-team-name }: { $light_team }
-game-config = Panjang Separuh: { $half_len },  Panjang Rehat Separuh Masa: { $half_time_len }
-    Sudden Death Dibenarkan: { $sd_allowed },  Masa Tambahan Dibenarkan: { $ot_allowed }
-team-timeouts = Masa Rehat Pasukan: { $value }
 team-timeouts-label = MASA REHAT
     PASUKAN:
-stop-clock-last-2 = Hentikan Jam 2 Minit Terakhir: { $stop_clock }
-ref-list = Ketua Pengadil: { $chief_ref }
-    Pencatat Masa: { $timer }
-    Pengadil Air 1: { $water_ref_1 }
-    Pengadil Air 2: { $water_ref_2 }
-    Pengadil Air 3: { $water_ref_3 }
-team-ref-list = Pengadil: { $ref_team }
-    Pencatat Masa/Markah: { $ts_keeper_team }
 unknown = Tidak Diketahui
 select-infraction = Sila pilih
 ## Butang masa perlawanan
@@ -392,7 +350,6 @@ rugby = RAGBI
 beep-test = BEEP TEST
 
 # Beep-test screen
-beep-test-pre = PRA
 beep-test-top-time-label = MASA
 beep-test-top-level-label = TAHAP
 beep-test-top-lap-label = PUSINGAN
@@ -400,9 +357,6 @@ beep-test-start = MULA
 beep-test-pause = JEDA
 beep-test-resume = SAMBUNG
 beep-test-reset = SET SEMULA
-beep-test-column-level = TAHAP
-beep-test-column-count = BILANGAN
-beep-test-column-duration = TEMPOH
 beep-test-edit-selected = Tahap { $level }
 beep-test-edit-time = MASA
 beep-test-edit-count = BILANGAN
@@ -447,12 +401,6 @@ two-halves = 2 SEPARUH
 one-period = 1 PERIOD
 game-len = PANJANG PERLAWANAN
 length-of-game-during-regular-play = Panjang perlawanan semasa permainan biasa
-
-# Single-period (1 Period) info variants — Game Length, no half-time line
-game-config-single-half = Panjang Perlawanan: { $half_len }
-    Sudden Death Dibenarkan: { $sd_allowed },  Masa Tambahan Dibenarkan: { $ot_allowed }
-game-length-ot-allowed-single-half = Panjang Perlawanan: { $half_length }
-         Masa Tambahan Dibenarkan: { $overtime }
 
 # Self-update / Updates page
 check-version = Semak Versi

--- a/refbox/translations/nl-NL/refbox.ftl
+++ b/refbox/translations/nl-NL/refbox.ftl
@@ -12,7 +12,6 @@ cancel = ANNULEREN
 delete = VERWIJDEREN
 back = TERUG
 apply = TOEPASSEN
-save = OPSLAAN
 user-options = GEBRUIKERSOPTIES
 new = NIEUW
 
@@ -35,8 +34,6 @@ team-timeout-count = AANTAL
     TEAM TIME-OUTS:
 
 # Waarschuwing toevoegen
-team-warning = TEAM-
-    WAARSCHUWING
 team-warning-line-1 = TEAM-
 team-warning-line-2 = WAARSCHUWING
 team-score-line-1 = TEAM-
@@ -81,8 +78,6 @@ audible-countdown-for-last-10-seconds = HOORBARE AFTELLING
     10 SECONDEN
 delay = VERTRAGING
 court = BAAN:
-single-half = ENKELE
-    HELFT:
 half-length-full = DUUR HELFT:
 game-length = WEDSTRIJDDUUR:
 overtime-allowed = VERLENGING
@@ -95,8 +90,6 @@ pre-ot-break-length = PAUZE VOOR
     VERLENGING:
 pre-sd-break-length = PAUZE VOOR
     PLTS DOOD:
-nominal-break-between-games = NOMINALE PAUZE
-    TUSSEN WEDSTR.:
 ot-half-length = DUUR HELFT
     VERLENGING:
 timeouts-counted-per = TIME-OUTS
@@ -151,13 +144,11 @@ half-length = DUUR HELFT
 length-of-half-during-regular-play = De duur van een helft tijdens regulier spel
 half-time-lenght = DUUR RUST
 length-of-half-time-period = De duur van de rustperiode
-nom-break = NOM PAUZE
 game-block = SPELBLOK
 game-block-full = SPELBLOK:
 game-block-help = Tijd van het begin van één wedstrijd tot het begin van de volgende
 game-block-too-short = Te kort voor de wedstrijd plus de minimale pauze
 game-block-tight = Krap — teamtime-outs kunnen wedstrijden buiten hun tijdslot duwen
-system-will-keep-game-times-spaced = Het systeem probeert de starttijden van wedstrijden gelijkmatig te verdelen. De totale tijd van de ene start tot de volgende is 2 × [Duur Helft] + [Duur Rust] + [Nominale Tijd Tussen Wedstrijden] (voorbeeld: als [Duur Helft] = 15 min, [Duur Rust] = 3 min en [Nominale Tijd] = 12 min, dan is de tijd van start tot start 45 min. Genomen time-outs of andere onderbrekingen verkorten de 12 min tot de minimale tijd tussen wedstrijden is bereikt).
 min-break = MIN PAUZE
 min-time-btwn-games = Als een wedstrijd langer duurt dan gepland, is dit de minimale tijd tussen wedstrijden die het systeem toestaat. Als wedstrijden uitlopen, probeert het systeem bij volgende wedstrijden in te halen, waarbij altijd deze minimale tijd wordt gerespecteerd.
 pre-ot-break-abreviated = PAUZE VOOR VERLENGING
@@ -169,7 +160,6 @@ len-of-overtime-halftime = De duur van de rust tijdens de verlenging
 pre-sd-break = PAUZE VOOR PLTS DOOD
 pre-sd-len = De duur van de pauze tussen het voorgaande speelgedeelte en Plotselinge Dood
 language = TAAL
-this-language = NEDERLANDS
 portal-login-code = CODE
 portal-login-instructions = Ga naar het { $portal }-portaal >> Evenementbeheer >> Scheidsrechterbeheer, klik op de + knop om een nieuwe Refbox toe te voegen en voer dit Refbox-ID in:
     { $id }
@@ -177,7 +167,6 @@ portal-login-instructions = Ga naar het { $portal }-portaal >> Evenementbeheer >
     Het { $portal }-portaal geeft vervolgens een bevestigingscode die u links via het nummerveld kunt invoeren.
     Druk op Klaar nadat u de code hebt ingevoerd
 
-help = HELP:
 
 # Bevestiging
 game-configuration-can-not-be-changed = De wedstrijdconfiguratie kan niet worden gewijzigd terwijl een wedstrijd bezig is.
@@ -214,24 +203,6 @@ refresh = VERNIEUWEN
 refreshing = VERNIEUWEN...
 settings = INSTELLINGEN
 none = Geen
-game-number-error = Fout ({ $game_number })
-next-game-number-error = Fout ({ $next_game_number })
-last-game-next-game = Vorige Wedstrijd: { $prev_game },
-    Volgende Wedstrijd: { $next_game }
-black-team-white-team = Donker Team: { $black_team }
-    Licht Team: { $white_team }
-game-length-ot-allowed = Duur Helft: { $half_length }
-         Duur Rust: { $half_time_length }
-         Verlenging Toegestaan: { $overtime }
-overtime-details = Duur Pauze Voor Verlenging: { $pre_overtime }
-             Duur Helft Verlenging: { $overtime_len }
-             Duur Rust Verlenging: { $overtime_half_time_len }
-sd-allowed = Plotselinge Dood Toegestaan: { $sd }
-pre-sd = Duur Pauze Voor Plotselinge Dood: { $pre_sd_len }
-team-to-len = Duur Team Time-out: { $to_len }
-time-btwn-games = Nominale Tijd Tussen Wedstrijden: { $time_btwn }
-game-block-info = Spelblok: { $game_block }
-min-brk-btwn-games = Minimale Tijd Tussen Wedstrijden: { $min_brk_time }
 
 
 # Lijstselecties
@@ -312,21 +283,8 @@ infraction = Overtreding: {$infraction}
 error = Fout ({ $number })
 two-games = Vorige Wedstrijd: { $prev_game },  Volgende Wedstrijd: { $next_game }
 one-game = Wedstrijd: { $game }
-teams = { -dark-team-name } Team: { $dark_team }
-    { -light-team-name } Team: { $light_team }
-game-config = Duur Helft: { $half_len },  Duur Rust: { $half_time_len }
-    Plotselinge Dood Toegestaan: { $sd_allowed },  Verlenging Toegestaan: { $ot_allowed }
-team-timeouts = Team Time-outs: { $value }
 team-timeouts-label = TEAM
     TIME-OUTS:
-stop-clock-last-2 = Klok Stoppen in Laatste 2 Minuten: { $stop_clock }
-ref-list = Hoofdscheidsrechter: { $chief_ref }
-    Tijdwaarnemer: { $timer }
-    Waterscheidsrechter 1: { $water_ref_1 }
-    Waterscheidsrechter 2: { $water_ref_2 }
-    Waterscheidsrechter 3: { $water_ref_3 }
-team-ref-list = Scheidsrechters: { $ref_team }
-    Tijdwaarnemer/Scorer: { $ts_keeper_team }
 unknown = Onbekend
 select-infraction = Maak een keuze
 ## Wedstrijdtijdknop
@@ -392,7 +350,6 @@ rugby = RUGBY
 beep-test = PIEPTEST
 
 # Beep-test screen
-beep-test-pre = PRE
 beep-test-top-time-label = TIJD
 beep-test-top-level-label = NIVEAU
 beep-test-top-lap-label = RONDE
@@ -400,9 +357,6 @@ beep-test-start = START
 beep-test-pause = PAUZE
 beep-test-resume = HERVATTEN
 beep-test-reset = RESET
-beep-test-column-level = NIVEAU
-beep-test-column-count = AANTAL
-beep-test-column-duration = DUUR
 beep-test-edit-selected = Niveau { $level }
 beep-test-edit-time = TIJD
 beep-test-edit-count = AANTAL
@@ -447,12 +401,6 @@ two-halves = 2 HELFTEN
 one-period = 1 PERIODE
 game-len = WEDSTRIJDDUUR
 length-of-game-during-regular-play = De duur van de wedstrijd tijdens regulier spel
-
-# Single-period (1 Period) info variants — Game Length, no half-time line
-game-config-single-half = Wedstrijdduur: { $half_len }
-    Plotselinge Dood Toegestaan: { $sd_allowed },  Verlenging Toegestaan: { $ot_allowed }
-game-length-ot-allowed-single-half = Wedstrijdduur: { $half_length }
-         Verlenging Toegestaan: { $overtime }
 
 # Self-update / Updates page
 check-version = Versie controleren

--- a/refbox/translations/pt-PT/refbox.ftl
+++ b/refbox/translations/pt-PT/refbox.ftl
@@ -12,7 +12,6 @@ cancel = CANCELAR
 delete = ELIMINAR
 back = VOLTAR
 apply = APLICAR
-save = GUARDAR
 user-options = OPÇÕES DO UTILIZADOR
 new = NOVO
 
@@ -35,8 +34,6 @@ team-timeout-count = NÚMERO DE
     TEMPOS DE EQUIPA:
 
 # Adicionar Aviso
-team-warning = AVISO DE
-    EQUIPA
 team-warning-line-1 = AVISO DE
 team-warning-line-2 = EQUIPA
 team-score-line-1 = RESULTADO DE
@@ -81,8 +78,6 @@ audible-countdown-for-last-10-seconds = CONTAGEM DECRESCENTE
     SONORA 10 S
 delay = ATRASO
 court = CAMPO:
-single-half = TEMPO
-    ÚNICO:
 half-length-full = DURAÇÃO DO TEMPO:
 game-length = DURAÇÃO DO JOGO:
 overtime-allowed = PRORROGAÇÃO
@@ -95,8 +90,6 @@ pre-ot-break-length = PAUSA PRÉ
     PRORROGAÇÃO:
 pre-sd-break-length = PAUSA PRÉ
     MORTE SÚBITA:
-nominal-break-between-games = PAUSA NOMINAL
-    ENTRE JOGOS:
 ot-half-length = DURAÇÃO TEMPO
     PRORROGAÇÃO:
 timeouts-counted-per = TEMPOS DE EQUIPA
@@ -151,13 +144,11 @@ half-length = DUR TEMPO
 length-of-half-during-regular-play = A duração de um tempo durante o jogo regular
 half-time-lenght = DUR INTERVALO
 length-of-half-time-period = A duração do período de intervalo
-nom-break = PAUSA NOM
 game-block = BLOCO DE JOGO
 game-block-full = BLOCO DE JOGO:
 game-block-help = Tempo desde o início de um jogo até ao início do seguinte
 game-block-too-short = Demasiado curto para o jogo mais a pausa mínima
 game-block-tight = Apertado — os tempos mortos podem fazer os jogos ultrapassar o seu slot
-system-will-keep-game-times-spaced = O sistema tentará manter os horários de início dos jogos espaçados de forma uniforme, sendo o tempo total de um início ao seguinte igual a 2 × [Duração do Tempo] + [Duração do Intervalo] + [Tempo Nominal Entre Jogos] (exemplo: se [Duração do Tempo] = 15 min, [Duração do Intervalo] = 3 min e [Tempo Nominal Entre Jogos] = 12 min, o tempo de início a início será de 45 min. Os tempos de equipa ou outras paragens reduzirão os 12 min até ser atingido o tempo mínimo entre jogos).
 min-break = PAUSA MÍN
 min-time-btwn-games = Se um jogo durar mais do que o previsto, este é o tempo mínimo entre jogos que o sistema atribuirá. Se os jogos ficarem atrasados, o sistema tentará recuperar nos jogos seguintes, respeitando sempre este tempo mínimo.
 pre-ot-break-abreviated = PAUSA PRÉ PRORR
@@ -169,7 +160,6 @@ len-of-overtime-halftime = A duração do intervalo da prorrogação
 pre-sd-break = PAUSA PRÉ MS
 pre-sd-len = A duração da pausa entre o período de jogo anterior e a Morte Súbita
 language = IDIOMA
-this-language = PORTUGUÊS
 portal-login-code = CÓDIGO
 portal-login-instructions = Aceda ao Portal { $portal } >> Gestão de Eventos >> Gestão de Árbitros, clique no botão + para adicionar um novo Refbox e introduza este ID de Refbox:
     { $id }
@@ -177,7 +167,6 @@ portal-login-instructions = Aceda ao Portal { $portal } >> Gestão de Eventos >>
     O Portal { $portal } fornecerá então um código de confirmação para introduzir à esquerda através do teclado numérico.
     Prima Concluído depois de ter introduzido o código
 
-help = AJUDA:
 
 # Confirmação
 game-configuration-can-not-be-changed = A configuração do jogo não pode ser alterada enquanto um jogo está em curso.
@@ -214,24 +203,6 @@ refresh = ATUALIZAR
 refreshing = A ATUALIZAR...
 settings = DEFINIÇÕES
 none = Nenhum
-game-number-error = Erro ({ $game_number })
-next-game-number-error = Erro ({ $next_game_number })
-last-game-next-game = Último Jogo: { $prev_game },
-    Próximo Jogo: { $next_game }
-black-team-white-team = Equipa Preta: { $black_team }
-    Equipa Branca: { $white_team }
-game-length-ot-allowed = Duração do Tempo: { $half_length }
-         Duração do Intervalo: { $half_time_length }
-         Prorrogação Permitida: { $overtime }
-overtime-details = Duração da Pausa Pré-Prorrogação: { $pre_overtime }
-             Duração do Tempo de Prorrogação: { $overtime_len }
-             Duração do Intervalo de Prorrogação: { $overtime_half_time_len }
-sd-allowed = Morte Súbita Permitida: { $sd }
-pre-sd = Duração da Pausa Pré-Morte Súbita: { $pre_sd_len }
-team-to-len = Duração do Tempo de Equipa: { $to_len }
-time-btwn-games = Tempo Nominal Entre Jogos: { $time_btwn }
-game-block-info = Bloco de Jogo: { $game_block }
-min-brk-btwn-games = Tempo Mínimo Entre Jogos: { $min_brk_time }
 
 
 # Seletores de Lista
@@ -312,21 +283,8 @@ infraction = Infração: {$infraction}
 error = Erro ({ $number })
 two-games = Último Jogo: { $prev_game },  Próximo Jogo: { $next_game }
 one-game = Jogo: { $game }
-teams = Equipa { -dark-team-name }: { $dark_team }
-    Equipa { -light-team-name }: { $light_team }
-game-config = Duração do Tempo: { $half_len },  Duração do Intervalo: { $half_time_len }
-    Morte Súbita Permitida: { $sd_allowed },  Prorrogação Permitida: { $ot_allowed }
-team-timeouts = Tempos de Equipa: { $value }
 team-timeouts-label = TEMPOS DE
     EQUIPA:
-stop-clock-last-2 = Parar Relógio nos Últimos 2 Minutos: { $stop_clock }
-ref-list = Árbitro Principal: { $chief_ref }
-    Controlador de Tempo: { $timer }
-    Árbitro Aquático 1: { $water_ref_1 }
-    Árbitro Aquático 2: { $water_ref_2 }
-    Árbitro Aquático 3: { $water_ref_3 }
-team-ref-list = Árbitros: { $ref_team }
-    Controlador de Tempo/Pontuação: { $ts_keeper_team }
 unknown = Desconhecido
 select-infraction = Selecione uma opção
 ## Botão de tempo de jogo
@@ -392,7 +350,6 @@ rugby = RÂGUEBI
 beep-test = BEEP TEST
 
 # Beep-test screen
-beep-test-pre = PRÉ
 beep-test-top-time-label = TEMPO
 beep-test-top-level-label = NÍVEL
 beep-test-top-lap-label = VOLTA
@@ -400,9 +357,6 @@ beep-test-start = INICIAR
 beep-test-pause = PAUSA
 beep-test-resume = RETOMAR
 beep-test-reset = REINICIAR
-beep-test-column-level = NÍVEL
-beep-test-column-count = CONT
-beep-test-column-duration = DURAÇÃO
 beep-test-edit-selected = Nível { $level }
 beep-test-edit-time = TEMPO
 beep-test-edit-count = CONT
@@ -447,12 +401,6 @@ two-halves = 2 TEMPOS
 one-period = 1 PERÍODO
 game-len = DURAÇÃO DO JOGO
 length-of-game-during-regular-play = A duração total do jogo durante o jogo regular
-
-# Single-period (1 Period) info variants — Game Length, no half-time line
-game-config-single-half = Duração do Jogo: { $half_len }
-    Morte Súbita Permitida: { $sd_allowed },  Prorrogação Permitida: { $ot_allowed }
-game-length-ot-allowed-single-half = Duração do Jogo: { $half_length }
-         Prorrogação Permitida: { $overtime }
 
 # Self-update / Updates page
 check-version = Verificar versão

--- a/refbox/translations/th-TH/refbox.ftl
+++ b/refbox/translations/th-TH/refbox.ftl
@@ -12,7 +12,6 @@ cancel = ยกเลิก
 delete = ลบ
 back = กลับ
 apply = ใช้
-save = บันทึก
 user-options = ตัวเลือกผู้ใช้
 new = ใหม่
 
@@ -35,8 +34,6 @@ team-timeout-count = จำนวน
     พักทีม:
 
 # เพิ่มการเตือน
-team-warning = การเตือน
-    ทีม
 team-warning-line-1 = การเตือน
 team-warning-line-2 = ทีม
 team-score-line-1 = คะแนน
@@ -81,8 +78,6 @@ audible-countdown-for-last-10-seconds = นับถอยหลังด้ว�
     10 วินาที
 delay = ล่าช้า
 court = สนาม:
-single-half = ครึ่ง
-    เดียว:
 half-length-full = ความยาวครึ่งเวลา:
 game-length = ความยาวเกม:
 overtime-allowed = อนุญาต
@@ -95,8 +90,6 @@ pre-ot-break-length = พักก่อน
     ต่อเวลาพิเศษ:
 pre-sd-break-length = พักก่อน
     ตายกะทันหัน:
-nominal-break-between-games = พักระหว่างเกม
-    ตามกำหนด:
 ot-half-length = ครึ่งเวลา
     ต่อเวลาพิเศษ:
 timeouts-counted-per = นับพักทีม
@@ -151,13 +144,11 @@ half-length = ความยาวครึ่ง
 length-of-half-during-regular-play = ความยาวของครึ่งเวลาระหว่างการเล่นปกติ
 half-time-lenght = ความยาวพักครึ่ง
 length-of-half-time-period = ความยาวของช่วงพักครึ่งเวลา
-nom-break = พักตามกำหนด
 game-block = บล็อกเกม
 game-block-full = บล็อกเกม:
 game-block-help = เวลาจากการเริ่มต้นของเกมหนึ่งถึงการเริ่มต้นของเกมถัดไป
 game-block-too-short = สั้นเกินไปสำหรับเกมรวมกับช่วงพักขั้นต่ำ
 game-block-tight = ตึง — การพักทีมอาจทำให้เกมเกินช่วงเวลาของตน
-system-will-keep-game-times-spaced = ระบบจะพยายามรักษาเวลาเริ่มเกมให้เท่ากัน โดยเวลารวมจากการเริ่มหนึ่งไปอีกการเริ่มหนึ่งคือ 2 × [ความยาวครึ่ง] + [ความยาวพักครึ่ง] + [เวลาระหว่างเกมตามกำหนด] (ตัวอย่าง: ถ้า [ความยาวครึ่ง] = 15 นาที, [ความยาวพักครึ่ง] = 3 นาที และ [เวลาระหว่างเกมตามกำหนด] = 12 นาที เวลาจากการเริ่มเกมหนึ่งไปอีกเกมหนึ่งจะเป็น 45 นาที การพักทีมหรือการหยุดนาฬิกาอื่นๆ จะลดเวลา 12 นาทีลงจนถึงค่าเวลาระหว่างเกมขั้นต่ำ)
 min-break = พักขั้นต่ำ
 min-time-btwn-games = หากเกมดำเนินนานกว่ากำหนด นี่คือเวลาระหว่างเกมขั้นต่ำที่ระบบจะจัดสรร หากเกมล่าช้า ระบบจะพยายามตามทันในเกมถัดไป โดยเคารพเวลาระหว่างเกมขั้นต่ำนี้เสมอ
 pre-ot-break-abreviated = พักก่อนต่อเวลาพิเศษ
@@ -169,7 +160,6 @@ len-of-overtime-halftime = ความยาวของพักครึ่�
 pre-sd-break = พักก่อนตายกะทันหัน
 pre-sd-len = ความยาวของการพักระหว่างช่วงเล่นก่อนหน้าและตายกะทันหัน
 language = ภาษา
-this-language = ภาษาไทย
 portal-login-code = รหัส
 portal-login-instructions = กรุณาไปที่ { $portal } Portal >> การจัดการกิจกรรม >> การจัดการผู้ตัดสิน คลิกปุ่ม + เพื่อเพิ่ม Refbox ใหม่ และป้อน Refbox ID นี้:
     { $id }
@@ -177,7 +167,6 @@ portal-login-instructions = กรุณาไปที่ { $portal } Portal >>
     { $portal } Portal จะให้รหัสยืนยันสำหรับป้อนทางซ้ายโดยใช้แป้นตัวเลข
     กดเสร็จสิ้นเมื่อป้อนรหัสแล้ว
 
-help = ช่วยเหลือ:
 
 # การยืนยัน
 game-configuration-can-not-be-changed = ไม่สามารถเปลี่ยนการตั้งค่าเกมได้ขณะที่เกมกำลังดำเนินอยู่
@@ -214,24 +203,6 @@ refresh = รีเฟรช
 refreshing = กำลังรีเฟรช...
 settings = การตั้งค่า
 none = ไม่มี
-game-number-error = ข้อผิดพลาด ({ $game_number })
-next-game-number-error = ข้อผิดพลาด ({ $next_game_number })
-last-game-next-game = เกมที่แล้ว: { $prev_game },
-    เกมถัดไป: { $next_game }
-black-team-white-team = ทีมดำ: { $black_team }
-    ทีมขาว: { $white_team }
-game-length-ot-allowed = ความยาวครึ่ง: { $half_length }
-         ความยาวพักครึ่ง: { $half_time_length }
-         อนุญาตต่อเวลาพิเศษ: { $overtime }
-overtime-details = ความยาวพักก่อนต่อเวลาพิเศษ: { $pre_overtime }
-             ความยาวครึ่งต่อเวลาพิเศษ: { $overtime_len }
-             ความยาวพักครึ่งต่อเวลาพิเศษ: { $overtime_half_time_len }
-sd-allowed = อนุญาตตายกะทันหัน: { $sd }
-pre-sd = ความยาวพักก่อนตายกะทันหัน: { $pre_sd_len }
-team-to-len = ระยะเวลาพักทีม: { $to_len }
-time-btwn-games = เวลาระหว่างเกมตามกำหนด: { $time_btwn }
-game-block-info = บล็อกเกม: { $game_block }
-min-brk-btwn-games = เวลาระหว่างเกมขั้นต่ำ: { $min_brk_time }
 
 
 # ตัวเลือกรายการ
@@ -312,20 +283,7 @@ infraction = การฝ่าฝืน: {$infraction}
 error = ข้อผิดพลาด ({ $number })
 two-games = เกมที่แล้ว: { $prev_game },  เกมถัดไป: { $next_game }
 one-game = เกม: { $game }
-teams = { -dark-team-name }: { $dark_team }
-    { -light-team-name }: { $light_team }
-game-config = ความยาวครึ่ง: { $half_len },  ความยาวพักครึ่ง: { $half_time_len }
-    อนุญาตตายกะทันหัน: { $sd_allowed },  อนุญาตต่อเวลาพิเศษ: { $ot_allowed }
-team-timeouts = พักทีม: { $value }
 team-timeouts-label = พักทีม:
-stop-clock-last-2 = หยุดนาฬิกาใน 2 นาทีสุดท้าย: { $stop_clock }
-ref-list = หัวหน้าผู้ตัดสิน: { $chief_ref }
-    กรรมการจับเวลา: { $timer }
-    ผู้ตัดสินในน้ำ 1: { $water_ref_1 }
-    ผู้ตัดสินในน้ำ 2: { $water_ref_2 }
-    ผู้ตัดสินในน้ำ 3: { $water_ref_3 }
-team-ref-list = ผู้ตัดสิน: { $ref_team }
-    กรรมการจับเวลา/บันทึกคะแนน: { $ts_keeper_team }
 unknown = ไม่ทราบ
 select-infraction = กรุณาเลือก
 ## ปุ่มเวลาเกม
@@ -391,7 +349,6 @@ rugby = รักบี้
 beep-test = ทดสอบบี๊พ
 
 # Beep-test screen
-beep-test-pre = เตรียม
 beep-test-top-time-label = เวลา
 beep-test-top-level-label = ระดับ
 beep-test-top-lap-label = รอบ
@@ -399,9 +356,6 @@ beep-test-start = เริ่ม
 beep-test-pause = หยุดชั่วคราว
 beep-test-resume = เล่นต่อ
 beep-test-reset = รีเซ็ต
-beep-test-column-level = ระดับ
-beep-test-column-count = จำนวน
-beep-test-column-duration = ระยะเวลา
 beep-test-edit-selected = ระดับ { $level }
 beep-test-edit-time = เวลา
 beep-test-edit-count = จำนวน
@@ -446,12 +400,6 @@ two-halves = 2 ครึ่ง
 one-period = 1 พีเรียด
 game-len = ความยาวเกม
 length-of-game-during-regular-play = ความยาวของเกมระหว่างการเล่นปกติ
-
-# Single-period (1 Period) info variants — Game Length, no half-time line
-game-config-single-half = ความยาวเกม: { $half_len }
-    อนุญาตตายกะทันหัน: { $sd_allowed },  อนุญาตต่อเวลาพิเศษ: { $ot_allowed }
-game-length-ot-allowed-single-half = ความยาวเกม: { $half_length }
-         อนุญาตต่อเวลาพิเศษ: { $overtime }
 
 # Self-update / Updates page
 check-version = ตรวจสอบเวอร์ชัน

--- a/refbox/translations/tl-PH/refbox.ftl
+++ b/refbox/translations/tl-PH/refbox.ftl
@@ -12,7 +12,6 @@ cancel = KANSELAHIN
 delete = BURAHIN
 back = BUMALIK
 apply = ILAPAT
-save = ITAGO
 user-options = MGA OPSYON NG USER
 new = BAGO
 
@@ -35,8 +34,6 @@ team-timeout-count = BILANG NG
     TIMEOUT:
 
 # Pagdagdag ng Babala
-team-warning = BABALA NG
-    KOPONAN
 team-warning-line-1 = BABALA NG
 team-warning-line-2 = KOPONAN
 team-score-line-1 = PUNTOS NG
@@ -81,8 +78,6 @@ audible-countdown-for-last-10-seconds = COUNTDOWN NA TUNOG
     HULING 10 SEGUNDO
 delay = ANTALA
 court = KORTE:
-single-half = ISANG
-    KALAHATI:
 half-length-full = HABA NG KALAHATI:
 game-length = HABA NG LARO:
 overtime-allowed = OVERTIME
@@ -95,8 +90,6 @@ pre-ot-break-length = HABA NG PAHINGA
     BAGO OT:
 pre-sd-break-length = HABA NG PAHINGA
     BAGO SD:
-nominal-break-between-games = NOMINAL NA PAHINGA
-    SA PAGITAN NG MGA LARO:
 ot-half-length = HABA NG
     KALAHATI SA OT:
 timeouts-counted-per = MGA TIMEOUT
@@ -151,13 +144,11 @@ half-length = HABA NG KALAHATI
 length-of-half-during-regular-play = Ang haba ng isang kalahati sa panahon ng regular na laro
 half-time-lenght = HABA NG PAHINGA
 length-of-half-time-period = Ang haba ng panahon ng pahinga
-nom-break = NOMINAL NA PAHINGA
 game-block = BLOKE NG LARO
 game-block-full = BLOKE NG LARO:
 game-block-help = Oras mula sa simula ng isang laro hanggang sa simula ng susunod
 game-block-too-short = Masyadong maikli para sa laro kasama ang pinakamaliit na pahinga
 game-block-tight = Masikip — ang mga timeout ng koponan ay maaaring itulak ang mga laro lampas sa kanilang slot
-system-will-keep-game-times-spaced = Susubukan ng sistema na panatilihing pantay ang mga oras ng simula ng laro, na ang kabuuang oras mula sa isang simula hanggang sa susunod ay 2 × [Haba ng Kalahati] + [Haba ng Pahinga] + [Nominal na Oras sa Pagitan ng mga Laro] (halimbawa: kung ang [Haba ng Kalahati] = 15 min, [Haba ng Pahinga] = 3 min at [Nominal na Oras sa Pagitan ng mga Laro] = 12 min, ang oras mula simula hanggang simula ay magiging 45 min. Ang anumang mga timeout o iba pang paghinto ng orasan ay magbabawas ng 12 min hanggang maabot ang pinakamaliit na oras sa pagitan ng mga laro).
 min-break = PINAKAMALIIT NA PAHINGA
 min-time-btwn-games = Kung ang isang laro ay mas matagal kaysa sa nakatakda, ito ang pinakamaliit na oras sa pagitan ng mga larong itatalaga ng sistema. Kung nahuhuli ang mga laro, awtomatikong susubukan ng sistema na makahabol sa mga susunod na laro, palaging iginagalang ang pinakamaliit na oras na ito sa pagitan ng mga laro.
 pre-ot-break-abreviated = PAHINGA BAGO OT
@@ -169,7 +160,6 @@ len-of-overtime-halftime = Ang haba ng pahinga sa Overtime
 pre-sd-break = PAHINGA BAGO SD
 pre-sd-len = Ang haba ng pahinga sa pagitan ng nakaraang panahon ng laro at Sudden Death
 language = WIKA
-this-language = FILIPINO
 portal-login-code = KODIGO
 portal-login-instructions = Pumunta sa { $portal } Portal >> Pamamahala ng Kaganapan >> Pamamahala ng Referee, i-click ang + na pindutan upang magdagdag ng bagong Refbox, at ilagay ang Refbox ID na ito:
     { $id }
@@ -177,7 +167,6 @@ portal-login-instructions = Pumunta sa { $portal } Portal >> Pamamahala ng Kagan
     Ang { $portal } Portal ay magbibigay ng confirmation code na ilalagay sa kaliwa gamit ang number pad.
     Pindutin ang Tapos kapag naipasok mo na ang code
 
-help = TULONG:
 
 # Kumpirmasyon
 game-configuration-can-not-be-changed = Hindi mababago ang configuration ng laro habang nagaganap ang laro.
@@ -214,24 +203,6 @@ refresh = I-REFRESH
 refreshing = NIRI-REFRESH...
 settings = MGA SETTING
 none = Wala
-game-number-error = Mali ({ $game_number })
-next-game-number-error = Mali ({ $next_game_number })
-last-game-next-game = Huling Laro: { $prev_game },
-    Susunod na Laro: { $next_game }
-black-team-white-team = Koponan ng Itim: { $black_team }
-    Koponan ng Puti: { $white_team }
-game-length-ot-allowed = Haba ng Kalahati: { $half_length }
-         Haba ng Pahinga: { $half_time_length }
-         Overtime Pinahintulutan: { $overtime }
-overtime-details = Haba ng Pahinga Bago Overtime: { $pre_overtime }
-             Haba ng Kalahati sa Overtime: { $overtime_len }
-             Haba ng Pahinga sa Overtime: { $overtime_half_time_len }
-sd-allowed = Sudden Death Pinahintulutan: { $sd }
-pre-sd = Haba ng Pahinga Bago Sudden Death: { $pre_sd_len }
-team-to-len = Tagal ng Timeout ng Koponan: { $to_len }
-time-btwn-games = Nominal na Oras sa Pagitan ng mga Laro: { $time_btwn }
-game-block-info = Bloke ng Laro: { $game_block }
-min-brk-btwn-games = Pinakamaliit na Oras sa Pagitan ng mga Laro: { $min_brk_time }
 
 
 # Mga Listahan
@@ -312,21 +283,8 @@ infraction = Paglabag: {$infraction}
 error = Mali ({ $number })
 two-games = Huling Laro: { $prev_game },  Susunod na Laro: { $next_game }
 one-game = Laro: { $game }
-teams = Koponan ng { -dark-team-name }: { $dark_team }
-    Koponan ng { -light-team-name }: { $light_team }
-game-config = Haba ng Kalahati: { $half_len },  Haba ng Pahinga: { $half_time_len }
-    Sudden Death Pinahintulutan: { $sd_allowed },  Overtime Pinahintulutan: { $ot_allowed }
-team-timeouts = Mga Timeout ng Koponan: { $value }
 team-timeouts-label = MGA TIMEOUT
     NG KOPONAN:
-stop-clock-last-2 = Ihinto ang Orasan sa Huling 2 Minuto: { $stop_clock }
-ref-list = Punong Ref: { $chief_ref }
-    Timer: { $timer }
-    Water Ref 1: { $water_ref_1 }
-    Water Ref 2: { $water_ref_2 }
-    Water Ref 3: { $water_ref_3 }
-team-ref-list = Mga Referee: { $ref_team }
-    Tagapanatili ng Puntos: { $ts_keeper_team }
 unknown = Hindi Alam
 select-infraction = Pumili
 ## Pindutan ng oras ng laro
@@ -392,7 +350,6 @@ rugby = RUGBY
 beep-test = BEEP TEST
 
 # Beep-test screen
-beep-test-pre = PAUNA
 beep-test-top-time-label = ORAS
 beep-test-top-level-label = ANTAS
 beep-test-top-lap-label = IKOT
@@ -400,9 +357,6 @@ beep-test-start = SIMULAN
 beep-test-pause = IHINTO
 beep-test-resume = IPAGPATULOY
 beep-test-reset = IBALIK
-beep-test-column-level = ANTAS
-beep-test-column-count = BILANG
-beep-test-column-duration = TAGAL
 beep-test-edit-selected = Antas { $level }
 beep-test-edit-time = ORAS
 beep-test-edit-count = BILANG
@@ -447,12 +401,6 @@ two-halves = 2 KALAHATI
 one-period = 1 YUGTO
 game-len = HABA NG LARO
 length-of-game-during-regular-play = Ang haba ng buong laro sa panahon ng regular na laro
-
-# Single-period (1 Period) info variants — Game Length, no half-time line
-game-config-single-half = Haba ng Laro: { $half_len }
-    Sudden Death Pinahintulutan: { $sd_allowed },  Overtime Pinahintulutan: { $ot_allowed }
-game-length-ot-allowed-single-half = Haba ng Laro: { $half_length }
-         Overtime Pinahintulutan: { $overtime }
 
 # Self-update / Updates page
 check-version = Tingnan ang Bersyon

--- a/refbox/translations/tr-TR/refbox.ftl
+++ b/refbox/translations/tr-TR/refbox.ftl
@@ -12,7 +12,6 @@ cancel = İPTAL
 delete = SİL
 back = GERİ
 apply = UYGULA
-save = KAYDET
 user-options = KULLANICI SEÇENEKLERİ
 new = YENİ
 
@@ -35,8 +34,6 @@ team-timeout-count = TAKIM MOLASI
     SAYISI:
 
 # Uyarı Ekleme
-team-warning = TAKIM
-    UYARISI
 team-warning-line-1 = TAKIM
 team-warning-line-2 = UYARISI
 team-score-line-1 = TAKIM
@@ -81,8 +78,6 @@ audible-countdown-for-last-10-seconds = SESLİ GERİ SAYIM
     SON 10 SANİYE
 delay = GECİKME
 court = SAHA:
-single-half = TEK
-    DEVRE:
 half-length-full = DEVRE SÜRESİ:
 game-length = OYUN SÜRESİ:
 overtime-allowed = UZATMA
@@ -95,8 +90,6 @@ pre-ot-break-length = UZATMA ÖNCESİ
     ARA SÜRESİ:
 pre-sd-break-length = ANİ ÖLÜM ÖNCESİ
     ARA SÜRESİ:
-nominal-break-between-games = OYUNLAR ARASI
-    NOMİNAL ARA:
 ot-half-length = UZATMA DEVRESİ
     SÜRESİ:
 timeouts-counted-per = MOLALAR
@@ -151,13 +144,11 @@ half-length = DEVRE SÜRESİ
 length-of-half-during-regular-play = Normal oyun sırasında bir devrenin süresi
 half-time-lenght = DEVRE ARASI SÜRESİ
 length-of-half-time-period = Devre arası süresinin uzunluğu
-nom-break = NOMİNAL ARA
 game-block = OYUN BLOĞU
 game-block-full = OYUN BLOĞU:
 game-block-help = Bir oyunun başlangıcından bir sonraki oyunun başlangıcına kadar geçen süre
 game-block-too-short = Oyunu ve minimum arayı sığdırmak için çok kısa
 game-block-tight = Dar — takım molaları oyunları zamanlamasının dışına itebilir
-system-will-keep-game-times-spaced = Sistem, oyun başlangıç zamanlarını eşit aralıklı tutmaya çalışır. Bir başlangıçtan diğerine toplam süre 2 × [Devre Uzunluğu] + [Devre Arası Uzunluğu] + [Oyunlar Arası Nominal Süre] şeklindedir (örnek: [Devre Uzunluğu] = 15dk, [Devre Arası Uzunluğu] = 3dk ve [Oyunlar Arası Nominal Süre] = 12dk ise, bir oyunun başlangıcından diğerine kadar geçen süre 45dk olacaktır. Alınan molalar veya diğer saat duraklamaları, oyunlar arası minimum süreye ulaşılana kadar 12dk'yı kısaltacaktır).
 min-break = MİNİMUM ARA
 min-time-btwn-games = Bir oyun planlanandan uzun sürerse, bu sistemin izin vereceği oyunlar arasındaki minimum süredir. Oyunlar geride kalırsa sistem, her zaman bu minimum süreye saygı göstererek sonraki oyunlarda yakalamaya otomatik olarak çalışacaktır.
 pre-ot-break-abreviated = UZATMA ÖNCESİ ARA
@@ -169,7 +160,6 @@ len-of-overtime-halftime = Uzatma devre arasının süresi
 pre-sd-break = ANİ ÖLÜM ÖNCESİ ARA
 pre-sd-len = Önceki oyun dönemi ile Ani Ölüm arasındaki ara süresinin uzunluğu
 language = DİL
-this-language = TÜRKÇE
 portal-login-code = KOD
 portal-login-instructions = Lütfen { $portal } Portal >> Event Management >> Referee Management bölümüne gidin, yeni bir Refbox eklemek için + düğmesine tıklayın ve bu Refbox kimliğini girin:
     { $id }
@@ -177,7 +167,6 @@ portal-login-instructions = Lütfen { $portal } Portal >> Event Management >> Re
     { $portal } Portal bunun üzerine sol taraftaki sayı tuş takımını kullanarak girmeniz için bir onay kodu sağlayacaktır.
     Kodu girdikten sonra Tamam'a basın
 
-help = YARDIM:
 
 # Onay
 game-configuration-can-not-be-changed = Oyun yapılandırması, bir oyun devam ederken değiştirilemez.
@@ -214,24 +203,6 @@ refresh = YENİLE
 refreshing = YENİLENİYOR...
 settings = AYARLAR
 none = Yok
-game-number-error = Hata ({ $game_number })
-next-game-number-error = Hata ({ $next_game_number })
-last-game-next-game = Önceki Oyun: { $prev_game },
-    Sonraki Oyun: { $next_game }
-black-team-white-team = Siyah Takım: { $black_team }
-    Beyaz Takım: { $white_team }
-game-length-ot-allowed = Devre Süresi: { $half_length }
-         Devre Arası Süresi: { $half_time_length }
-         Uzatma İzin Verildi: { $overtime }
-overtime-details = Uzatma Öncesi Ara Süresi: { $pre_overtime }
-             Uzatma Devre Süresi: { $overtime_len }
-             Uzatma Devre Arası Süresi: { $overtime_half_time_len }
-sd-allowed = Ani Ölüm İzin Verildi: { $sd }
-pre-sd = Ani Ölüm Öncesi Ara Süresi: { $pre_sd_len }
-team-to-len = Takım Molası Süresi: { $to_len }
-time-btwn-games = Oyunlar Arası Nominal Süre: { $time_btwn }
-game-block-info = Oyun Bloğu: { $game_block }
-min-brk-btwn-games = Oyunlar Arası Minimum Süre: { $min_brk_time }
 
 
 # Liste Seçiciler
@@ -312,21 +283,8 @@ infraction = İhlal: {$infraction}
 error = Hata ({ $number })
 two-games = Önceki Oyun: { $prev_game },  Sonraki Oyun: { $next_game }
 one-game = Oyun: { $game }
-teams = { -dark-team-name } Takım: { $dark_team }
-    { -light-team-name } Takım: { $light_team }
-game-config = Devre Süresi: { $half_len },  Devre Arası Süresi: { $half_time_len }
-    Ani Ölüm İzin Verildi: { $sd_allowed },  Uzatma İzin Verildi: { $ot_allowed }
-team-timeouts = Takım Molaları: { $value }
 team-timeouts-label = TAKIM
     MOLALARI:
-stop-clock-last-2 = Son 2 Dakikada Saati Durdur: { $stop_clock }
-ref-list = Başhakem: { $chief_ref }
-    Zaman Ayarlayıcı: { $timer }
-    Su Hakemi 1: { $water_ref_1 }
-    Su Hakemi 2: { $water_ref_2 }
-    Su Hakemi 3: { $water_ref_3 }
-team-ref-list = Hakemler: { $ref_team }
-    Zaman/Skor Tutanlar: { $ts_keeper_team }
 unknown = Bilinmiyor
 select-infraction = Seçim yapın
 ## Oyun zamanı düğmesi
@@ -392,7 +350,6 @@ rugby = RAGBİ
 beep-test = BEEP TEST
 
 # Beep-test screen
-beep-test-pre = ÖN
 beep-test-top-time-label = SÜRE
 beep-test-top-level-label = SEVİYE
 beep-test-top-lap-label = TUR
@@ -400,9 +357,6 @@ beep-test-start = BAŞLAT
 beep-test-pause = DURAKLAT
 beep-test-resume = DEVAM ET
 beep-test-reset = SIFIRLA
-beep-test-column-level = SEVİYE
-beep-test-column-count = ADET
-beep-test-column-duration = SÜRE
 beep-test-edit-selected = Seviye { $level }
 beep-test-edit-time = SÜRE
 beep-test-edit-count = ADET
@@ -447,12 +401,6 @@ two-halves = 2 DEVRE
 one-period = 1 PERİYOT
 game-len = OYUN SÜRESİ
 length-of-game-during-regular-play = Normal oyun sırasında oyunun süresi
-
-# Single-period (1 Period) info variants — Game Length, no half-time line
-game-config-single-half = Oyun Süresi: { $half_len }
-    Ani Ölüm İzin Verildi: { $sd_allowed },  Uzatma İzin Verildi: { $ot_allowed }
-game-length-ot-allowed-single-half = Oyun Süresi: { $half_length }
-         Uzatma İzin Verildi: { $overtime }
 
 # Self-update / Updates page
 check-version = Sürümü Denetle

--- a/refbox/translations/zh-CN/refbox.ftl
+++ b/refbox/translations/zh-CN/refbox.ftl
@@ -12,7 +12,6 @@ cancel = 取消
 delete = 删除
 back = 返回
 apply = 应用
-save = 保存
 user-options = 用户选项
 new = 新建
 
@@ -35,8 +34,6 @@ team-timeout-count = 队伍暂停
     次数:
 
 # 警告添加
-team-warning = 队伍
-    警告
 team-warning-line-1 = 队伍
 team-warning-line-2 = 警告
 team-score-line-1 = 队伍
@@ -81,8 +78,6 @@ audible-countdown-for-last-10-seconds = 最后10秒
     声音倒计时
 delay = 延误
 court = 球场：
-single-half = 单节
-    比赛：
 half-length-full = 半场时长：
 game-length = 比赛时长：
 overtime-allowed = 允许
@@ -95,8 +90,6 @@ pre-ot-break-length = 加时前
     休息时长：
 pre-sd-break-length = 突然死亡前
     休息时长：
-nominal-break-between-games = 场间名义
-    休息时间：
 ot-half-length = 加时半场
     时长：
 timeouts-counted-per = 暂停
@@ -151,13 +144,11 @@ half-length = 半场时长
 length-of-half-during-regular-play = 常规比赛中每半场的时长
 half-time-lenght = 中场时长
 length-of-half-time-period = 中场休息阶段的时长
-nom-break = 名义休息
 game-block = 赛程块
 game-block-full = 赛程块：
 game-block-help = 从一场比赛开始到下一场比赛开始所经过的时间
 game-block-too-short = 时间太短，无法容纳比赛加上最短休息
 game-block-tight = 紧张 — 队伍暂停可能导致比赛超出其时段
-system-will-keep-game-times-spaced = 系统将尽量保持比赛开始时间均匀分布，从一场比赛开始到下一场比赛开始的总时间为 2 × [半场时长] + [中场时长] + [名义场间时间]（例如：若[半场时长] = 15分钟、[中场时长] = 3分钟、[名义场间时间] = 12分钟，则从一场比赛开始到下一场的时间为45分钟。任何暂停或其他停钟操作都会缩短这12分钟，直到达到最短场间时间为止）。
 min-break = 最短休息
 min-time-btwn-games = 若比赛超出预定时长，这是系统分配的场间最短时间。若比赛落后于计划，系统将在后续比赛中自动追赶，始终遵守此最短场间时间。
 pre-ot-break-abreviated = 加时前休息
@@ -169,7 +160,6 @@ len-of-overtime-halftime = 加时赛中场休息的时长
 pre-sd-break = 突然死亡前休息
 pre-sd-len = 前一比赛阶段到突然死亡赛之间的休息时长
 language = 语言
-this-language = 中文（简体）
 portal-login-code = 代码
 portal-login-instructions = 请前往{ $portal } Portal >> 赛事管理 >> 裁判管理，点击+按钮添加新的Refbox，并输入此Refbox ID：
     { $id }
@@ -177,7 +167,6 @@ portal-login-instructions = 请前往{ $portal } Portal >> 赛事管理 >> 裁�
     { $portal } Portal随后将提供一个确认码，请使用左侧数字键盘输入。
     输入完成后请按"完成"
 
-help = 帮助：
 
 # 确认
 game-configuration-can-not-be-changed = 比赛进行中无法更改比赛配置。
@@ -214,24 +203,6 @@ refresh = 刷新
 refreshing = 刷新中...
 settings = 设置
 none = 无
-game-number-error = 错误（{ $game_number }）
-next-game-number-error = 错误（{ $next_game_number }）
-last-game-next-game = 上场：{ $prev_game }，
-    下场：{ $next_game }
-black-team-white-team = 黑队：{ $black_team }
-    白队：{ $white_team }
-game-length-ot-allowed = 半场时长：{ $half_length }
-         中场时长：{ $half_time_length }
-         允许加时赛：{ $overtime }
-overtime-details = 加时前休息时长：{ $pre_overtime }
-             加时赛半场时长：{ $overtime_len }
-             加时赛中场时长：{ $overtime_half_time_len }
-sd-allowed = 允许突然死亡：{ $sd }
-pre-sd = 突然死亡前休息时长：{ $pre_sd_len }
-team-to-len = 队伍暂停时长：{ $to_len }
-time-btwn-games = 名义场间时间：{ $time_btwn }
-game-block-info = 比赛块：{ $game_block }
-min-brk-btwn-games = 最短场间时间：{ $min_brk_time }
 
 
 # 列表选择
@@ -312,20 +283,7 @@ infraction = 犯规类型：{$infraction}
 error = 错误（{ $number }）
 two-games = 上场：{ $prev_game }，  下场：{ $next_game }
 one-game = 比赛：{ $game }
-teams = { -dark-team-name }：{ $dark_team }
-    { -light-team-name }：{ $light_team }
-game-config = 半场时长：{ $half_len }，  中场时长：{ $half_time_len }
-    允许突然死亡：{ $sd_allowed }，  允许加时赛：{ $ot_allowed }
-team-timeouts = 队伍暂停：{ $value }
 team-timeouts-label = 队伍暂停：
-stop-clock-last-2 = 最后2分钟停钟：{ $stop_clock }
-ref-list = 主裁判：{ $chief_ref }
-    计时员：{ $timer }
-    水下裁判1：{ $water_ref_1 }
-    水下裁判2：{ $water_ref_2 }
-    水下裁判3：{ $water_ref_3 }
-team-ref-list = 裁判员：{ $ref_team }
-    计时/记分员：{ $ts_keeper_team }
 unknown = 未知
 select-infraction = 请选择
 ## 比赛时间按钮
@@ -391,7 +349,6 @@ rugby = 橄榄球
 beep-test = 蜂鸣测试
 
 # Beep-test screen
-beep-test-pre = 准备
 beep-test-top-time-label = 时间
 beep-test-top-level-label = 级别
 beep-test-top-lap-label = 圈数
@@ -399,9 +356,6 @@ beep-test-start = 开始
 beep-test-pause = 暂停
 beep-test-resume = 继续
 beep-test-reset = 重置
-beep-test-column-level = 级别
-beep-test-column-count = 次数
-beep-test-column-duration = 时长
 beep-test-edit-selected = 级别 { $level }
 beep-test-edit-time = 时间
 beep-test-edit-count = 次数
@@ -446,12 +400,6 @@ two-halves = 2 个半场
 one-period = 1 节
 game-len = 比赛时长
 length-of-game-during-regular-play = 常规比赛中整场比赛的时长
-
-# Single-period (1 Period) info variants — Game Length, no half-time line
-game-config-single-half = 比赛时长：{ $half_len }
-    允许突然死亡：{ $sd_allowed }，  允许加时赛：{ $ot_allowed }
-game-length-ot-allowed-single-half = 比赛时长：{ $half_length }
-         允许加时赛：{ $overtime }
 
 # Self-update / Updates page
 check-version = 检查版本


### PR DESCRIPTION
## What changed

32 pieces of on-screen text that no part of the app uses any more have been deleted, in all 15
languages — 783 lines, 480 dead translated strings. Nothing an operator sees changes.

Each one traces to a screen that was rewritten at some point and left its old wording behind:
the removed referee-list feature, the game-info table rewrite, and the beep-test table redesign.

One section heading is removed with them (`# Single-period (1 Period) info variants`), because
both of its entries were dead. `# Warning Add` is deliberately kept — it sits directly above an
orphan, but it heads a section whose other entries are still live.

## Why

Dead text makes translation work bigger than it needs to be. Every new language means someone
translating 355 strings when only 323 of them can ever appear on screen, and a translator has no
way to tell which is which. It also makes the files harder to search when a wording change is
needed.

## Scope

`refbox/translations/` only — the 15 `.ftl` language files. No code was changed.

## How to verify

**The build passing is the real proof.** Text is looked up through `fl!`, which is checked when
the software is compiled — if a piece of text that the app still uses had been deleted, the build
would fail rather than produce a blank label at a tournament. `just check` passes.

Two further checks, in case the build argument isn't convincing on its own:

- All 323 text keys the code actually uses still have an entry.
- Every language file went from 355 entries to 323, with the same 32 found and removed in each —
  so no language is left inconsistent with the others.

To confirm by eye, run the app and visit the screens whose rewrites left this text behind — the
game info screen and the beep test screen — and check they read correctly, then switch languages
and check one or two others.

**Method note for the reviewer:** an earlier count said 22 keys. That was too low because the
search matched partial words, so a key like `beep-test-pre` was wrongly treated as "still used"
by the unrelated `beep-test-preset-ref`. This used exact matching on the call sites plus
references between translation entries, and confirmed there is no place where a key name is
assembled at runtime.

## Not included

The misspelled key names `abreviat` and `lenght` are left alone. They are live key names, so
correcting them means a coordinated rename across all 15 files — that belongs in its own change.