### PR TITLE
fix(refbox): show the custom site address on one line

### DIFF
--- a/refbox/src/app/view_builders/configuration.rs
+++ b/refbox/src/app/view_builders/configuration.rs
@@ -897,15 +897,17 @@ fn make_event_config_page<'a>(
                 // The committed address, never the one being typed: an address
                 // that has not been applied is not the address in use, and
                 // showing it here would hide exactly that difference.
+                // "None provided" rather than the "None selected" the rows below
+                // use: those offer a list refbox fetched, while an address is
+                // typed in, so "selected" describes the wrong action.
                 let shown = if committed_site_url.is_empty() {
-                    fl!("none-selected")
+                    fl!("none-provided")
                 } else {
                     committed_site_url.to_string()
                 };
-                make_value_button(
+                make_long_value_button(
                     fl!("custom-site"),
                     shown,
-                    (true, true),
                     Some(Message::ChangeConfigPage(ConfigPage::CustomSite(false))),
                 )
                 .height(Length::Fill)

--- a/refbox/src/app/view_builders/shared_elements.rs
+++ b/refbox/src/app/view_builders/shared_elements.rs
@@ -1341,6 +1341,61 @@ where
     button
 }
 
+/// A value row whose value is long and whose label is short — the custom site's
+/// address is the only one so far.
+///
+/// Two differences from `make_value_button`, both of which a web address needs:
+///
+/// * The shares are reversed, so the value gets the larger one. The 3:2 split
+///   there suits a long label beside a short value (`OT HALF TIME LENGTH: 5:00`);
+///   a four-letter label beside a URL is the same row backwards, and it left
+///   half the row empty while the address wrapped in the remaining third.
+/// * The value shrinks rather than wrapping, because `best_split` breaks after a
+///   `/`. That is right for `1/HALBZEIT` and wrong for an address, where a break
+///   mid-path reads as a character that is not there.
+///
+/// Shares rather than `Shrink` for the value: `FitText::layout` fits to
+/// `limits.max()`, so a `Shrink` value is measured against the whole row and a
+/// long enough address would crowd the label out entirely — the failure the
+/// comment in `make_value_button` records.
+pub(super) fn make_long_value_button<'a, T, U>(
+    first_label: T,
+    second_label: U,
+    message: Option<Message>,
+) -> Button<'a, Message>
+where
+    Message: 'a + Clone,
+    T: IntoFragment<'a>,
+    U: IntoFragment<'a>,
+{
+    let mut button = button(
+        row![
+            fit_text(first_label)
+                .size(MEDIUM_TEXT)
+                .align_x(Horizontal::Left)
+                .width(Length::FillPortion(2))
+                .height(Length::Shrink),
+            fit_text(second_label)
+                .size(MEDIUM_TEXT)
+                .no_wrap()
+                .align_x(Horizontal::Right)
+                .width(Length::FillPortion(3))
+                .height(Length::Shrink),
+        ]
+        .spacing(SPACING)
+        .align_y(Alignment::Center)
+        .padding(PADDING),
+    )
+    .height(Length::Fixed(MIN_BUTTON_SIZE))
+    .width(Length::Fill)
+    .style(light_gray_button);
+
+    if let Some(message) = message {
+        button = button.on_press(message);
+    }
+    button
+}
+
 pub(super) fn make_penalty_dropdown<'a>(
     infraction: Infraction,
     display_infraction_name: bool,

--- a/refbox/translations/de-DE/refbox.ftl
+++ b/refbox/translations/de-DE/refbox.ftl
@@ -41,6 +41,7 @@ team-score-line-2 = TORE
 
 # Konfiguration
 none-selected = Nichts ausgewählt
+none-provided = Nichts angegeben
 loading = Wird geladen...
 game-select = SPIEL:
 game-options = SPIELOPTIONEN

