### PR TITLE
fix(refbox): keep App settings applied across a mode-switch restart

### DIFF
--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -1498,18 +1498,13 @@ impl RefBoxApp {
         let current_court = edited.current_court.clone();
         let schedule = edited.schedule.clone();
         let mode = edited.mode;
-        let collect_scorer_cap_num = edited.collect_scorer_cap_num;
-        let track_fouls_and_warnings = edited.track_fouls_and_warnings;
-        let show_behind_schedule_time = edited.show_behind_schedule_time;
-        let confirm_score = edited.confirm_score;
-        let audible_countdown = edited.audible_countdown;
-        let hide_time = edited.hide_time;
 
         // Cross-portal Mode change requires explicit confirmation and an app
         // restart. Raise the confirmation before committing any fields so that
         // cancelling rolls back the entire Apply (Option A semantics, matching
         // GameConfigChangedFromApply). The commit happens in the RestartAndApply
-        // branch of the confirmation handler (Task 8 path).
+        // branch of the confirmation handler, which calls the same
+        // `commit_app_toggles` used below so the two cannot drift.
         if crosses_portal(self.config.mode, mode) {
             return Some(ConfirmationKind::PortalTenantSwitch {
                 from_mode: self.config.mode,
@@ -1518,6 +1513,11 @@ impl RefBoxApp {
             });
         }
 
+        // Committed here, while `edited` is still borrowed, so the six toggles
+        // need no per-field locals. `config` and `edited_settings` are disjoint
+        // fields, so this mutable borrow and the immutable one above coexist.
+        let hide_time_changed = commit_app_toggles(&mut self.config, edited);
+
         self.commit_source(source);
         // Route through set_current_event_id so portal_event_id stays in
         // sync (ADR 011 amendment 2026-04-23 dormant-until-linked).
@@ -1525,18 +1525,12 @@ impl RefBoxApp {
         self.current_court = current_court;
         self.schedule = schedule;
         self.config.mode = mode;
-        self.config.collect_scorer_cap_num = collect_scorer_cap_num;
-        self.config.track_fouls_and_warnings = track_fouls_and_warnings;
-        self.config.show_behind_schedule_time = show_behind_schedule_time;
-        self.config.confirm_score = confirm_score;
-        self.config.audible_countdown = audible_countdown;
-        // The "show countdown for last 10 seconds" toggle lives on this App page,
-        // so its commit must happen here. Notify the update server only when it
-        // actually changed. Bounded channel with one message per Apply from the
-        // GUI loop, so it cannot be full; Closed means the update-server task is
-        // gone (application-fatal), matching the other unwrap sites.
-        if self.config.hide_time != hide_time {
-            self.config.hide_time = hide_time;
+        // `hide_time` is mirrored to the update server, which the pure helper
+        // cannot do — so notify here, and only when it actually changed.
+        // Bounded channel with one message per Apply from the GUI loop, so it
+        // cannot be full; Closed means the update-server task is gone
+        // (application-fatal), matching the other unwrap sites.
+        if hide_time_changed {
             self.update_sender
                 .set_hide_time(self.config.hide_time)
                 .unwrap();
@@ -6316,6 +6310,151 @@ mod usable_cap_numbers_tests {
             usable_cap_numbers(&[player(Some(100)), player(Some(255)), player(Some(50))]),
             vec![50]
         );
+    }
+}
+
+/// Copy the six plain `Config` toggles owned by the App Options page out of the
+/// staged edits. Returns `true` when `hide_time` changed, which the live Apply
+/// path has to report to the update server.
+///
+/// A free function shared by both commit paths, rather than a method or two
+/// copies of the field list, because the two paths drifting apart *is* the
+/// defect this exists to prevent: the App page's Apply commits directly, while a
+/// Hockey ↔ Rugby change defers its commit to the `RestartAndApply` confirmation
+/// arm, which for a long time committed only the mode and silently dropped the
+/// rest.
+///
+/// `source`, `mode` and the portal selections are deliberately NOT handled here.
+/// Each carries side effects that differ between the two paths — `commit_source`,
+/// `set_current_event_id`, the portal-queue flush — and needs `&mut self`.
+fn commit_app_toggles(config: &mut Config, edited: &EditableSettings) -> bool {
+    config.collect_scorer_cap_num = edited.collect_scorer_cap_num;
+    config.track_fouls_and_warnings = edited.track_fouls_and_warnings;
+    config.show_behind_schedule_time = edited.show_behind_schedule_time;
+    config.confirm_score = edited.confirm_score;
+    config.audible_countdown = edited.audible_countdown;
+    let hide_time_changed = config.hide_time != edited.hide_time;
+    config.hide_time = edited.hide_time;
+    hide_time_changed
+}
+
+#[cfg(test)]
+mod commit_app_toggles_tests {
+    use super::*;
+
+    /// All six toggles set to the opposite of their `Config` default, so a
+    /// missing assignment cannot pass by coincidence.
+    fn all_flipped() -> EditableSettings {
+        EditableSettings {
+            collect_scorer_cap_num: false,
+            track_fouls_and_warnings: true,
+            show_behind_schedule_time: false,
+            confirm_score: false,
+            audible_countdown: true,
+            hide_time: true,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn all_six_toggles_are_copied() {
+        let mut config = Config::default();
+
+        commit_app_toggles(&mut config, &all_flipped());
+
+        assert!(!config.collect_scorer_cap_num);
+        assert!(config.track_fouls_and_warnings);
+        assert!(!config.show_behind_schedule_time);
+        assert!(!config.confirm_score);
+        assert!(config.audible_countdown);
+        assert!(config.hide_time);
+    }
+
+    #[test]
+    fn all_six_toggles_are_copied_the_other_way() {
+        // Guards against a hardcoded assignment rather than a copy: the same six
+        // fields driven back in the opposite direction.
+        let mut config = Config::default();
+        commit_app_toggles(&mut config, &all_flipped());
+        let edited = EditableSettings::default();
+
+        commit_app_toggles(&mut config, &edited);
+
+        assert_eq!(config.collect_scorer_cap_num, edited.collect_scorer_cap_num);
+        assert_eq!(
+            config.track_fouls_and_warnings,
+            edited.track_fouls_and_warnings
+        );
+        assert_eq!(
+            config.show_behind_schedule_time,
+            edited.show_behind_schedule_time
+        );
+        assert_eq!(config.confirm_score, edited.confirm_score);
+        assert_eq!(config.audible_countdown, edited.audible_countdown);
+        assert_eq!(config.hide_time, edited.hide_time);
+    }
+
+    #[test]
+    fn hide_time_change_is_reported() {
+        let mut config = Config::default();
+        assert!(!config.hide_time, "test assumes the default is off");
+        let edited = EditableSettings {
+            hide_time: true,
+            ..Default::default()
+        };
+
+        assert!(commit_app_toggles(&mut config, &edited));
+    }
+
+    #[test]
+    fn unchanged_hide_time_is_not_reported() {
+        // The live Apply path messages the update server only on a real change.
+        let mut config = Config::default();
+        let edited = EditableSettings {
+            hide_time: config.hide_time,
+            ..Default::default()
+        };
+        assert!(!commit_app_toggles(&mut config, &edited));
+
+        config.hide_time = true;
+        let edited = EditableSettings {
+            hide_time: true,
+            ..Default::default()
+        };
+        assert!(!commit_app_toggles(&mut config, &edited));
+    }
+
+    #[test]
+    fn fields_owned_by_other_paths_are_untouched() {
+        // `mode` and `source` must NOT be committed by this helper. Both have
+        // side effects that differ between the two commit paths — the mode
+        // confirmation and the portal-queue flush — so they stay with the
+        // callers. Adding them here would bypass both.
+        let mut config = Config::default();
+        let mode_before = config.mode;
+        let source_before = config.source;
+        let remembered_before = config.remembered_remote;
+        assert_ne!(
+            mode_before,
+            Mode::Rugby,
+            "test needs an edited mode that differs from the default"
+        );
+        assert_ne!(
+            source_before,
+            GameSource::Portal,
+            "test needs an edited source that differs from the default"
+        );
+        let edited = EditableSettings {
+            mode: Mode::Rugby,
+            source: GameSource::Portal,
+            ..all_flipped()
+        };
+
+        commit_app_toggles(&mut config, &edited);
+
+        assert_eq!(config.mode, mode_before);
+        assert_eq!(config.source, source_before);
+        assert_eq!(config.remembered_remote, remembered_before);
     }
 }
 

--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -1867,24 +1867,74 @@ impl RefBoxApp {
                 AppState::EditGameConfig(ConfigPage::Main)
             }
             ConfirmationOption::RestartAndApply => {
-                // Extract the proposed mode from the in-flight PortalTenantSwitch state.
-                // This arm is only reachable when the app_state is PortalTenantSwitch
-                // (the view builder only offers RestartAndApply for that kind).
-                let to_mode =
+                // Extract the proposed mode and source from the in-flight
+                // PortalTenantSwitch state. This arm is only reachable when the
+                // app_state is PortalTenantSwitch (the view builder only offers
+                // RestartAndApply for that kind).
+                let (to_mode, new_source) =
                     if let AppState::ConfirmationPage(ConfirmationKind::PortalTenantSwitch {
                         to_mode,
+                        source,
                         ..
                     }) = self.app_state
                     {
-                        to_mode
+                        (to_mode, source)
                     } else {
                         unreachable!("RestartAndApply is only offered by PortalTenantSwitch pages")
                     };
+
+                // Capture the committed source BEFORE anything below overwrites
+                // it. The queue flush must be decided on the source the queued
+                // items were created under, not the one being applied — see the
+                // flush comment below.
+                let old_source = self.source;
+
+                // apply_app_options raised this confirmation *before* committing
+                // any field, so that Cancel rolls back the whole Apply. That
+                // makes this arm the only place the operator's App-page edits can
+                // be written, and the restart re-reads config from disk — so
+                // anything skipped here is silently lost. The shared helper is
+                // what keeps this list from drifting from the live Apply path.
+                //
+                // Safety: PortalTenantSwitch is only raised by apply_app_options,
+                // which returns early unless edited_settings is Some, and the
+                // confirmation page offers no action that clears it. Same
+                // invariant as the KeepGameAndApply arm above.
+                let edited = self.edited_settings.as_ref().unwrap();
+                // The "hide_time changed" flag is deliberately dropped: the
+                // update server is told at startup, and this process is about to
+                // be replaced by a fresh one.
+                let _ = commit_app_toggles(&mut self.config, edited);
 
                 // Commit the new mode. The proposed mode was held only in the
                 // ConfirmationKind variant and was never written to self.config, so
                 // this is the first and only write.
                 self.config.mode = to_mode;
+
+                // Commit the source too, mirroring apply_app_options exactly.
+                //
+                // This is a no-op in every state reachable today: the source can
+                // only be changed on the Game page, `edited.source` is seeded
+                // from the committed source on entry, and every exit from a page
+                // either commits it (the Apply path) or reverts it
+                // (CancelConfigPage -> revert_from_snapshot, and the Game
+                // snapshot carries `source`). So it always already equals
+                // `self.source` here. Kept anyway, because dropping it restores
+                // the very asymmetry between the two commit paths that this
+                // helper pairing exists to remove — and it becomes a real loss
+                // the day a source control appears on the App page.
+                //
+                // Safe without repointing the live client for the same reason
+                // the mode is: this arm always ends in a restart, and the restart
+                // rebuilds the client from the committed config. See the repoint
+                // invariant in the ApplyConfigPage handler.
+                //
+                // Read from the confirmation variant rather than from `edited`
+                // above, because that is the value the operator was shown and
+                // confirmed. The two are equal in any case: the confirmation page
+                // offers only Cancel and Restart, so nothing can edit
+                // `edited_settings` while it is up.
+                self.commit_source(new_source);
 
                 // Clear the current event id. This unpins the portal-health background
                 // task from the old tenant's event so it stops probing after restart.
@@ -1894,11 +1944,13 @@ impl RefBoxApp {
                 // tenant cannot be delivered to the new tenant — discard them so the
                 // restarted app starts with a clean queue.
                 //
-                // Only for the built-in portal. A custom site is one address the
-                // operator typed and it does not change with the mode, so results
-                // queued for it are still deliverable to exactly that site after
-                // the restart; flushing them would destroy real game results.
-                if self.source == GameSource::Portal {
+                // Only for the built-in portal, and only for the source the items
+                // were queued under, which is why `old_source` is captured above.
+                // A custom site is one address the operator typed and it does not
+                // change with the mode, so results queued for it are still
+                // deliverable to exactly that site after the restart; flushing
+                // them would destroy real game results.
+                if old_source == GameSource::Portal {
                     if let Err(e) = crate::portal_manager::queue::save(
                         self.portal_manager.queue_dir(),
                         &crate::portal_manager::queue::QueueFile::empty(),
@@ -3667,10 +3719,11 @@ impl RefBoxApp {
                 //      in progress, which `refuse_repoint` has already turned
                 //      back; the fourth requires the incomplete remote state
                 //      that leaves the Game page's APPLY with no press action.
-                //    - The App arm's `PortalTenantSwitch`, which commits
-                //      nothing itself and is safe only because it always ends
-                //      in a restart, and the restart rebuilds the client from
-                //      the committed config.
+                //    - The App arm's `PortalTenantSwitch`, whose
+                //      `RestartAndApply` handler commits the new source without
+                //      repointing the live client, and is safe only because it
+                //      always ends in a restart, and the restart rebuilds the
+                //      client from the committed config.
                 //    - Language/Main/User and the unusable-address exit, where
                 //      no repoint can be pending at all: `pending_site_change`
                 //      answers `None` for those pages, and `site_target`
@@ -6373,9 +6426,18 @@ mod commit_app_toggles_tests {
     #[test]
     fn all_six_toggles_are_copied_the_other_way() {
         // Guards against a hardcoded assignment rather than a copy: the same six
-        // fields driven back in the opposite direction.
+        // fields driven back in the opposite direction. All six start `true` so
+        // that committing an all-default (all-false) EditableSettings has to
+        // change every one of them — starting from `all_flipped()` would leave
+        // three already false, and their assertions would then pass even with
+        // the assignment deleted.
         let mut config = Config::default();
-        commit_app_toggles(&mut config, &all_flipped());
+        config.collect_scorer_cap_num = true;
+        config.track_fouls_and_warnings = true;
+        config.show_behind_schedule_time = true;
+        config.confirm_score = true;
+        config.audible_countdown = true;
+        config.hide_time = true;
         let edited = EditableSettings::default();
 
         commit_app_toggles(&mut config, &edited);
@@ -6425,36 +6487,44 @@ mod commit_app_toggles_tests {
     }
 
     #[test]
-    fn fields_owned_by_other_paths_are_untouched() {
+    fn only_the_six_toggles_are_written() {
         // `mode` and `source` must NOT be committed by this helper. Both have
         // side effects that differ between the two commit paths — the mode
         // confirmation and the portal-queue flush — so they stay with the
         // callers. Adding them here would bypass both.
+        //
+        // Compared whole-struct rather than field by field, so this also fails
+        // if a field is dropped from the helper, or if any other Config field
+        // (game, sound, custom_site, display_mode, ...) is written. Drift
+        // between the two commit paths is the defect the helper exists to
+        // prevent, so the guard is deliberately exhaustive rather than a list
+        // of the fields someone thought to name.
         let mut config = Config::default();
-        let mode_before = config.mode;
-        let source_before = config.source;
-        let remembered_before = config.remembered_remote;
-        assert_ne!(
-            mode_before,
-            Mode::Rugby,
-            "test needs an edited mode that differs from the default"
-        );
-        assert_ne!(
-            source_before,
-            GameSource::Portal,
-            "test needs an edited source that differs from the default"
-        );
         let edited = EditableSettings {
             mode: Mode::Rugby,
             source: GameSource::Portal,
             ..all_flipped()
         };
+        assert_ne!(
+            config.mode, edited.mode,
+            "test needs an edited mode that differs from the default"
+        );
+        assert_ne!(
+            config.source, edited.source,
+            "test needs an edited source that differs from the default"
+        );
+
+        let mut expected = config.clone();
+        expected.collect_scorer_cap_num = edited.collect_scorer_cap_num;
+        expected.track_fouls_and_warnings = edited.track_fouls_and_warnings;
+        expected.show_behind_schedule_time = edited.show_behind_schedule_time;
+        expected.confirm_score = edited.confirm_score;
+        expected.audible_countdown = edited.audible_countdown;
+        expected.hide_time = edited.hide_time;
 
         commit_app_toggles(&mut config, &edited);
 
-        assert_eq!(config.mode, mode_before);
-        assert_eq!(config.source, source_before);
-        assert_eq!(config.remembered_remote, remembered_before);
+        assert_eq!(config, expected);
     }
 }
 


### PR DESCRIPTION
## What changed

Switching the app between Hockey and Rugby used to throw away the App Options settings you
changed at the same time. Only the new mode survived; the six on/off settings on that page
snapped back to what they were before.

Those six are:

- TRACK CAP NUMBER OF SCORER
- TRACK FOULS AND WARNINGS
- CONFIRM SCORE AT GAME END
- SHOW COUNTDOWN FOR LAST 10 SECONDS
- AUDIBLE COUNTDOWN FOR LAST 10 SECONDS
- SHOW BEHIND TIME/DELAY

Now all six are saved along with the mode. Everything else about the mode switch is unchanged:
the confirmation dialog still appears, Cancel still abandons the whole change, and the portal
link is still invalidated exactly as the dialog warns.

## Why

Changing between Hockey and Rugby requires restarting the app, and the restart reloads settings
from disk. The confirmation step deliberately saves nothing up front, so that pressing Cancel
abandons the entire change — but the code that runs after you confirm only ever saved the mode.
Everything else you had just applied was gone once the app reopened.

There was no warning. The dialog mentions only the portal link, so the lost toggles were silent.

This matters because those six settings are precisely the ones an operator changes at the same
time as the sport. Foul-and-warning tracking is one of them, which is a likely explanation for
previous reports of foul icons disappearing after a mode change.

## Scope

One file: `refbox/src/app/mod.rs`. No other crates, no dependency changes, no new settings.

The list of settings to copy now lives in one shared place used by both save paths — the normal
Apply and the restart-after-mode-change. Two separate copies of that list drifting apart is what
caused this bug, so a single shared list is what prevents it recurring.

Three other App Options fields (selected event, court, and schedule) are still deliberately
cleared by a mode switch. That is by design and is what the dialog's portal-link warning refers
to.

## How to verify

1. Open Settings → APP and note the six toggle values.
2. Change several of them **and** tap APP until the mode changes between Hockey 6v6 and Rugby, in
   the same visit to the page.
3. Press APPLY and confirm the restart. The app closes and reopens itself.
4. Go back into Settings → APP.

Expected: the new mode **and** all the toggle values you set. On master, the mode changes but
every toggle reverts.

Also worth checking Cancel still works: make the same edits, press APPLY, then Cancel the dialog.
Nothing should change, including the mode.

This was verified on screen before opening the PR — mode Rugby → Hockey 6v6 with all six toggles
flipped, and all six confirmed held in the saved settings file after the restart.

## Testing honesty

The automated tests cover the shared copying code: they fail if it drops one of the six settings,
and also if it writes any setting it should not. Both directions were checked by deliberately
breaking the code to confirm the tests actually catch it.

What the tests **cannot** cover is the restart path calling that shared code. Confirmation-dialog
handling lives inside the app's main event loop, which is not reachable from unit tests in this
crate. That link is covered by the on-screen walkthrough above, not by CI.

## One correction worth recording

Earlier notes on this bug described **seven** lost fields, including the game source, and the
original audit that raised it said nine. The real number is **six**. The game source cannot be
lost here: it can only be changed on the Game page, and every way of leaving that page either
saves it or discards it, so by the time the App page's APPLY is pressed it always already matches
what is saved. The code still writes it, so that both save paths stay identical — dropping it
would reintroduce exactly the asymmetry this PR removes — but no operator-visible loss was
occurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
