### PR TITLE
chore(refbox): remove seven unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5378,7 +5378,6 @@ dependencies = [
  "rppal",
  "rust-embed",
  "serde",
- "serde_derive",
  "serde_json",
  "sha2",
  "skip_error",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,21 +1051,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "conquer-once"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d008a441c0f269f36ca13712528069a86a3e60dffee1d98b976eb3b0b2160b4"
-dependencies = [
- "conquer-util",
-]
-
-[[package]]
-name = "conquer-util"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e763eef8846b13b380f37dfecda401770b0ca4e56e95170237bd7c25c7db3582"
-
-[[package]]
 name = "convert_case"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5446,11 +5431,9 @@ dependencies = [
  "clap",
  "collect_array",
  "confy",
- "conquer-once",
  "crc",
  "derivative",
  "directories",
- "dyn-clone",
  "embedded-graphics",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
@@ -5465,9 +5448,6 @@ dependencies = [
  "iced_core",
  "iced_futures",
  "iced_graphics",
- "iced_renderer",
- "iced_runtime",
- "iced_winit",
  "image 0.25.8",
  "led-panel-sim",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,21 +291,10 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener",
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
-]
-
-[[package]]
-name = "async-channel"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
-dependencies = [
- "concurrent-queue",
- "event-listener 2.5.3",
- "futures-core",
 ]
 
 [[package]]
@@ -359,21 +348,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-global-executor"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
-dependencies = [
- "async-channel 2.5.0",
- "async-executor",
- "async-io",
- "async-lock",
- "blocking",
- "futures-lite",
- "once_cell",
-]
-
-[[package]]
 name = "async-io"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,7 +371,7 @@ version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
 ]
@@ -419,14 +393,14 @@ version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
 dependencies = [
- "async-channel 2.5.0",
+ "async-channel",
  "async-io",
  "async-lock",
  "async-signal",
  "async-task",
  "blocking",
  "cfg-if",
- "event-listener 5.4.1",
+ "event-listener",
  "futures-lite",
  "rustix 1.1.2",
 ]
@@ -458,33 +432,6 @@ dependencies = [
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "async-std"
-version = "1.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
-dependencies = [
- "async-channel 1.9.0",
- "async-global-executor",
- "async-io",
- "async-lock",
- "async-process",
- "crossbeam-utils",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-lite",
- "gloo-timers",
- "kv-log-macro",
- "log",
- "memchr",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "slab",
- "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -671,7 +618,7 @@ version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
 dependencies = [
- "async-channel 2.5.0",
+ "async-channel",
  "async-task",
  "futures-io",
  "futures-lite",
@@ -1915,12 +1862,6 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
@@ -1936,7 +1877,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener",
  "pin-project-lite",
 ]
 
@@ -2447,18 +2388,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
-name = "gloo-timers"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "glow"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2917,7 +2846,6 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c04a6745ba2e80f32cf01e034fd00d853aa4f4cd8b91888099cb7aaee0d5d7c"
 dependencies = [
- "async-std",
  "futures",
  "iced_core",
  "log",
@@ -3526,15 +3454,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3697,9 +3616,6 @@ name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
-dependencies = [
- "value-bag",
-]
 
 [[package]]
 name = "log-mdc"
@@ -5446,7 +5362,6 @@ dependencies = [
  "i18n-embed-fl",
  "iced",
  "iced_core",
- "iced_futures",
  "iced_graphics",
  "image 0.25.8",
  "led-panel-sim",
@@ -7316,12 +7231,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "value-bag"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943ce29a8a743eb10d6082545d861b24f9d1b160b7d741e0f2cdf726bec909c5"
-
-[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8395,7 +8304,7 @@ dependencies = [
  "async-trait",
  "blocking",
  "enumflags2",
- "event-listener 5.4.1",
+ "event-listener",
  "futures-core",
  "futures-lite",
  "hex",

--- a/refbox/Cargo.toml
+++ b/refbox/Cargo.toml
@@ -17,10 +17,8 @@ bs58 = "0.5.1"
 clap = { version = "4", features = ["derive"] }
 collect_array = "0.1"
 confy = "1.0"
-conquer-once = "0.4"
 derivative = "2"
 directories = "6"
-dyn-clone = "1.0.19"
 embedded-graphics = "0.8"
 enum-derive-2018 = "3"
 enum-iterator = "2.1.0"
@@ -34,9 +32,6 @@ image = { version = "0.25", default-features = false, features = ["png"] }
 iced_core = "0.13"
 iced_futures = { version = "0.13", features = ["async-std"] }
 iced_graphics = "0.13"
-iced_renderer = "0.13"
-iced_runtime = "0.13"
-iced_winit = "0.13"
 led-panel-sim = { version = "0.4.9", path = "../led-panel-sim" }
 log = "0.4"
 log-panics = { version = "2", features = ["with-backtrace"]}

--- a/refbox/Cargo.toml
+++ b/refbox/Cargo.toml
@@ -30,7 +30,6 @@ i18n-embed-fl = "0.10.0"
 # Already present transitively via iced; pinned to the same major to avoid a new version.
 image = { version = "0.25", default-features = false, features = ["png"] }
 iced_core = "0.13"
-iced_futures = { version = "0.13", features = ["async-std"] }
 iced_graphics = "0.13"
 led-panel-sim = { version = "0.4.9", path = "../led-panel-sim" }
 log = "0.4"

--- a/refbox/Cargo.toml
+++ b/refbox/Cargo.toml
@@ -43,7 +43,6 @@ paste = "1"
 reqwest = { version = "0.12", features = ["json"] }
 rust-embed = "8.7.2"
 serde = "1"
-serde_derive = "1"
 serde_json = "1"
 sha2 = "0.10"
 skip_error = "3"


### PR DESCRIPTION
## What changed

Nothing about how the refbox behaves. Seven entries come out of refbox's list of external
code libraries — libraries the refbox source code never actually uses. Three separate commits,
so any one group can be reverted on its own:

**1. Five that were simply never used** — `conquer-once`, `dyn-clone`, `iced_renderer`,
`iced_runtime`, `iced_winit`.

The three `iced_*` ones stay in the build regardless, because the `iced` user-interface
framework brings them in itself; refbox was just naming them a second time. `conquer-once` was
the only thing pulling itself and a helper library into the build, so those two stop being
compiled.

**2. `iced_futures`** — refbox was asking for this with an "async-std" option switched on.
That option installs a second, alternative engine for running background work. iced's own code
only selects that engine when the tokio engine is *not* chosen, and refbox chooses tokio — so
the alternative engine was being compiled into every build and then never used. Removing it
takes `async-std` and about six supporting libraries out of every build, the Raspberry Pi
included.

**3. `serde_derive`** — dead text. What it provides already reaches refbox through
`uwh-common`.

## Why

Dead weight in three ways: longer build times, more third-party code for the security scan to
cover, and a misleading picture of what the refbox actually depends on. The `iced_futures` entry
is the most worthwhile of the three — roughly seven libraries leave every build.

This came out of the code-quality audit. Worth noting for the reviewer: the audit report had
called two of these unsafe to remove, and both of those claims turned out to be wrong. Each
removal here was re-verified from scratch rather than taken on trust — see "How to verify".

## Scope

Two files: `refbox/Cargo.toml` and `Cargo.lock`. No Rust source changed. No other crate's
dependency list was touched — `cargo machete` also reports findings in `uwh-common`,
`schedule-processor`, `matrix-drawing`, and `wireless-remote`, and all of those are deliberately
left alone here (two of them are false positives, and `uwh-common` is high blast radius and
needs its own change).

## How to verify

1. `just check` — formatting, linter, all tests, and the security scan all pass.
2. `cargo machete` no longer lists `refbox` in its output.
3. The proof that nothing else shifted: for each of the three commits, the complete resolved
   dependency graph — every library in the build and every option switched on in each one, 658
   entries — was compared against `master`, on both the PC architecture and the Raspberry Pi
   architecture. The only differences are the libraries intended to leave. For the third commit
   the graph is byte-for-byte identical to the second, confirming that entry was doing nothing.
4. The one thing worth an eyeball rather than a command: removing `iced_futures` also switched
   some optional settings back off in `log`, the library refbox uses for all of its logging
   (`kv, kv_unstable, value-bag` → just `std`). This was traced and is inert — `log4rs` only
   touches that structured-logging interface behind its own `log_kv` option, which is not enabled
   in this build, and refbox's own code never calls it. To confirm on the hardware: launch the
   refbox, run the clock, and check the log file still fills up normally.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