--- a/refbox/translations/en-US/refbox.ftl
+++ b/refbox/translations/en-US/refbox.ftl
@@ -40,6 +40,7 @@ team-score-line-2 = SCORE
 
 # Configuration
 none-selected = None Selected
+none-provided = None Provided
 loading = Loading...
 game-select = GAME:
 game-options = GAME OPTIONS

--- a/refbox/translations/es/refbox.ftl
+++ b/refbox/translations/es/refbox.ftl
@@ -40,6 +40,7 @@ team-score-line-2 = DE EQUIPO
 
 # Configuration
 none-selected = Ninguno seleccionado
+none-provided = Ninguno proporcionado
 loading = Cargando...
 game-select = JUEGO:
 game-options = OPCIONES DE JUEGO

--- a/refbox/translations/fr/refbox.ftl
+++ b/refbox/translations/fr/refbox.ftl
@@ -39,6 +39,7 @@ team-score-line-2 = D'ÉQUIPE
 
 # Configuration
 none-selected = Aucun Sélectionné
+none-provided = Aucun Fourni
 loading = Chargement...
 game-select = MATCH:
 game-options = OPTIONS DU MATCH

--- a/refbox/translations/id-ID/refbox.ftl
+++ b/refbox/translations/id-ID/refbox.ftl
@@ -41,6 +41,7 @@ team-score-line-2 = TIM
 
 # Konfigurasi
 none-selected = Tidak Ada Dipilih
+none-provided = Belum Diisi
 loading = Memuat...
 game-select = PERTANDINGAN:
 game-options = OPSI PERTANDINGAN

--- a/refbox/translations/it-IT/refbox.ftl
+++ b/refbox/translations/it-IT/refbox.ftl
@@ -41,6 +41,7 @@ team-score-line-2 = DI SQUADRA
 
 # Configurazione
 none-selected = Nessuno Selezionato
+none-provided = Nessuno Fornito
 loading = Caricamento...
 game-select = PARTITA:
 game-options = OPZIONI PARTITA

--- a/refbox/translations/ja-JP/refbox.ftl
+++ b/refbox/translations/ja-JP/refbox.ftl
@@ -41,6 +41,7 @@ team-score-line-2 = 得点
 
 # 設定
 none-selected = 未選択
+none-provided = 未入力
 loading = 読込中...
 game-select = 試合:
 game-options = 試合オプション

--- a/refbox/translations/ko-KR/refbox.ftl
+++ b/refbox/translations/ko-KR/refbox.ftl
@@ -43,6 +43,7 @@ team-score-line-2 = 점수
 
 # 설정
 none-selected = 선택 없음
+none-provided = 입력 없음
 loading = 불러오는 중...
 game-select = 경기:
 game-options = 경기 옵션

--- a/refbox/translations/ms-MY/refbox.ftl
+++ b/refbox/translations/ms-MY/refbox.ftl
@@ -41,6 +41,7 @@ team-score-line-2 = PASUKAN
 
 # Konfigurasi
 none-selected = Tiada Dipilih
+none-provided = Belum Diisi
 loading = Memuatkan...
 game-select = PERLAWANAN:
 game-options = PILIHAN PERLAWANAN

--- a/refbox/translations/nl-NL/refbox.ftl
+++ b/refbox/translations/nl-NL/refbox.ftl
@@ -41,6 +41,7 @@ team-score-line-2 = SCORE
 
 # Configuratie
 none-selected = Niets Geselecteerd
+none-provided = Niets Opgegeven
 loading = Laden...
 game-select = WEDSTRIJD:
 game-options = WEDSTRIJDOPTIES

--- a/refbox/translations/pt-PT/refbox.ftl
+++ b/refbox/translations/pt-PT/refbox.ftl
@@ -41,6 +41,7 @@ team-score-line-2 = EQUIPA
 
 # Configuração
 none-selected = Nenhum Selecionado
+none-provided = Nenhum Fornecido
 loading = A carregar...
 game-select = JOGO:
 game-options = OPÇÕES DE JOGO

