### PR TITLE
chore(refbox): remove dead settings-page gate and lint allows

### DIFF
--- a/refbox/src/app/view_builders/configuration.rs
+++ b/refbox/src/app/view_builders/configuration.rs
@@ -60,9 +60,9 @@ impl EditableSettings {
     /// isn't in the schedule, or the chosen game's court doesn't match the
     /// currently-selected court.
     ///
-    /// Both `apply_game_options` (gating the actual commit) and
-    /// `make_cancel_apply_footer` (disabling Apply when nothing is committable)
-    /// rely on this predicate, so they stay in sync.
+    /// Both `apply_game_options` (gating the actual commit) and the Game page's
+    /// action row in `make_event_config_page` (disabling Apply when nothing is
+    /// committable) rely on this predicate, so they stay in sync.
     pub(in super::super) fn uwhportal_incomplete(&self) -> bool {
         if !self.using_uwhportal {
             return false;
@@ -467,14 +467,11 @@ fn make_cancel_apply_footer<'a>(
     snapshot: Option<&PageEntrySnapshot>,
     game_in_progress: bool,
 ) -> Element<'a, Message> {
-    // Apply is enabled when there are pending changes AND the resulting state is
-    // committable. For Game Options in portal mode, "committable" requires a
-    // complete portal selection (event + court + schedule + game-in-schedule);
-    // otherwise pressing Apply would only open a wasteful "fix something and try
-    // again" dialog. Other pages have no committability gate.
-    let apply_blocked = matches!(page, ConfigPage::Game) && edited.uwhportal_incomplete();
+    // Apply is enabled when there are pending changes. The pages that use this
+    // footer (App, Display, Sound, Remotes) have no committability gate; the
+    // Game page has one but builds its own action row rather than using this.
     let has_changes = page_has_changes(page, edited, snapshot);
-    let apply_enabled = has_changes && !apply_blocked;
+    let apply_enabled = has_changes;
 
     let cancel = make_button(cancel_or_back_label(has_changes))
         .style(red_button)
@@ -591,7 +588,6 @@ fn game_block_validity(cfg: &GameConfig) -> GameBlockValidity {
 }
 
 // View builder takes app-state slices; grouping into a context struct is a separate refactor across all view_builders. Filed as a Findings-Backlog item in AUDIT-PLAN.md (Unit 3, 2026-05-13).
-#[allow(clippy::too_many_arguments)]
 fn make_event_config_page<'a>(
     snapshot: &GameSnapshot,
     settings: &EditableSettings,
@@ -925,9 +921,8 @@ fn make_event_config_page<'a>(
     }
 
     // Action row: Cancel | Game-number picker | Apply.
-    // Apply is blocked when the portal state is incomplete (carried over from
-    // make_cancel_apply_footer's gate so a click on Apply can't reach a
-    // wasteful confirmation dialog).
+    // Apply is blocked when the portal state is incomplete, so a click on Apply
+    // can't reach a wasteful "fix something and try again" dialog.
     let apply_blocked = settings.uwhportal_incomplete();
     // A red (too-short) Game Block is invalid, so APPLY must be disabled until it
     // is widened. Only gate this in portal-OFF mode — that is the only mode that
@@ -965,7 +960,6 @@ fn make_event_config_page<'a>(
     col.into()
 }
 
-#[allow(clippy::too_many_arguments)]
 fn make_app_config_page<'a>(
     mode: Mode,
     snapshot: &GameSnapshot,
@@ -1110,7 +1104,6 @@ fn layout_preview_handle(layout: FrontDisplayLayout, white_on_right: bool) -> im
     image::Handle::from_bytes(bytes)
 }
 
-#[allow(clippy::too_many_arguments)]
 fn make_display_config_page<'a>(
     snapshot: &GameSnapshot,
     settings: &EditableSettings,
@@ -1253,7 +1246,6 @@ fn make_display_config_page<'a>(
     .into()
 }
 
-#[allow(clippy::too_many_arguments)]
 fn make_sound_config_page<'a>(
     snapshot: &GameSnapshot,
     settings: &EditableSettings,
@@ -1819,7 +1811,6 @@ fn font_family_id(lang: Language) -> u8 {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 fn make_buzzer_select_page<'a>(
     snapshot: &GameSnapshot,
     settings: &EditableSettings,


### PR DESCRIPTION
## What changed

Two pieces of dead code removed from the settings screens. Neither is visible to an operator, and
neither can change behaviour.

**An Apply rule that could never fire.** The shared "Cancel / Apply" bar at the bottom of the
settings sub-pages carried a rule saying *"if this is the Game Options page and the portal setup
is incomplete, grey out Apply."* But Game Options does not use that shared bar — it builds its own
action row, because it needs room for the game-number picker between the two buttons. Only four
pages use the shared bar: App, Display, Sound and Remotes. So the Game branch was unreachable.

**Five clippy suppressions that suppressed nothing.** Five functions carried a
`#[allow(clippy::too_many_arguments)]` note despite being under the limit. The sixth, on
`make_remote_config_page`, is kept — at 8 arguments it is the only one that genuinely trips the
lint.

Two comments that named the removed rule are corrected so the file no longer describes a
relationship that does not exist.

## Why

Both make the file mislead the next reader. The gate implies the shared bar serves Game Options;
it does not. And the five unnecessary suppressions would silently hide the warning if someone
later added an eighth argument to one of those functions — which is exactly the moment you would
want to be told.

## Scope

One file: `refbox/src/app/view_builders/configuration.rs`. Nothing else is touched.

## How to verify

`just check` passes — formatting, linting on both feature configurations, the full test suite,
and the security audit.

The two claims were each verified before anything was deleted, rather than taken on faith:

- **The gate is unreachable.** `make_cancel_apply_footer` is private to that file, so its list of
  callers is closed and can be checked exhaustively. All four callers pass a fixed page name —
  `App`, `Display`, `Sound`, `Remotes(..)`. None is `Game`, so the condition is always false.
- **The Game page's own rule is stronger, not equal.** It disables Apply for an incomplete portal
  selection *and* for a Game Block that is too short. So nothing was lost by removing the weaker
  copy — there was never a gap for it to fill.
- **The suppressions were unnecessary.** There is no `clippy.toml` in the repo, so the default
  limit of 7 arguments applies and the warning only fires above it. The five removed sit at 6 or
  7 arguments; the one kept has 8. If any removal had been load-bearing, the linter would have
  failed the build.

By hand: open Settings and visit App, Display, Sound and Remotes — Apply is grey with no pending
edits and green once something is changed. Then open Game Options and confirm Apply still stays
grey while the portal selection is incomplete, or while the Game Block is showing red.

## Noted but deliberately not changed

Two tests near the bottom of the file re-create the Game page's Apply rule by hand, but with only
two of its three conditions — they leave out the Game Block check. They would still pass if that
part of the live rule broke. This is pre-existing and unrelated to the code removed here, so it
is left for its own change rather than widened into this one.