### PR TITLE
chore(refbox): remove dead could_end_game branch and unused ClockState default

### DIFF
--- a/refbox/src/tournament_manager/mod.rs
+++ b/refbox/src/tournament_manager/mod.rs
@@ -1233,29 +1233,11 @@ impl TournamentManager {
             {
                 self.check_time_remaining(now, start_time, time_remaining_at_start)
             } else {
-                if let Some(TimeoutState::RugbyPenaltyShot(ClockState::CountingDown {
-                    start_time,
-                    time_remaining_at_start,
-                })) = self.timeout_state
-                {
-                    if !self.check_time_remaining(now, start_time, time_remaining_at_start)? {
-                        return Ok(false);
-                    } else if let ClockState::Stopped { clock_time } = self.clock_state {
-                        if clock_time.is_zero() {
-                            return Ok(true);
-                        }
-                    }
-                };
-
-                if let ClockState::CountingDown {
-                    start_time,
-                    time_remaining_at_start,
-                } = self.clock_state
-                {
-                    self.check_time_remaining(now, start_time, time_remaining_at_start)
-                } else {
-                    Ok(false)
-                }
+                // The clock is neither counting up (handled above, which always returns) nor
+                // counting down, so it is stopped. The rugby-penalty-shot check above has
+                // already run against this same unchanged state, so repeating it here could
+                // only reach the same non-returning outcome.
+                Ok(false)
             }
         }
     }
@@ -2476,14 +2458,6 @@ enum ClockState {
         start_time: Instant,
         time_at_start: Duration,
     },
-}
-
-impl std::default::Default for ClockState {
-    fn default() -> Self {
-        ClockState::Stopped {
-            clock_time: Duration::default(),
-        }
-    }
 }
 
 impl ClockState {
@@ -7666,6 +7640,45 @@ mod test {
         };
         tm.set_scores(BlackWhiteBundle { black: 4, white: 5 }, start_time);
         assert_eq!(Ok(false), tm.could_end_game(next_time));
+    }
+
+    // Pins the path where the game clock is stopped and a rugby penalty shot's time HAS
+    // elapsed. The assertions above cover the not-yet-elapsed case, which returns early;
+    // this one falls past every early return, so it characterises the tail of
+    // could_end_game.
+    #[test]
+    fn test_could_end_game_stopped_clock_with_elapsed_rugby_penalty_shot() {
+        initialize();
+        let config = GameConfig {
+            overtime_allowed: false,
+            sudden_death_allowed: false,
+            ..Default::default()
+        };
+        let mut tm = TournamentManager::new(config);
+
+        let start_time = Instant::now();
+        let now = start_time + Duration::from_secs(10);
+
+        // SecondHalf so that check_time_remaining can return true at all.
+        tm.current_period = GamePeriod::SecondHalf;
+        tm.set_timeout_state(Some(TimeoutState::RugbyPenaltyShot(
+            ClockState::CountingDown {
+                start_time,
+                time_remaining_at_start: Duration::from_secs(5),
+            },
+        )));
+
+        // Stopped but NOT at zero: the shot's time has elapsed, yet the game cannot end.
+        tm.clock_state = ClockState::Stopped {
+            clock_time: Duration::from_secs(5),
+        };
+        assert_eq!(Ok(false), tm.could_end_game(now));
+
+        // Stopped AT zero is the boundary, and returns true from the earlier check.
+        tm.clock_state = ClockState::Stopped {
+            clock_time: Duration::ZERO,
+        };
+        assert_eq!(Ok(true), tm.could_end_game(now));
     }
 
     #[test]


### PR DESCRIPTION
## What changed

Two dead constructs removed from the game clock, plus the test that proves the first one was dead.

**A duplicated block that could never do anything.** The function deciding *"could the game end
right now?"* ended with a fallback that repeated, word for word, two checks it had already
performed earlier in the same call — and then fell through to "no". About 25 lines, replaced by
the single answer they always produced.

**An unused default value for the clock's internal state.** Never called.

**A new characterization test**, which is the part worth a reviewer's attention.

## Why

Dead code in the most sensitive file in the project is worse than dead code anywhere else,
because it is exactly the code someone will read while trying to understand a timing bug under
pressure. A duplicated block invites the reader to believe there is a case it handles. There is
not.

## Scope

One file: `refbox/src/tournament_manager/mod.rs`.

## How to verify

**This PR asks you to trust an argument about unreachable code, so here is the argument.**

The function takes `&self` and mutates nothing, so every value it reads is fixed for the whole
call, and `check_time_remaining` is pure — it reads only its arguments and `current_period`.

Reaching the removed branch means the game clock is `Stopped`: `ClockState` has exactly three
variants, the `CountingUp` arm above it always returns, and the `CountingDown` pattern just
failed to match. Given that, the repeated timeout check re-evaluates conditions the first copy
already evaluated. An error would have propagated; a false would have returned false; a true with
a zero clock would have returned true. The only way to arrive at the repeat is the one
combination that makes the repeat fall through as well. So the whole branch collapses to `false`.

The `Default` impl is a separate and simpler case: `ClockState` is private to its module, so no
other crate can reach it, nothing holding one implements `Default`, and there is no `mem::take`.
For a private type the compiler settles it — any surviving use would now be a build error, not a
warning. It survived this long because Rust does not flag unused trait implementations.

**The evidence, not just the argument:**

- The new test was written **first and run against the unchanged code, where it passed**, then
  again after the change, where it still passes. The clock gives identical answers to identical
  questions before and after.
- `just check` passes — formatting, linting on both feature configurations, the full suite, and
  the security audit.
- **All 43 golden-trace scenarios pass against unmodified baselines.** These replay recorded
  games through the state machine step by step. The baseline files are checked in and were not
  rewritten by the run, so this is a genuine comparison against previously recorded behaviour
  rather than the suite adopting new behaviour as its new expectation.

**Something the reviewer should know:** the pre-existing `test_could_end_game` looked like it
covered this situation, but it sets up a 20-second rugby penalty shot and then asks 1 second in,
so the shot has not elapsed and the function returns before ever reaching the removed branch.
**Nothing in the suite exercised that code before this PR.** It does now — that is what the new
test is for.

Nothing an operator can see changes. If anything did, that would be a defect in this change.

## Not touched

`refbox/src/beep_test/cadence.rs` contains a separate, identically-named `ClockState` with its
own `Default`. Different type, different file, deliberately left alone.