--- a/refbox/translations/th-TH/refbox.ftl
+++ b/refbox/translations/th-TH/refbox.ftl
@@ -41,6 +41,7 @@ team-score-line-2 = ทีม
 
 # การตั้งค่า
 none-selected = ไม่ได้เลือก
+none-provided = ไม่ได้ระบุ
 loading = กำลังโหลด...
 game-select = เกม:
 game-options = ตัวเลือกเกม

--- a/refbox/translations/tl-PH/refbox.ftl
+++ b/refbox/translations/tl-PH/refbox.ftl
@@ -41,6 +41,7 @@ team-score-line-2 = KOPONAN
 
 # Configuration
 none-selected = Wala na Pinili
+none-provided = Walang Ibinigay
 loading = Naglo-load...
 game-select = LARO:
 game-options = MGA OPSYON SA LARO

--- a/refbox/translations/tr-TR/refbox.ftl
+++ b/refbox/translations/tr-TR/refbox.ftl
@@ -41,6 +41,7 @@ team-score-line-2 = SKORU
 
 # Yapılandırma
 none-selected = Seçim Yok
+none-provided = Belirtilmedi
 loading = Yükleniyor...
 game-select = OYUN:
 game-options = OYUN SEÇENEKLERİ

--- a/refbox/translations/zh-CN/refbox.ftl
+++ b/refbox/translations/zh-CN/refbox.ftl
@@ -41,6 +41,7 @@ team-score-line-2 = 比分
 
 # 设置
 none-selected = 未选择
+none-provided = 未填写
 loading = 加载中...
 game-select = 比赛：
 game-options = 比赛选项


### PR DESCRIPTION
## What changed

Two fixes to the SITE row on the game-source settings page — the row that shows which
site refbox is pointed at when the source is CUSTOM. Both are display-only; nothing about
how refbox talks to a site changes.

1. **The address now shows on one line, at full size.** It used to wrap in the middle of
   the URL path while half the row sat empty beside it, so an operator checking which site
   refbox was pointed at read what looked like a broken address.
2. **With no address applied the row now reads "None Provided".** It used to borrow
   "None Selected" from the pickers above it, which reads as though a choice were pending
   rather than a field left blank. Translated into all 15 languages, each following its
   own capitalisation convention.

## Why

The SITE row is the only place an operator can confirm refbox is pointed at the right
third-party site. A wrapped address is easy to misread — a line break falling mid-path
looks like a character that is not there — which defeats the purpose of showing it.

The wording change is smaller but the same idea: "None Selected" implies the operator has
a choice still to make, when what it actually means is that no address has been entered.

## Scope

Changes are limited to `refbox`: two files under `refbox/src/app/view_builders/`
(`configuration.rs`, `shared_elements.rs`) and the 15 translation files. No shared types,
no wire format, no game logic. The new layout helper is used by this one row only, so no
other button or row on any screen can be affected.

## How to verify

On the settings page, set the game source to CUSTOM.

1. Before entering any address, the SITE row should read `SITE: None Provided` — not
   "None Selected".
2. Open the SITE editor and enter a long address, for example
   `https://a-fairly-long-site-name.example.org/api/1234-A`, then press APPLY.
3. The SITE row should show that address **on a single line**, at the same text size as
   the other rows, with no break anywhere in the path.

Both were confirmed on screen before this was committed. `just check` passes — formatting,
linter, 532 tests and the security scan all clean.

## Note for the reviewer

The layout helper is a *sibling* of the existing `make_value_button` rather than an option
on it, and it deliberately avoids `Length::Shrink` and uses `no_wrap` instead of a new text
fit mode. Both of those alternatives were tried and both fail — a long enough address
squeezes the `SITE:` label out entirely under `Shrink`. The reasoning is recorded in the
helper's own doc comment so it is not re-litigated later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
