### PR TITLE
fix(refbox): make the connection wording source-neutral

### DIFF
--- a/docs/superpowers/plans/2026-08-12-source-neutral-health-wording.md
+++ b/docs/superpowers/plans/2026-08-12-source-neutral-health-wording.md
@@ -1,0 +1,319 @@
+# Source-Neutral Health Wording Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop refbox telling an operator about "the Portal" on five screens that are really about the connection, so the wording is correct whether the game source is the UWH Portal or a third-party site.
+
+**Architecture:** Text only. Five Fluent string values change in all 15 locales, and two now-unused `portal =` arguments are deleted from their `fl!` call sites. No key is renamed, no key is added or removed, and no behaviour changes.
+
+**Tech Stack:** Rust 2024, Fluent (`.ftl`) translation files, `fl!` macro.
+
+**Spec:** `docs/superpowers/specs/2026-08-12-source-neutral-health-wording-design.md`
+
+**Branch:** `fix/refbox/source-neutral-health-wording`, off `origin/master` at `526fc7c9`. The spec is already committed there at `a0856abe`.
+
+## Global Constraints
+
+- **The five key names do not change.** `portal-advisory-at-game-end`, `portal-summary-title`, `portal-row-token-expired`, `portal-page-attention-info`, `uwhportal-token-no-pending-link` keep their names. Only their values change.
+- **`portal-login-instructions` is out of scope.** Do not touch it. It names the UWH Portal's own menus and needs per-source text, which is a separate job.
+- **The `portal-row-*` siblings are out of scope** (`portal-row-stuck`, `portal-row-pending`, `portal-row-stats-pending`, `portal-row-recent`, `portal-retry-all`). They are already source-neutral.
+- **`portal_name_for_mode` is not touched.** It stays where it is and keeps its nine other call sites.
+- **All 15 locales get real translated text.** No English placeholders, no untranslated key left behind. The exact strings are given verbatim in the tasks below — use them as written.
+- **Every string in this plan is final and approved.** Do not paraphrase, "improve", or re-localise them. String 5 in particular is the human's own literal.
+- **MSRV 1.85, Rust 2024, `-D warnings`.** Unchanged by this work but still enforced by `just check`.
+
+## No test is written for this change — deliberately
+
+This plan departs from the usual test-first cycle, and the reason is recorded so a reviewer does not read it as an oversight:
+
+- The repository has **no translation-coverage test at all** — nothing asserts that a key exists in every locale. This was checked, not assumed.
+- A test that asserts a literal piece of display copy would fail on every future wording tweak while catching nothing a human would not see instantly on screen.
+
+The verification that replaces it is mechanical and is spelled out in each task: a `grep` count that proves every locale was edited and that the word "Portal" is gone from exactly the five keys, plus `just check`, plus an on-screen pass.
+
+## File Structure
+
+**Modified — translations (15 files, same 5 keys in each):**
+
+- `refbox/translations/{de-DE,en-US,es,fr,id-ID,it-IT,ja-JP,ko-KR,ms-MY,nl-NL,pt-PT,th-TH,tl-PH,tr-TR,zh-CN}/refbox.ftl`
+
+**Modified — Rust (2 files, one deleted argument each):**
+
+- `refbox/src/app/view_builders/portal_detail.rs:37-40` — the `portal-summary-title` call.
+- `refbox/src/app/view_builders/portal_attention_action.rs:61-64` — the `portal-page-attention-info` call.
+
+Nothing else needs touching, and this was verified rather than assumed: `mode` stays in use in both files (it is passed to `make_game_time_button`), and both files reach `portal_name_for_mode` through `use super::*;` — Rust does not warn on unused glob imports, so no import needs removing.
+
+---
+
+### Task 1: English strings and the two argument deletions
+
+This is the whole change, visible in English. Doing it in one task means the build proves the Rust edits and the English wording together.
+
+**Files:**
+- Modify: `refbox/translations/en-US/refbox.ftl` (lines 199, 427, 429, 439, 442)
+- Modify: `refbox/src/app/view_builders/portal_detail.rs:37-40`
+- Modify: `refbox/src/app/view_builders/portal_attention_action.rs:61-64`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: the five final English strings, which Task 2 translates. No Rust signature changes, so nothing downstream depends on this beyond the strings themselves.
+
+- [ ] **Step 1: Edit the five English values**
+
+In `refbox/translations/en-US/refbox.ftl`, replace exactly these five lines. Everything else in the file stays untouched.
+
+```ftl
+uwhportal-token-no-pending-link = The connection is not expecting communication.
+    Please try again.
+```
+
+(The `    Please try again.` continuation line already exists with that exact four-space indent — keep it.)
+
+```ftl
+portal-summary-title = CONNECTION STATUS
+portal-row-token-expired = Access token expired — tap to re-login
+portal-page-attention-info = The game result has not been accepted
+portal-advisory-at-game-end = Connection issue detected. Score will still be queued — find an admin to resolve.
+```
+
+Note the em dashes (`—`) in two of these are the character already used throughout the file. Copy them, do not substitute a hyphen.
+
+- [ ] **Step 2: Delete the argument in `portal_detail.rs`**
+
+At `refbox/src/app/view_builders/portal_detail.rs:37`, this:
+
+```rust
+    let title = text(fl!(
+        "portal-summary-title",
+        portal = portal_name_for_mode(mode)
+    ))
+```
+
+becomes this:
+
+```rust
+    let title = text(fl!("portal-summary-title"))
+```
+
+- [ ] **Step 3: Delete the argument in `portal_attention_action.rs`**
+
+At `refbox/src/app/view_builders/portal_attention_action.rs:61`, this:
+
+```rust
+            text(fl!(
+                "portal-page-attention-info",
+                portal = portal_name_for_mode(mode)
+            ))
+            .size(SMALL_PLUS_TEXT),
+```
+
+becomes this:
+
+```rust
+            text(fl!("portal-page-attention-info")).size(SMALL_PLUS_TEXT),
+```
+
+- [ ] **Step 4: Build and confirm it compiles clean**
+
+Run: `cargo build -p refbox`
+Expected: builds with no warnings. If an unused-variable warning names `mode`, stop — that means `make_game_time_button` no longer takes it and the plan's assumption has gone stale; report it rather than deleting the variable.
+
+- [ ] **Step 5: Confirm English no longer says Portal in these five places**
+
+Run:
+
+```bash
+grep -n "portal-advisory-at-game-end\|portal-summary-title\|portal-row-token-expired\|portal-page-attention-info\|uwhportal-token-no-pending-link" refbox/translations/en-US/refbox.ftl
+```
+
+Expected: five lines, none containing the word `Portal` and none containing `{ $portal }`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add refbox/translations/en-US/refbox.ftl refbox/src/app/view_builders/portal_detail.rs refbox/src/app/view_builders/portal_attention_action.rs
+git commit -m "fix(refbox): make the English health wording source-neutral"
+```
+
+---
+
+### Task 2: The remaining 14 locales
+
+**Files:**
+- Modify: the `refbox.ftl` of `de-DE`, `es`, `fr`, `id-ID`, `it-IT`, `ja-JP`, `ko-KR`, `ms-MY`, `nl-NL`, `pt-PT`, `th-TH`, `tl-PH`, `tr-TR`, `zh-CN`
+
+**Interfaces:**
+- Consumes: the five English strings finalised in Task 1.
+- Produces: nothing further depends on this.
+
+Two things to know before starting, both established by reading the files rather than guessed:
+
+1. **Spanish and French do not currently say "portal" in `uwhportal-token-no-pending-link`.** They say "no pending link was found" — a different sentence from the English. They are being retranslated to the new English meaning, not merely having a word removed. That is intended.
+2. **`portal-row-token-expired` must match each language's own `access-token` label**, which is the row the operator lands beside after tapping it. The label values are already in each file; the strings below were written from them.
+
+- [ ] **Step 1: Apply `portal-advisory-at-game-end` in all 14**
+
+```
+de-DE  Verbindungsproblem erkannt. Spielstand wird trotzdem in die Warteschlange gestellt — bitte einen Administrator zur Lösung kontaktieren.
+es     Problema de conexión detectado. El resultado se encolará igualmente — busca a un administrador para resolverlo.
+fr     Problème de connexion détecté. Le résultat sera tout de même mis en file d'attente — trouvez un administrateur pour le résoudre.
+id-ID  Masalah koneksi terdeteksi. Skor tetap akan diantrekan — temui admin untuk menyelesaikan.
+it-IT  Rilevato problema di connessione. Il punteggio sarà comunque accodato — contatta un amministratore.
+ja-JP  接続の問題を検出しました。スコアはキューに残ります — 管理者に解決を依頼してください。
+ko-KR  연결 문제가 감지되었습니다. 점수는 계속 대기열에 있습니다 — 관리자에게 문의하세요.
+ms-MY  Masalah sambungan dikesan. Markah masih akan dibariskan — cari admin untuk selesaikan.
+nl-NL  Verbindingsprobleem gedetecteerd. Score blijft in wachtrij — zoek een beheerder om het op te lossen.
+pt-PT  Problema de ligação detetado. O resultado será mantido em fila — contacte um administrador para resolver.
+th-TH  ตรวจพบปัญหาการเชื่อมต่อ คะแนนจะยังคงอยู่ในคิว — ติดต่อผู้ดูแลเพื่อแก้ไข
+tl-PH  May problema sa koneksyon. Ipipila pa rin ang puntos — humanap ng admin para ayusin.
+tr-TR  Bağlantı sorunu algılandı. Skor yine de sıraya alınacak — çözmek için bir yöneticiye başvurun.
+zh-CN  检测到连接问题。比分仍会排队 — 请联系管理员解决。
+```
+
+- [ ] **Step 2: Apply `portal-summary-title` in all 14**
+
+This is a page title and is upper-case in the Latin-script locales, matching how each file already writes it.
+
+```
+de-DE  VERBINDUNGSSTATUS
+es     ESTADO DE CONEXIÓN
+fr     STATUT DE CONNEXION
+id-ID  STATUS KONEKSI
+it-IT  STATO CONNESSIONE
+ja-JP  接続状態
+ko-KR  연결 상태
+ms-MY  STATUS SAMBUNGAN
+nl-NL  VERBINDINGSSTATUS
+pt-PT  ESTADO DA LIGAÇÃO
+th-TH  สถานะการเชื่อมต่อ
+tl-PH  STATUS NG KONEKSYON
+tr-TR  BAĞLANTI DURUMU
+zh-CN  连接状态
+```
+
+Each of these loses its `{ $portal }` placeholder entirely.
+
+- [ ] **Step 3: Apply `portal-row-token-expired` in all 14**
+
+```
+de-DE  Zugriffstoken abgelaufen — zum erneuten Anmelden tippen
+es     Token de acceso expirado — toca para iniciar sesión
+fr     Jeton d'accès expiré — touchez pour vous reconnecter
+id-ID  Token akses kedaluwarsa — ketuk untuk login ulang
+it-IT  Token di accesso scaduto — tocca per accedere di nuovo
+ja-JP  アクセストークンの有効期限が切れました — タップして再ログイン
+ko-KR  액세스 토큰 만료됨 — 탭하여 다시 로그인
+ms-MY  Token akses tamat tempoh — ketik untuk log masuk semula
+nl-NL  Toegangstoken verlopen — tik om opnieuw in te loggen
+pt-PT  Token de acesso expirou — toque para iniciar sessão novamente
+th-TH  โทเค็นการเข้าถึงหมดอายุ — แตะเพื่อเข้าสู่ระบบใหม่
+tl-PH  Nag-expire ang access token — pindutin para mag-login muli
+tr-TR  Erişim tokeni sona erdi — yeniden giriş için dokunun
+zh-CN  访问令牌已过期 — 点击重新登录
+```
+
+- [ ] **Step 4: Apply `portal-page-attention-info` in all 14**
+
+Each of these loses its `{ $portal }` placeholder and its trailing "on/by … Portal" phrase.
+
+```
+de-DE  Das Spielergebnis wurde nicht angenommen
+es     El resultado del juego no ha sido aceptado
+fr     Le résultat du match n'a pas été accepté
+id-ID  Hasil pertandingan belum diterima
+it-IT  Il risultato della partita non è stato accettato
+ja-JP  試合結果が受理されていません
+ko-KR  경기 결과가 수락되지 않았습니다
+ms-MY  Keputusan perlawanan tidak diterima
+nl-NL  De wedstrijduitslag is niet geaccepteerd
+pt-PT  O resultado do jogo não foi aceite
+th-TH  ผลเกมยังไม่ได้รับการยอมรับ
+tl-PH  Hindi pa tinatanggap ang resulta ng laro
+tr-TR  Oyun sonucu kabul edilmedi
+zh-CN  比赛结果尚未被接受
+```
+
+Note for `fr`: the line being replaced contains a typo, `n.a pas été accepté`. The replacement above spells it `n'a`. That is a correction of the line this change is already rewriting, not separate scope creep.
+
+- [ ] **Step 5: Apply `uwhportal-token-no-pending-link` in all 14**
+
+Each is two lines: the sentence, then the existing continuation line. The continuation text is unchanged from what is already in each file and is repeated here so it is not lost.
+
+**Indentation warning.** The continuation lines are indented further below only so this table lines up on the page. In the file each continuation line takes **exactly four spaces**, matching what is already there and matching the `uwhportal-token-invalid-code` entry directly above it. Fluent treats the indent as significant — getting it wrong changes the rendered text. The safest edit is to replace only the first line of each entry and leave the existing continuation line untouched on disk.
+
+```
+de-DE  Die Verbindung erwartet keine Kommunikation.
+           Bitte erneut versuchen.
+es     La conexión no espera comunicación.
+           Por favor, inténtelo de nuevo.
+fr     La connexion n'attend aucune communication.
+           Veuillez réessayer.
+id-ID  Koneksi tidak mengharapkan komunikasi.
+           Silakan coba lagi.
+it-IT  La connessione non si aspetta comunicazioni.
+           Riprova.
+ja-JP  接続は通信を待っていません。
+           もう一度試してください。
+ko-KR  연결이 통신을 기다리지 않습니다.
+           다시 시도하세요.
+ms-MY  Sambungan tidak menjangka komunikasi.
+           Sila cuba lagi.
+nl-NL  De verbinding verwacht geen communicatie.
+           Probeer het opnieuw.
+pt-PT  A ligação não está à espera de comunicação.
+           Tente novamente.
+th-TH  การเชื่อมต่อไม่รอการสื่อสาร
+           โปรดลองอีกครั้ง
+tl-PH  Hindi inaasahan ng koneksyon ang komunikasyon.
+           Pakisubukan muli.
+tr-TR  Bağlantı iletişim beklemiyor.
+           Lütfen tekrar deneyin.
+zh-CN  连接未等待通信。
+           请重试。
+```
+
+- [ ] **Step 6: Prove every locale was edited and none was missed**
+
+Run:
+
+```bash
+grep -c "portal-advisory-at-game-end\|portal-summary-title\|portal-row-token-expired\|portal-page-attention-info\|uwhportal-token-no-pending-link" refbox/translations/*/refbox.ftl
+```
+
+Expected: **15 files, each reporting `5`.** A file reporting fewer means a key was accidentally renamed or deleted.
+
+Then run:
+
+```bash
+grep -n "Portal\|portal\|{ \$portal }" refbox/translations/*/refbox.ftl | grep "portal-advisory-at-game-end\|portal-summary-title\|portal-row-token-expired\|portal-page-attention-info\|uwhportal-token-no-pending-link"
+```
+
+Expected: **only the key names themselves match** — no line may still contain `{ $portal }`, and no line's *value* may contain the word Portal in any casing.
+
+- [ ] **Step 7: Run the full gate**
+
+Run: `just check`
+Expected: exit 0. Formatting, `-D warnings`, the full test suite and the security scan all clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add refbox/translations/
+git commit -m "fix(refbox): make the health wording source-neutral in all locales"
+```
+
+---
+
+## Final verification, before the PR
+
+- [ ] `just check` exit 0 at the final tree.
+- [ ] `git diff --stat origin/master` shows only the 15 `.ftl` files, the 2 Rust files, and the spec and plan docs. Anything else is scope creep.
+- [ ] On screen, with the game source set to CUSTOM and the stub running: the game-end advisory, the health page title, and the submission-error page all read neutrally.
+- [ ] On screen, with the game source set to UWH PORTAL: the same screens still read correctly. The neutral wording has to be *accurate* there, not merely tolerable.
+
+String 3 (expired access token) and string 5 (no pending link) are the two that need arranging rather than merely observing — string 3 needs a rejected token with an event selected, string 5 needs a link attempt the far end refuses with `NoPendingLink`. If they cannot be produced in reasonable time, say so plainly in the PR rather than implying they were seen.
+
+## Deviations
+
+_Record anything that diverged from this plan here, rather than in standalone commits._

--- a/docs/superpowers/specs/2026-08-12-source-neutral-health-wording-design.md
+++ b/docs/superpowers/specs/2026-08-12-source-neutral-health-wording-design.md
@@ -1,0 +1,103 @@
+# Source-neutral health wording — design
+
+**Date:** 2026-08-12
+**Status:** approved by Eric, not yet implemented
+**Scope:** `refbox` only — 15 translation files and two argument deletions
+
+## The problem
+
+Since the game-source picker merged (PR #2168), an operator can point refbox at a third-party
+site instead of the UWH Portal. Five screens still tell that operator about "the Portal".
+
+The word does not come from the site they chose. `{ $portal }` resolves through
+`portal_name_for_mode`, which returns the **game mode** — `UWH` or `UWR` — so the strings read
+"UWH Portal" no matter what the game source is. Two of the five strings interpolate it; the other
+three hardcode the English word "Portal" outright.
+
+Eric spotted this on the game-end advisory during the post-merge walkthrough.
+
+## The decision
+
+**Drop the word rather than re-parameterise it.** These five strings are about the *connection*,
+so neutral wording is correct for UWH Portal operators too — nobody loses information.
+
+Re-parameterising was considered and rejected: refbox never learns a custom site's name, only the
+address the operator typed. The best it could substitute is a URL, and "has not been accepted on
+`https://your-site/api/1234-A` Portal" is worse than saying nothing.
+
+**Vocabulary — "connection".** All five strings land on "connection" or on plain wording that
+needs no noun for the far end at all.
+
+**Key names do not change.** `portal-summary-title` and the rest stay as they are. Key names are
+never shown to anyone; renaming them would multiply the diff across 15 files and 4 call sites for
+no operator-visible benefit, and would leave the block half-renamed alongside the `portal-row-*`
+siblings this change does not touch.
+
+## The five strings
+
+| # | Key | Where the operator sees it | After |
+|---|-----|---------------------------|-------|
+| 1 | `portal-advisory-at-game-end` | Advisory at game end | **Connection issue detected.** Score will still be queued — find an admin to resolve. |
+| 2 | `portal-summary-title` | Health page title | **CONNECTION STATUS** |
+| 3 | `portal-row-token-expired` | Red row on the health page | **Access token expired — tap to re-login** |
+| 4 | `portal-page-attention-info` | Submission-error page | **The game result has not been accepted** |
+| 5 | `uwhportal-token-no-pending-link` | Failed link attempt | **The connection is not expecting communication.** |
+
+Everything not shown in bold is unchanged. String 1 keeps its second sentence; string 5 keeps its
+existing second line, "Please try again."
+
+Three of these need a note, because the reasoning is not recoverable from the text:
+
+- **String 3 names the access token deliberately.** Tapping that row does not open the login
+  keypad — it lands the operator on the game settings page and leaves them to find the control,
+  which is the row labelled `ACCESS TOKEN:` (renamed from `UWHPORTAL TOKEN:` in PR #2168). Naming
+  the same thing two different ways is the exact confusion this change exists to remove.
+- **String 4 drops its trailing phrase rather than replacing it.** The page it sits on is already
+  titled "Game { $game } submission error", so the sentence does not need to re-establish what
+  failed.
+- **String 5 is Eric's literal**, chosen over the proposed "The game source is not expecting a
+  connection." Implement it exactly as written. Known and accepted: the message appears when the
+  far end has no pending link request — nobody has added this Refbox on the site yet — and neither
+  the old wording nor the new one tells the operator that. Not a regression; out of scope here.
+
+## What is explicitly not in scope
+
+- **`portal-login-instructions`.** It walks the operator through the UWH Portal's own menus
+  (`Event Management >> Referee Management >>` the `+` button), so it needs different text per
+  source, not neutral text. That is gap 15 of the third-party contract document — a separate job.
+- **`{ $portal }` itself and `portal_name_for_mode`.** Both stay exactly as they are; they are
+  still used by other strings.
+- **The `portal-row-*` siblings** (`portal-row-stuck`, `portal-row-pending`,
+  `portal-row-stats-pending`, `portal-row-recent`). They are already source-neutral.
+- **Any behavioural change** to health checks, linking, the queue, or the token indicator.
+
+## Files
+
+**Translations — 5 values × 15 locales.** `refbox/translations/*/refbox.ftl`. Every locale gets
+real translated text, no English placeholders, following each language's own capitalisation
+convention for the block it sits in.
+
+**Rust — two deleted arguments, nothing else.**
+
+- `refbox/src/app/view_builders/portal_detail.rs` — drop `portal = portal_name_for_mode(mode)`
+  from the `portal-summary-title` call.
+- `refbox/src/app/view_builders/portal_attention_action.rs` — drop the same argument from the
+  `portal-page-attention-info` call.
+
+Nothing else in either file needs touching, and this was checked rather than assumed:
+
+- `mode` stays in use in both files — it is passed to `make_game_time_button`.
+- No import needs removing. Both files bring `portal_name_for_mode` in through `use super::*;`,
+  and Rust does not warn on unused glob imports, so `-D warnings` stays satisfied. The function
+  itself remains in use at eight other call sites and is not touched.
+
+## Acceptance criteria
+
+1. With the game source set to CUSTOM, none of the five screens says "Portal".
+2. With the game source set to UWH PORTAL, the same five screens read correctly — the neutral
+   wording is not merely tolerable there, it is accurate.
+3. No locale contains an untranslated English placeholder for the five keys.
+4. `just check` passes: formatting, `-D warnings`, the full test suite, and the security scan.
+
+Strings 1–4 are reachable against the verification stub. String 5 needs a link attempt the far end
+rejects with `NoPendingLink`.

--- a/refbox/src/app/view_builders/portal_attention_action.rs
+++ b/refbox/src/app/view_builders/portal_attention_action.rs
@@ -58,11 +58,7 @@ pub(in super::super) fn build_portal_attention_action<'a>(
 
     let note = container(
         column![
-            text(fl!(
-                "portal-page-attention-info",
-                portal = portal_name_for_mode(mode)
-            ))
-            .size(SMALL_PLUS_TEXT),
+            text(fl!("portal-page-attention-info")).size(SMALL_PLUS_TEXT),
             text(fl!(
                 "portal-page-attention-score",
                 white = white_score,

--- a/refbox/src/app/view_builders/portal_detail.rs
+++ b/refbox/src/app/view_builders/portal_detail.rs
@@ -34,15 +34,12 @@ pub(in super::super) fn build_portal_detail_page<'a>(
         ..
     } = data;
 
-    let title = text(fl!(
-        "portal-summary-title",
-        portal = portal_name_for_mode(mode)
-    ))
-    .height(Length::Fill)
-    .width(Length::Fill)
-    .align_x(Horizontal::Center)
-    .align_y(Vertical::Center)
-    .size(MEDIUM_TEXT);
+    let title = text(fl!("portal-summary-title"))
+        .height(Length::Fill)
+        .width(Length::Fill)
+        .align_x(Horizontal::Center)
+        .align_y(Vertical::Center)
+        .size(MEDIUM_TEXT);
 
     let num_items = rows.len();
 

--- a/refbox/translations/de-DE/refbox.ftl
+++ b/refbox/translations/de-DE/refbox.ftl
@@ -192,7 +192,7 @@ link-locked-game = Während eines laufenden Spiels kann keine Verbindung zur Spi
 source-locked-queue = Es warten noch Spielergebnisse auf den Versand. Senden oder verwerfen Sie diese zuerst.
 uwhportal-token-invalid-code = Ungültiger Code eingegeben.
     Bitte erneut versuchen.
-uwhportal-token-no-pending-link = Portal erwartet keine Verbindung.
+uwhportal-token-no-pending-link = Die Verbindung erwartet keine Kommunikation.
     Bitte erneut versuchen.
 go-back-to-editor = ZURÜCK ZUM EDITOR
 discard-changes = ÄNDERUNGEN VERWERFEN
@@ -393,9 +393,9 @@ false-start = Fehlstart
 
 
 # Portal Health Indicator
-portal-summary-title = { $portal } PORTAL STATUS
+portal-summary-title = VERBINDUNGSSTATUS
 portal-retry-all = ALLE WIEDERHOLEN
-portal-row-token-expired = Portal-Anmeldung abgelaufen — zum erneuten Anmelden tippen
+portal-row-token-expired = Zugriffstoken abgelaufen — zum erneuten Anmelden tippen
 portal-row-stuck = Spiel { $game } Übermittlungsfehler, zum Beheben tippen
 portal-row-pending = Spiel { $game } Spielstand nicht gesendet, zum erneuten Versuch tippen
 portal-row-stats-pending = Spiel { $game } Statistik nicht gesendet, zum erneuten Versuch tippen
@@ -405,10 +405,10 @@ portal-action-force-submit = Dieses Spielergebnis erneut senden
 portal-action-discard = Dieses Spielergebnis verwerfen
 portal-action-discard-confirm = ZUM BESTÄTIGEN DES VERWERFENS ERNEUT TIPPEN
 portal-page-title-attention = Übermittlungsfehler Spiel { $game }
-portal-page-attention-info = Das Spielergebnis wurde vom { $portal } Portal nicht angenommen
+portal-page-attention-info = Das Spielergebnis wurde nicht angenommen
 portal-page-attention-score = Gespeichertes Spielergebnis: Weiß { $white } - Schwarz { $black }
 portal-page-attention-remediation = Sie können erneut versuchen, wenn die Verbindung bestätigt ist, oder verwerfen, um den Fehler zu löschen
-portal-advisory-at-game-end = Portal-Problem erkannt. Spielstand wird trotzdem in die Warteschlange gestellt — bitte einen Administrator zur Lösung kontaktieren.
+portal-advisory-at-game-end = Verbindungsproblem erkannt. Spielstand wird trotzdem in die Warteschlange gestellt — bitte einen Administrator zur Lösung kontaktieren.
 
 # 2 Halves / 1 Period selector (Half Length editor)
 two-halves = 2 HALBZEITEN

--- a/refbox/translations/en-US/refbox.ftl
+++ b/refbox/translations/en-US/refbox.ftl
@@ -195,7 +195,7 @@ link-locked-game = You can not connect to the game source while a game is in pro
 source-locked-queue = Game results are still waiting to be sent. Send or discard them first.
 uwhportal-token-invalid-code = Invalid code entered.
     Please try again.
-uwhportal-token-no-pending-link = Portal not expecting a connection.
+uwhportal-token-no-pending-link = The connection is not expecting communication.
     Please try again.
 go-back-to-editor = GO BACK TO EDITOR
 discard-changes = DISCARD CHANGES
@@ -423,9 +423,9 @@ free-arm = Free Arm
 false-start = False Start
 
 # Portal Health Indicator
-portal-summary-title = { $portal } PORTAL STATUS
+portal-summary-title = CONNECTION STATUS
 portal-retry-all = RETRY ALL
-portal-row-token-expired = Portal login expired — tap to re-login
+portal-row-token-expired = Access token expired — tap to re-login
 portal-row-stuck = Game { $game } Score send error, tap to fix
 portal-row-pending = Game { $game } Score not sent, tap to retry
 portal-row-stats-pending = Game { $game } Stats not sent, tap to retry
@@ -435,10 +435,10 @@ portal-action-force-submit = Retry this game result
 portal-action-discard = Discard this game result
 portal-action-discard-confirm = TAP AGAIN TO CONFIRM DISCARD
 portal-page-title-attention = Game { $game } submission error
-portal-page-attention-info = The game result has not been accepted on { $portal } Portal
+portal-page-attention-info = The game result has not been accepted
 portal-page-attention-score = Stored game result: Light { $white } - Dark { $black }
 portal-page-attention-remediation = You can Retry if connection is verified, or discard to clear the error
-portal-advisory-at-game-end = Portal issue detected. Score will still be queued — find an admin to resolve.
+portal-advisory-at-game-end = Connection issue detected. Score will still be queued — find an admin to resolve.
 
 # 2 Halves / 1 Period selector (Half Length editor)
 two-halves = 2 HALVES

--- a/refbox/translations/es/refbox.ftl
+++ b/refbox/translations/es/refbox.ftl
@@ -203,7 +203,7 @@ source-locked-queue = Todavía hay resultados de juegos esperando a ser enviados
 uwhportal-token-invalid-code = Código inválido.
     Por favor, inténtelo de nuevo.
 ### Check
-uwhportal-token-no-pending-link = No se encontró ningún enlace pendiente.
+uwhportal-token-no-pending-link = La conexión no espera comunicación.
     Por favor, inténtelo de nuevo.
 go-back-to-editor = VOLVER AL EDITOR
 discard-changes = DESCARTAR CAMBIOS
@@ -405,9 +405,9 @@ false-start = Saque nulo
 
 
 # Portal Health Indicator
-portal-summary-title = ESTADO DE { $portal } PORTAL
+portal-summary-title = ESTADO DE CONEXIÓN
 portal-retry-all = REINTENTAR TODO
-portal-row-token-expired = Sesión del portal expirada — toca para iniciar sesión
+portal-row-token-expired = Token de acceso expirado — toca para iniciar sesión
 portal-row-stuck = Juego { $game } · Error al enviar resultado, toca para corregir
 portal-row-pending = Juego { $game } · Resultado no enviado, toca para reintentar
 portal-row-stats-pending = Juego { $game } · Estadísticas no enviadas, toca para reintentar
@@ -417,10 +417,10 @@ portal-action-force-submit = Reintentar este resultado
 portal-action-discard = Descartar este resultado
 portal-action-discard-confirm = TOCA DE NUEVO PARA CONFIRMAR DESCARTE
 portal-page-title-attention = Juego { $game } · Error de envío
-portal-page-attention-info = El resultado del juego no ha sido aceptado por { $portal } Portal
+portal-page-attention-info = El resultado del juego no ha sido aceptado
 portal-page-attention-score = Resultado almacenado: Claro { $white } - Oscuro { $black }
 portal-page-attention-remediation = Puedes Reintentar si la conexión está verificada, o descartar para borrar el error
-portal-advisory-at-game-end = Problema del portal detectado. El resultado se encolará igualmente — busca a un administrador para resolverlo.
+portal-advisory-at-game-end = Problema de conexión detectado. El resultado se encolará igualmente — busca a un administrador para resolverlo.
 
 # 2 Halves / 1 Period selector (Half Length editor)
 two-halves = 2 MITADES

--- a/refbox/translations/fr/refbox.ftl
+++ b/refbox/translations/fr/refbox.ftl
@@ -196,7 +196,7 @@ source-locked-queue = Des résultats de match attendent encore d'être envoyés.
 uwhportal-token-invalid-code = Code invalide.
     Veuillez réessayer.
 ### Check
-uwhportal-token-no-pending-link = Aucun lien en attente trouvé.
+uwhportal-token-no-pending-link = La connexion n'attend aucune communication.
     Veuillez réessayer.
 go-back-to-editor = RETOURNER À L'ÉDITEUR
 discard-changes = ANNULER LES MODIFICATIONS
@@ -397,9 +397,9 @@ false-start = Faux départs
 
 
 # Portal Health Indicator
-portal-summary-title = STATUT { $portal } PORTAL
+portal-summary-title = STATUT DE CONNEXION
 portal-retry-all = TOUT RÉESSAYER
-portal-row-token-expired = Session du portail expirée — touchez pour vous reconnecter
+portal-row-token-expired = Jeton d'accès expiré — touchez pour vous reconnecter
 portal-row-stuck = Match { $game } · Erreur d'envoi du résultat, touchez pour corriger
 portal-row-pending = Match { $game } · Résultat non envoyé, touchez pour réessayer
 portal-row-stats-pending = Match { $game } · Statistiques non envoyées, touchez pour réessayer
@@ -409,10 +409,10 @@ portal-action-force-submit = Réessayer ce résultat
 portal-action-discard = Supprimer ce résultat
 portal-action-discard-confirm = TOUCHEZ À NOUVEAU POUR CONFIRMER LA SUPPRESSION
 portal-page-title-attention = Match { $game } · Erreur d'envoi
-portal-page-attention-info = Le résultat du match n.a pas été accepté par { $portal } Portal
+portal-page-attention-info = Le résultat du match n'a pas été accepté
 portal-page-attention-score = Résultat stocké : Clair { $white } - Foncé { $black }
 portal-page-attention-remediation = Vous pouvez Réessayer si la connexion est vérifiée, ou supprimer pour effacer l'erreur
-portal-advisory-at-game-end = Problème du portail détecté. Le résultat sera tout de même mis en file d'attente — trouvez un administrateur pour le résoudre.
+portal-advisory-at-game-end = Problème de connexion détecté. Le résultat sera tout de même mis en file d'attente — trouvez un administrateur pour le résoudre.
 
 # 2 Halves / 1 Period selector (Half Length editor)
 two-halves = 2 PÉRIODES

--- a/refbox/translations/id-ID/refbox.ftl
+++ b/refbox/translations/id-ID/refbox.ftl
@@ -192,7 +192,7 @@ link-locked-game = Tidak dapat terhubung ke sumber pertandingan saat pertandinga
 source-locked-queue = Masih ada hasil pertandingan yang menunggu untuk dikirim. Kirim atau buang terlebih dahulu.
 uwhportal-token-invalid-code = Kode yang dimasukkan tidak valid.
     Silakan coba lagi.
-uwhportal-token-no-pending-link = Portal tidak mengharapkan koneksi.
+uwhportal-token-no-pending-link = Koneksi tidak mengharapkan komunikasi.
     Silakan coba lagi.
 go-back-to-editor = KEMBALI KE EDITOR
 discard-changes = BUANG PERUBAHAN
@@ -393,9 +393,9 @@ false-start = Start Curang
 
 
 # Portal Health Indicator
-portal-summary-title = STATUS { $portal } PORTAL
+portal-summary-title = STATUS KONEKSI
 portal-retry-all = ULANGI SEMUA
-portal-row-token-expired = Login Portal kedaluwarsa — ketuk untuk login ulang
+portal-row-token-expired = Token akses kedaluwarsa — ketuk untuk login ulang
 portal-row-stuck = Pertandingan { $game } Galat kirim skor, ketuk untuk perbaiki
 portal-row-pending = Pertandingan { $game } Skor belum terkirim, ketuk untuk coba lagi
 portal-row-stats-pending = Pertandingan { $game } Statistik belum terkirim, ketuk untuk coba lagi
@@ -405,10 +405,10 @@ portal-action-force-submit = Coba lagi kirim hasil pertandingan ini
 portal-action-discard = Buang hasil pertandingan ini
 portal-action-discard-confirm = KETUK LAGI UNTUK KONFIRMASI BUANG
 portal-page-title-attention = Galat pengiriman Pertandingan { $game }
-portal-page-attention-info = Hasil pertandingan belum diterima oleh { $portal } Portal
+portal-page-attention-info = Hasil pertandingan belum diterima
 portal-page-attention-score = Hasil pertandingan tersimpan: Putih { $white } - Hitam { $black }
 portal-page-attention-remediation = Anda dapat Coba Lagi jika koneksi sudah terverifikasi, atau buang untuk menghapus galat
-portal-advisory-at-game-end = Masalah Portal terdeteksi. Skor tetap akan diantrekan — temui admin untuk menyelesaikan.
+portal-advisory-at-game-end = Masalah koneksi terdeteksi. Skor tetap akan diantrekan — temui admin untuk menyelesaikan.
 
 # 2 Halves / 1 Period selector (Half Length editor)
 two-halves = 2 BABAK

--- a/refbox/translations/it-IT/refbox.ftl
+++ b/refbox/translations/it-IT/refbox.ftl
@@ -192,7 +192,7 @@ link-locked-game = Non è possibile connettersi all'origine delle partite mentre
 source-locked-queue = Ci sono ancora risultati di partite in attesa di essere inviati. Inviali o eliminali prima di procedere.
 uwhportal-token-invalid-code = Codice inserito non valido.
     Riprova.
-uwhportal-token-no-pending-link = Il portale non si aspetta una connessione.
+uwhportal-token-no-pending-link = La connessione non si aspetta comunicazioni.
     Riprova.
 go-back-to-editor = TORNA ALL'EDITOR
 discard-changes = SCARTA MODIFICHE
@@ -393,9 +393,9 @@ false-start = Falsa Partenza
 
 
 # Portal Health Indicator
-portal-summary-title = STATO PORTALE { $portal }
+portal-summary-title = STATO CONNESSIONE
 portal-retry-all = RIPROVA TUTTO
-portal-row-token-expired = Sessione Portale scaduta — tocca per accedere di nuovo
+portal-row-token-expired = Token di accesso scaduto — tocca per accedere di nuovo
 portal-row-stuck = Partita { $game } Errore invio punteggio, tocca per correggere
 portal-row-pending = Partita { $game } Punteggio non inviato, tocca per riprovare
 portal-row-stats-pending = Partita { $game } Statistiche non inviate, tocca per riprovare
@@ -405,10 +405,10 @@ portal-action-force-submit = Riprova questo risultato
 portal-action-discard = Scarta questo risultato
 portal-action-discard-confirm = TOCCA DI NUOVO PER CONFERMARE LO SCARTO
 portal-page-title-attention = Errore invio Partita { $game }
-portal-page-attention-info = Il risultato della partita non è stato accettato dal Portale { $portal }
+portal-page-attention-info = Il risultato della partita non è stato accettato
 portal-page-attention-score = Risultato memorizzato: Bianco { $white } - Nero { $black }
 portal-page-attention-remediation = Puoi Riprovare se la connessione è verificata, oppure scartare per annullare l'errore
-portal-advisory-at-game-end = Rilevato problema con il Portale. Il punteggio sarà comunque accodato — contatta un amministratore.
+portal-advisory-at-game-end = Rilevato problema di connessione. Il punteggio sarà comunque accodato — contatta un amministratore.
 
 # 2 Halves / 1 Period selector (Half Length editor)
 two-halves = 2 TEMPI

--- a/refbox/translations/ja-JP/refbox.ftl
+++ b/refbox/translations/ja-JP/refbox.ftl
@@ -192,7 +192,7 @@ link-locked-game = 試合進行中は試合データの取得元に接続でき�
 source-locked-queue = 送信待ちの試合結果があります。先に送信するか破棄してください。
 uwhportal-token-invalid-code = 無効なコードが入力されました。
     もう一度試してください。
-uwhportal-token-no-pending-link = ポータルは接続を待っていません。
+uwhportal-token-no-pending-link = 接続は通信を待っていません。
     もう一度試してください。
 go-back-to-editor = 編集画面に戻る
 discard-changes = 変更を破棄
@@ -393,9 +393,9 @@ false-start = 不正スタート
 
 
 # Portal Health Indicator
-portal-summary-title = { $portal } PORTAL 状態
+portal-summary-title = 接続状態
 portal-retry-all = すべて再試行
-portal-row-token-expired = ポータルのログインが期限切れです — タップして再ログイン
+portal-row-token-expired = アクセストークンの有効期限が切れました — タップして再ログイン
 portal-row-stuck = 試合 { $game } のスコア送信エラー、タップして修正
 portal-row-pending = 試合 { $game } のスコアが未送信、タップして再試行
 portal-row-stats-pending = 試合 { $game } の統計が未送信、タップして再試行
@@ -405,10 +405,10 @@ portal-action-force-submit = この試合結果を再送信
 portal-action-discard = この試合結果を破棄
 portal-action-discard-confirm = もう一度タップして破棄を確定
 portal-page-title-attention = 試合 { $game } の送信エラー
-portal-page-attention-info = 試合結果が { $portal } ポータルに受理されていません
+portal-page-attention-info = 試合結果が受理されていません
 portal-page-attention-score = 保存された試合結果: 白 { $white } - 黒 { $black }
 portal-page-attention-remediation = 接続が確認できれば再送信、またはエラーをクリアするには破棄してください
-portal-advisory-at-game-end = ポータルの問題を検出しました。スコアはキューに残ります — 管理者に解決を依頼してください。
+portal-advisory-at-game-end = 接続の問題を検出しました。スコアはキューに残ります — 管理者に解決を依頼してください。
 
 # 2 Halves / 1 Period selector (Half Length editor)
 two-halves = 2ハーフ

--- a/refbox/translations/ko-KR/refbox.ftl
+++ b/refbox/translations/ko-KR/refbox.ftl
@@ -194,7 +194,7 @@ link-locked-game = 경기 진행 중에는 경기 출처에 연결할 수 없습
 source-locked-queue = 아직 전송되지 않은 경기 결과가 있습니다. 먼저 전송하거나 삭제하세요.
 uwhportal-token-invalid-code = 잘못된 코드가 입력되었습니다.
     다시 시도하세요.
-uwhportal-token-no-pending-link = Portal이 연결을 기다리지 않습니다.
+uwhportal-token-no-pending-link = 연결이 통신을 기다리지 않습니다.
     다시 시도하세요.
 go-back-to-editor = 편집기로 돌아가기
 discard-changes = 변경 사항 버리기
@@ -395,9 +395,9 @@ false-start = 부정 출발
 
 
 # Portal Health Indicator
-portal-summary-title = { $portal } PORTAL 상태
+portal-summary-title = 연결 상태
 portal-retry-all = 모두 재시도
-portal-row-token-expired = Portal 로그인 만료됨 — 탭하여 다시 로그인
+portal-row-token-expired = 액세스 토큰 만료됨 — 탭하여 다시 로그인
 portal-row-stuck = 경기 { $game } 점수 전송 오류, 탭하여 수정
 portal-row-pending = 경기 { $game } 점수 전송 안 됨, 탭하여 재시도
 portal-row-stats-pending = 경기 { $game } 통계 전송 안 됨, 탭하여 재시도
@@ -407,10 +407,10 @@ portal-action-force-submit = 이 경기 결과 재시도
 portal-action-discard = 이 경기 결과 버리기
 portal-action-discard-confirm = 버리기 확인을 위해 다시 탭하세요
 portal-page-title-attention = 경기 { $game } 전송 오류
-portal-page-attention-info = 경기 결과가 { $portal } Portal에서 수락되지 않았습니다
+portal-page-attention-info = 경기 결과가 수락되지 않았습니다
 portal-page-attention-score = 저장된 경기 결과: 흰 { $white } - 검정 { $black }
 portal-page-attention-remediation = 연결이 확인되면 재시도하거나, 오류를 지우려면 버리기를 선택하세요
-portal-advisory-at-game-end = Portal 문제가 감지되었습니다. 점수는 계속 대기열에 있습니다 — 관리자에게 문의하세요.
+portal-advisory-at-game-end = 연결 문제가 감지되었습니다. 점수는 계속 대기열에 있습니다 — 관리자에게 문의하세요.
 
 # 2 Halves / 1 Period selector (Half Length editor)
 two-halves = 2 하프

--- a/refbox/translations/ms-MY/refbox.ftl
+++ b/refbox/translations/ms-MY/refbox.ftl
@@ -192,7 +192,7 @@ link-locked-game = Tidak boleh menyambung ke sumber perlawanan semasa perlawanan
 source-locked-queue = Masih ada keputusan perlawanan yang menunggu untuk dihantar. Hantar atau buang dahulu.
 uwhportal-token-invalid-code = Kod yang dimasukkan tidak sah.
     Sila cuba lagi.
-uwhportal-token-no-pending-link = Portal tidak menjangka sambungan.
+uwhportal-token-no-pending-link = Sambungan tidak menjangka komunikasi.
     Sila cuba lagi.
 go-back-to-editor = KEMBALI KE EDITOR
 discard-changes = BUANG PERUBAHAN
@@ -393,9 +393,9 @@ false-start = Permulaan Palsu
 
 
 # Portal Health Indicator
-portal-summary-title = STATUS PORTAL { $portal }
+portal-summary-title = STATUS SAMBUNGAN
 portal-retry-all = CUBA SEMULA SEMUA
-portal-row-token-expired = Log masuk portal tamat tempoh — ketik untuk log masuk semula
+portal-row-token-expired = Token akses tamat tempoh — ketik untuk log masuk semula
 portal-row-stuck = Perlawanan { $game } Ralat hantar markah, ketik untuk perbaiki
 portal-row-pending = Perlawanan { $game } Markah belum dihantar, ketik untuk cuba semula
 portal-row-stats-pending = Perlawanan { $game } Statistik belum dihantar, ketik untuk cuba semula
@@ -405,10 +405,10 @@ portal-action-force-submit = Cuba semula keputusan perlawanan ini
 portal-action-discard = Buang keputusan perlawanan ini
 portal-action-discard-confirm = KETIK SEKALI LAGI UNTUK SAHKAN BUANG
 portal-page-title-attention = Ralat penghantaran perlawanan { $game }
-portal-page-attention-info = Keputusan perlawanan tidak diterima di Portal { $portal }
+portal-page-attention-info = Keputusan perlawanan tidak diterima
 portal-page-attention-score = Keputusan perlawanan disimpan: Putih { $white } - Hitam { $black }
 portal-page-attention-remediation = Anda boleh Cuba Semula jika sambungan disahkan, atau buang untuk membersihkan ralat
-portal-advisory-at-game-end = Masalah portal dikesan. Markah masih akan dibariskan — cari admin untuk selesaikan.
+portal-advisory-at-game-end = Masalah sambungan dikesan. Markah masih akan dibariskan — cari admin untuk selesaikan.
 
 # 2 Halves / 1 Period selector (Half Length editor)
 two-halves = 2 SEPARUH

--- a/refbox/translations/nl-NL/refbox.ftl
+++ b/refbox/translations/nl-NL/refbox.ftl
@@ -192,7 +192,7 @@ link-locked-game = Er kan geen verbinding met de wedstrijdbron worden gemaakt te
 source-locked-queue = Er wachten nog wedstrijduitslagen om verzonden te worden. Verzend of verwijder deze eerst.
 uwhportal-token-invalid-code = Ongeldige code ingevoerd.
     Probeer het opnieuw.
-uwhportal-token-no-pending-link = Portaal verwacht geen verbinding.
+uwhportal-token-no-pending-link = De verbinding verwacht geen communicatie.
     Probeer het opnieuw.
 go-back-to-editor = TERUG NAAR EDITOR
 discard-changes = WIJZIGINGEN VERWERPEN
@@ -393,9 +393,9 @@ false-start = Vals Vertrek
 
 
 # Portal Health Indicator
-portal-summary-title = { $portal } PORTAALSTATUS
+portal-summary-title = VERBINDINGSSTATUS
 portal-retry-all = ALLES OPNIEUW
-portal-row-token-expired = Portaal-login verlopen — tik om opnieuw in te loggen
+portal-row-token-expired = Toegangstoken verlopen — tik om opnieuw in te loggen
 portal-row-stuck = Wedstrijd { $game } Fout bij verzenden score, tik om te herstellen
 portal-row-pending = Wedstrijd { $game } Score niet verzonden, tik om opnieuw te proberen
 portal-row-stats-pending = Wedstrijd { $game } Statistieken niet verzonden, tik om opnieuw te proberen
@@ -405,10 +405,10 @@ portal-action-force-submit = Deze wedstrijduitslag opnieuw proberen
 portal-action-discard = Deze wedstrijduitslag verwerpen
 portal-action-discard-confirm = TIK NOGMAALS OM VERWERPEN TE BEVESTIGEN
 portal-page-title-attention = Wedstrijd { $game } verzendfout
-portal-page-attention-info = De wedstrijduitslag is niet geaccepteerd op { $portal } Portaal
+portal-page-attention-info = De wedstrijduitslag is niet geaccepteerd
 portal-page-attention-score = Opgeslagen wedstrijduitslag: Licht { $white } - Donker { $black }
 portal-page-attention-remediation = U kunt Opnieuw proberen als de verbinding is geverifieerd, of verwerpen om de fout te wissen
-portal-advisory-at-game-end = Portaalprobleem gedetecteerd. Score blijft in wachtrij — zoek een beheerder om het op te lossen.
+portal-advisory-at-game-end = Verbindingsprobleem gedetecteerd. Score blijft in wachtrij — zoek een beheerder om het op te lossen.
 
 # 2 Halves / 1 Period selector (Half Length editor)
 two-halves = 2 HELFTEN

--- a/refbox/translations/pt-PT/refbox.ftl
+++ b/refbox/translations/pt-PT/refbox.ftl
@@ -192,7 +192,7 @@ link-locked-game = Não é possível ligar à origem dos jogos enquanto um jogo 
 source-locked-queue = Ainda há resultados de jogos à espera de serem enviados. Envie-os ou elimine-os primeiro.
 uwhportal-token-invalid-code = Código introduzido inválido.
     Tente novamente.
-uwhportal-token-no-pending-link = O portal não está à espera de uma ligação.
+uwhportal-token-no-pending-link = A ligação não está à espera de comunicação.
     Tente novamente.
 go-back-to-editor = VOLTAR AO EDITOR
 discard-changes = DESCARTAR ALTERAÇÕES
@@ -393,9 +393,9 @@ false-start = Saída Falsa
 
 
 # Portal Health Indicator
-portal-summary-title = ESTADO DO PORTAL { $portal }
+portal-summary-title = ESTADO DA LIGAÇÃO
 portal-retry-all = REPETIR TUDO
-portal-row-token-expired = Sessão do portal expirou — toque para iniciar sessão novamente
+portal-row-token-expired = Token de acesso expirou — toque para iniciar sessão novamente
 portal-row-stuck = Jogo { $game } Erro no envio do resultado, toque para corrigir
 portal-row-pending = Jogo { $game } Resultado não enviado, toque para tentar novamente
 portal-row-stats-pending = Jogo { $game } Estatísticas não enviadas, toque para tentar novamente
@@ -405,10 +405,10 @@ portal-action-force-submit = Tentar novamente este resultado
 portal-action-discard = Descartar este resultado
 portal-action-discard-confirm = TOQUE NOVAMENTE PARA CONFIRMAR DESCARTE
 portal-page-title-attention = Erro no envio do Jogo { $game }
-portal-page-attention-info = O resultado do jogo não foi aceite no Portal { $portal }
+portal-page-attention-info = O resultado do jogo não foi aceite
 portal-page-attention-score = Resultado guardado: Branca { $white } - Preta { $black }
 portal-page-attention-remediation = Pode Tentar Novamente se a ligação estiver verificada, ou descartar para limpar o erro
-portal-advisory-at-game-end = Problema detetado no portal. O resultado será mantido em fila — contacte um administrador para resolver.
+portal-advisory-at-game-end = Problema de ligação detetado. O resultado será mantido em fila — contacte um administrador para resolver.
 
 # 2 Halves / 1 Period selector (Half Length editor)
 two-halves = 2 TEMPOS

--- a/refbox/translations/th-TH/refbox.ftl
+++ b/refbox/translations/th-TH/refbox.ftl
@@ -192,7 +192,7 @@ link-locked-game = ไม่สามารถเชื่อมต่อกั�
 source-locked-queue = ยังมีผลการแข่งขันที่รอส่งอยู่ ส่งหรือทิ้งผลเหล่านั้นก่อน
 uwhportal-token-invalid-code = รหัสที่ป้อนไม่ถูกต้อง
     โปรดลองอีกครั้ง
-uwhportal-token-no-pending-link = พอร์ทัลไม่รอการเชื่อมต่อ
+uwhportal-token-no-pending-link = การเชื่อมต่อไม่รอการสื่อสาร
     โปรดลองอีกครั้ง
 go-back-to-editor = กลับไปยังตัวแก้ไข
 discard-changes = ยกเลิกการเปลี่ยนแปลง
@@ -392,9 +392,9 @@ false-start = การออกตัวผิด
 
 
 # Portal Health Indicator
-portal-summary-title = สถานะ { $portal } PORTAL
+portal-summary-title = สถานะการเชื่อมต่อ
 portal-retry-all = ลองใหม่ทั้งหมด
-portal-row-token-expired = การเข้าสู่ระบบพอร์ทัลหมดอายุ — แตะเพื่อเข้าสู่ระบบใหม่
+portal-row-token-expired = โทเค็นการเข้าถึงหมดอายุ — แตะเพื่อเข้าสู่ระบบใหม่
 portal-row-stuck = เกม { $game } ส่งคะแนนผิดพลาด แตะเพื่อแก้ไข
 portal-row-pending = เกม { $game } ยังไม่ส่งคะแนน แตะเพื่อลองอีกครั้ง
 portal-row-stats-pending = เกม { $game } ยังไม่ส่งสถิติ แตะเพื่อลองอีกครั้ง
@@ -404,10 +404,10 @@ portal-action-force-submit = ลองส่งผลเกมอีกครั
 portal-action-discard = ทิ้งผลเกมนี้
 portal-action-discard-confirm = แตะอีกครั้งเพื่อยืนยันการทิ้ง
 portal-page-title-attention = ข้อผิดพลาดในการส่งเกม { $game }
-portal-page-attention-info = ผลเกมยังไม่ได้รับการยอมรับบน { $portal } Portal
+portal-page-attention-info = ผลเกมยังไม่ได้รับการยอมรับ
 portal-page-attention-score = ผลเกมที่จัดเก็บไว้: ขาว { $white } - ดำ { $black }
 portal-page-attention-remediation = คุณสามารถลองอีกครั้งหากการเชื่อมต่อได้รับการยืนยัน หรือทิ้งเพื่อล้างข้อผิดพลาด
-portal-advisory-at-game-end = ตรวจพบปัญหาพอร์ทัล คะแนนจะยังคงอยู่ในคิว — ติดต่อผู้ดูแลเพื่อแก้ไข
+portal-advisory-at-game-end = ตรวจพบปัญหาการเชื่อมต่อ คะแนนจะยังคงอยู่ในคิว — ติดต่อผู้ดูแลเพื่อแก้ไข
 
 # 2 Halves / 1 Period selector (Half Length editor)
 two-halves = 2 ครึ่ง

--- a/refbox/translations/tl-PH/refbox.ftl
+++ b/refbox/translations/tl-PH/refbox.ftl
@@ -192,7 +192,7 @@ link-locked-game = Hindi makakakonekta sa pinagkukunan ng laro habang nagaganap 
 source-locked-queue = May mga resulta ng laro na naghihintay pang maipadala. Ipadala o itapon muna ang mga ito.
 uwhportal-token-invalid-code = Maling code ang naipasok.
     Pakisubukan muli.
-uwhportal-token-no-pending-link = Hindi inaasahan ng Portal ang isang koneksyon.
+uwhportal-token-no-pending-link = Hindi inaasahan ng koneksyon ang komunikasyon.
     Pakisubukan muli.
 go-back-to-editor = BUMALIK SA EDITOR
 discard-changes = ITAPON ANG MGA PAGBABAGO
@@ -393,9 +393,9 @@ false-start = Maling Simula
 
 
 # Portal Health Indicator
-portal-summary-title = STATUS NG { $portal } PORTAL
+portal-summary-title = STATUS NG KONEKSYON
 portal-retry-all = ULITIN LAHAT
-portal-row-token-expired = Nag-expire ang Portal login — pindutin para mag-login muli
+portal-row-token-expired = Nag-expire ang access token — pindutin para mag-login muli
 portal-row-stuck = Laro { $game } Error sa pagpapadala ng puntos, pindutin para ayusin
 portal-row-pending = Laro { $game } Hindi naipadala ang puntos, pindutin para subukan muli
 portal-row-stats-pending = Laro { $game } Hindi naipadala ang estadistika, pindutin para subukan muli
@@ -405,10 +405,10 @@ portal-action-force-submit = Subukang muli ang resulta ng larong ito
 portal-action-discard = Itapon ang resulta ng larong ito
 portal-action-discard-confirm = PINDUTIN MULI UPANG KUMPIRMAHIN ANG PAGTAPON
 portal-page-title-attention = Error sa pagsumite ng Laro { $game }
-portal-page-attention-info = Hindi pa tinatanggap ang resulta ng laro sa { $portal } Portal
+portal-page-attention-info = Hindi pa tinatanggap ang resulta ng laro
 portal-page-attention-score = Naka-imbak na resulta: Puti { $white } - Itim { $black }
 portal-page-attention-remediation = Maaari kang Subukang Muli kung naberipika ang koneksyon, o itapon upang alisin ang error
-portal-advisory-at-game-end = May problema sa Portal. Ipipila pa rin ang puntos — humanap ng admin para ayusin.
+portal-advisory-at-game-end = May problema sa koneksyon. Ipipila pa rin ang puntos — humanap ng admin para ayusin.
 
 # 2 Halves / 1 Period selector (Half Length editor)
 two-halves = 2 KALAHATI

--- a/refbox/translations/tr-TR/refbox.ftl
+++ b/refbox/translations/tr-TR/refbox.ftl
@@ -192,7 +192,7 @@ link-locked-game = Bir oyun devam ederken oyun kaynağına bağlanılamaz.
 source-locked-queue = Gönderilmeyi bekleyen oyun sonuçları var. Önce bunları gönderin veya silin.
 uwhportal-token-invalid-code = Geçersiz kod girildi.
     Lütfen tekrar deneyin.
-uwhportal-token-no-pending-link = Portal bir bağlantı beklemiyordur.
+uwhportal-token-no-pending-link = Bağlantı iletişim beklemiyor.
     Lütfen tekrar deneyin.
 go-back-to-editor = DÜZENLEYICIYE GERİ DÖN
 discard-changes = DEĞİŞİKLİKLERİ İPTAL ET
@@ -393,9 +393,9 @@ false-start = Hatalı Başlangıç
 
 
 # Portal Health Indicator
-portal-summary-title = { $portal } PORTAL DURUMU
+portal-summary-title = BAĞLANTI DURUMU
 portal-retry-all = TÜMÜNÜ TEKRAR DENE
-portal-row-token-expired = Portal oturumu sona erdi — yeniden giriş için dokunun
+portal-row-token-expired = Erişim tokeni sona erdi — yeniden giriş için dokunun
 portal-row-stuck = Oyun { $game } Skor gönderme hatası, düzeltmek için dokunun
 portal-row-pending = Oyun { $game } Skor gönderilmedi, tekrar denemek için dokunun
 portal-row-stats-pending = Oyun { $game } İstatistikler gönderilmedi, tekrar denemek için dokunun
@@ -405,10 +405,10 @@ portal-action-force-submit = Bu oyun sonucunu tekrar dene
 portal-action-discard = Bu oyun sonucunu iptal et
 portal-action-discard-confirm = İPTALİ ONAYLAMAK İÇİN TEKRAR DOKUN
 portal-page-title-attention = Oyun { $game } gönderim hatası
-portal-page-attention-info = Oyun sonucu { $portal } Portal'da kabul edilmedi
+portal-page-attention-info = Oyun sonucu kabul edilmedi
 portal-page-attention-score = Saklanan oyun sonucu: Beyaz { $white } - Siyah { $black }
 portal-page-attention-remediation = Bağlantı doğrulandıysa Tekrar Dene'yi seçebilir veya hatayı temizlemek için iptal edebilirsiniz
-portal-advisory-at-game-end = Portal sorunu algılandı. Skor yine de sıraya alınacak — çözmek için bir yöneticiye başvurun.
+portal-advisory-at-game-end = Bağlantı sorunu algılandı. Skor yine de sıraya alınacak — çözmek için bir yöneticiye başvurun.
 
 # 2 Halves / 1 Period selector (Half Length editor)
 two-halves = 2 DEVRE

--- a/refbox/translations/zh-CN/refbox.ftl
+++ b/refbox/translations/zh-CN/refbox.ftl
@@ -192,7 +192,7 @@ link-locked-game = 比赛进行中无法连接到比赛来源。
 source-locked-queue = 仍有比赛结果等待发送。请先发送或丢弃它们。
 uwhportal-token-invalid-code = 输入的代码无效。
     请重试。
-uwhportal-token-no-pending-link = Portal未等待连接。
+uwhportal-token-no-pending-link = 连接未等待通信。
     请重试。
 go-back-to-editor = 返回编辑器
 discard-changes = 放弃更改
@@ -392,9 +392,9 @@ false-start = 抢跑
 
 
 # Portal Health Indicator
-portal-summary-title = { $portal } PORTAL 状态
+portal-summary-title = 连接状态
 portal-retry-all = 全部重试
-portal-row-token-expired = Portal 登录已过期 — 点击重新登录
+portal-row-token-expired = 访问令牌已过期 — 点击重新登录
 portal-row-stuck = 比赛 { $game } 比分发送错误，点击修复
 portal-row-pending = 比赛 { $game } 比分未发送，点击重试
 portal-row-stats-pending = 比赛 { $game } 统计未发送，点击重试
@@ -404,10 +404,10 @@ portal-action-force-submit = 重试此比赛结果
 portal-action-discard = 放弃此比赛结果
 portal-action-discard-confirm = 再次点击以确认放弃
 portal-page-title-attention = 比赛 { $game } 提交错误
-portal-page-attention-info = 比赛结果尚未被 { $portal } Portal 接受
+portal-page-attention-info = 比赛结果尚未被接受
 portal-page-attention-score = 已存储比赛结果：白队 { $white } - 黑队 { $black }
 portal-page-attention-remediation = 若连接已确认，可重试；或放弃以清除错误
-portal-advisory-at-game-end = 检测到 Portal 问题。比分仍会排队 — 请联系管理员解决。
+portal-advisory-at-game-end = 检测到连接问题。比分仍会排队 — 请联系管理员解决。
 
 # 2 Halves / 1 Period selector (Half Length editor)
 two-halves = 2 个半场


### PR DESCRIPTION
## What changed

Five screens stopped telling the operator about "the Portal".

| Where the operator sees it | Now says |
|---|---|
| Advisory at game end | **Connection issue detected.** Score will still be queued — find an admin to resolve. |
| Health page title | **CONNECTION STATUS** |
| Red row on the health page | **Access token expired — tap to re-login** |
| Submission-error page | **The game result has not been accepted** |
| Failed link attempt | **The connection is not expecting communication.** |

All fifteen languages. Nothing about how refbox connects, links, queues or sends results changes —
this is display text only.

## Why

Since the game-source picker merged (#2168) an operator can point refbox at a third-party site
instead of the UWH Portal. These five screens still said "Portal" to that operator.

The word was not even coming from the site they chose. `{ $portal }` resolves through
`portal_name_for_mode`, which returns the **game mode** — `UWH` or `UWR` — so the text read
"UWH Portal" no matter what the game source was. Three of the five hardcoded the English word
outright.

Dropping the word was chosen over re-pointing it. These strings are about the *connection*, so the
neutral wording is accurate for UWH Portal operators too — nobody loses information.
Re-parameterising was considered and rejected: refbox never learns a custom site's name, only the
address typed, so the best it could substitute is a URL, and "has not been accepted on
`https://your-site/api/1234-A` Portal" is worse than saying nothing.

## Scope

`refbox` only. 15 translation files, plus two deleted `portal =` arguments in
`portal_detail.rs` and `portal_attention_action.rs`. No key was renamed, added or removed. No
shared types, no wire format, no behaviour. `portal_name_for_mode` is untouched and keeps its nine
other call sites.

Deliberately **not** included: `portal-login-instructions`, which walks the operator through the
UWH Portal's own menus and needs different text per source rather than neutral text. That is gap 15
of the third-party contract document and belongs on its own branch.

## Three decisions the diff will not explain

1. **The expired-token row names the access token on purpose.** Tapping it does not open the login
   keypad — it lands the operator on the game settings page and leaves them to find the control,
   which is the row labelled `ACCESS TOKEN:`. Naming one thing two ways is the confusion this PR
   exists to remove, so each language uses its own `access-token` label wording.
2. **The submission-error line drops its trailing phrase rather than replacing it.** The page is
   already titled "Game N submission error", so the sentence does not need to restate what failed.
3. **Spanish and French were retranslated, not edited.** Both previously said "no pending link was
   found" — a different statement from the English — so they needed the new meaning, not a word
   removed. While rewriting the French submission-error line, an existing typo (`n.a pas` for
   `n'a pas`) was corrected.

## How to verify

Mechanically, and these were run:

- No value in any of the 15 files still contains the word "Portal" or a `{ $portal }` placeholder.
- All 15 files still carry all 5 keys — nothing was renamed or lost.
- `just check` passes: formatting, `-D warnings`, 630 tests, security scan.

On screen, set the game source to CUSTOM and confirm none of the five screens says "Portal", then
set it to UWH PORTAL and confirm they all still read correctly — the neutral wording has to be
accurate there, not merely tolerable.

## What was not verified on screen, and why

**The fit of the changed strings was reasoned about, not seen.** Stating that plainly rather than
implying a walkthrough happened.

Refbox was run against the verification stub, but the three screens carrying these strings proved
impractical to reach: the health page shows no title until something is in the queue, the advisory
needs a game ending with a connection fault, and the failed-link message needs a link the far end
refuses. None could be produced without staging a tournament-sized scenario.

What replaces sight is a per-string character count, measured as rendered (a `{ $portal }`
placeholder is 11 characters in the file but about 3 on screen):

- **42 of the 75 strings got shorter, 10 are unchanged in length, and 23 grew.** Only a string that
  grew can newly clip.
- The largest growth is the failed-link message — French +14, English +12, German +11 — which sits
  in a two-line dialog with room to spare.
- The German advisory is the longest string in the set at 135 characters, but grew only 4 from an
  existing 131 that already fits.
- The expired-token row got **shorter** in almost every language, German by 4.
- Everything else moved by two characters or fewer.

If a reviewer can reach these screens more easily, the fit is the thing worth looking at.

## Related

Follows #2168 (game source selection) and #2201 (custom site address on one line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
