### PR TITLE
chore(workspace): fix ovetime and recieve typos in log output

### DIFF
--- a/overlay/src/main.rs
+++ b/overlay/src/main.rs
@@ -80,8 +80,8 @@ fn texture_from_image_result(image: network::Image) -> Result<Texture, Box<dyn s
 }
 
 impl State {
-    fn update_state(&mut self, recieved_update: StateUpdate) {
-        match recieved_update {
+    fn update_state(&mut self, received_update: StateUpdate) {
+        match received_update {
             StateUpdate::Snapshot(snapshot) => {
                 if self.snapshot.event_id != snapshot.event_id {
                     info!("Snapshot for new event received: {:?}", snapshot.event_id);
@@ -278,8 +278,8 @@ async fn main() {
         assert!(!net_worker.is_finished(), "Networking thread panikd!");
         clear_background(BLACK);
 
-        if let Ok(recieved_state) = rx.try_recv() {
-            local_state.update_state(recieved_state);
+        if let Ok(received_state) = rx.try_recv() {
+            local_state.update_state(received_state);
             // sync local penalty list
             flag_renderer.synchronize_flags(&local_state);
         }

--- a/overlay/src/network.rs
+++ b/overlay/src/network.rs
@@ -326,7 +326,7 @@ async fn fetch_game_data(
             let text = data
                 .text()
                 .await
-                .expect("Response body could not be recieved!");
+                .expect("Response body could not be received!");
             let data: Value = match serde_json::from_str(text.as_str()) {
                 Ok(d) => d,
                 _ => {
@@ -481,7 +481,7 @@ pub async fn networking_thread(
                     Ok(snapshot) => {
                         debug!("Got snapshot from refbox!");
                         snapshot_tx.send(snapshot.clone()).unwrap_or_else(|e| {
-                            error!("Frontend could not recieve snapshot!: {e}")
+                            error!("Frontend could not receive snapshot!: {e}")
                         });
                     }
                     Err(e) => {
@@ -507,7 +507,7 @@ pub async fn networking_thread(
 
                 state_tx
                     .send(StateUpdate::Snapshot(new_snapshot.clone()))
-                    .unwrap_or_else(|e| error!("Frontend could not recieve snapshot!: {e}"));
+                    .unwrap_or_else(|e| error!("Frontend could not receive snapshot!: {e}"));
 
                 // initial case when no data is initialised
                 if last_snapshot.is_none() {
@@ -558,7 +558,7 @@ pub async fn networking_thread(
                             state_tx
                                 .send(StateUpdate::GameData(next_game_data))
                                 .unwrap_or_else(|e| {
-                                    error!("Frontend could not recieve snapshot!: {e}")
+                                    error!("Frontend could not receive snapshot!: {e}")
                                 });
                         } else if let Some(ref event_id) = new_snapshot.event_id {
                             let game_number = new_snapshot.game_number().clone();
@@ -612,7 +612,7 @@ pub async fn networking_thread(
                                     info!("Sending game data for event: {:?}, game: {}", event_id, game_data.game_number);
                                     state_tx
                                         .send(StateUpdate::GameData(game_data))
-                                        .unwrap_or_else(|e| error!("Frontend could not recieve snapshot!: {e}"));
+                                        .unwrap_or_else(|e| error!("Frontend could not receive snapshot!: {e}"));
                                 } else if let Some(next_game_number) = snapshot.next_game_number() {
                                     if game_data.game_number == *next_game_number {
                                         info!("Saving game data for next game: {} / event: {:?}", next_game_number, event_id);
@@ -645,7 +645,7 @@ pub async fn networking_thread(
                             if event_logos.event_id == *event_id {
                                 state_tx
                                     .send(StateUpdate::EventLogos(event_id.clone(), event_logos))
-                                    .unwrap_or_else(|e| error!("Frontend could not recieve snapshot!: {e}"));
+                                    .unwrap_or_else(|e| error!("Frontend could not receive snapshot!: {e}"));
                             } else {
                                 warn!("Received event logos for event {:?}, but current snapshot is for event {:?}, discarding!", event_logos.event_id, snapshot.event_id);
                             }

--- a/refbox/src/tournament_manager/mod.rs
+++ b/refbox/src/tournament_manager/mod.rs
@@ -1375,7 +1375,7 @@ impl TournamentManager {
                         leave_game_clock_running = false;
                     }
                     (GamePeriod::OvertimeHalfTime, _) => {
-                        info!("{} Entering ovetime second half", self.status_string(now));
+                        info!("{} Entering overtime second half", self.status_string(now));
                         self.current_period = GamePeriod::OvertimeSecondHalf;
                         need_cull = true;
                     }
@@ -1860,7 +1860,7 @@ impl TournamentManager {
                 need_cull = true;
             }
             GamePeriod::OvertimeHalfTime => {
-                info!("{} Entering ovetime second half", self.status_string(now));
+                info!("{} Entering overtime second half", self.status_string(now));
                 self.current_period = GamePeriod::OvertimeSecondHalf;
                 need_cull = true;
             }


### PR DESCRIPTION
## What changed

Two misspelled words that ship in the software's diagnostic output, corrected across three files.

- **`ovetime` → `overtime`**, twice in the game clock. Both are the same log line — *"Entering
  ovetime second half"* — written when a game moves into the second half of overtime. The state
  machine reaches that point by two different routes, and both had the typo.
- **`recieve` → `receive`**, six times in the overlay's network code: five error-log lines saying
  the overlay could not get a snapshot from the refbox, plus one crash message about a response
  body. Four more occurrences in the overlay's main file were variable names rather than message
  text, and are corrected too.

Nothing an operator sees changes. No log levels, message wording, or logic differ — apart from
the two variable renames, the diff changes nothing but the letters inside quotation marks.

## Why

These lines go into the log files. When something goes wrong at a tournament and someone searches
those logs — or the code — for "overtime" or "receive", the misspelled lines don't come back.
That's a small thing right up until it's the line you needed.

## Scope

Three files across two crates, one concern:

- `refbox/src/tournament_manager/mod.rs` — the game clock's two log lines
- `overlay/src/network.rs` — six message strings
- `overlay/src/main.rs` — two local variable names

## How to verify

`just check` passes — formatting, linting on both feature configurations, the full test suite,
and the security audit. Searching every tracked file in the repository for either misspelling now
returns nothing.

Three checks were made before editing, because this reaches into the game clock — the most
sensitive code in the project:

- **No golden trace fixture records these strings.** Those fixtures capture state transitions,
  not log text. Confirmed by searching every tracked file rather than only the source code.
- **No test asserts on either message**, so nothing depended on the misspelling.
- **The variable renames are contained.** `update_state` is an ordinary method on a local struct,
  not part of any shared interface, so both names are private to that one file — and the
  compiler proves it, since the build passes.

**Note for anyone repeating the search:** a plain recursive search returns many more matches.
All the extras are inside `.worktrees/` and `.claude/worktrees/`, which are other checkouts of
this same repository rather than additional source. `git grep` ignores them correctly.

## Not included

The misspellings `abreviat` and `lenght` are left alone — those are live translation key names,
so correcting them needs a coordinated rename across all 15 language files, which belongs in its
own change.