### PR TITLE
fix(refbox): keep four settings across a config migration

### DIFF
--- a/refbox/src/config.rs
+++ b/refbox/src/config.rs
@@ -362,7 +362,7 @@ impl Config {
             mut collect_scorer_cap_num,
             mut track_fouls_and_warnings,
             mut show_behind_schedule_time,
-            confirm_score,
+            mut confirm_score,
             mut audible_countdown,
             mut source,
             mut remembered_remote,
@@ -372,9 +372,9 @@ impl Config {
             mut uwhportal,
             mut custom_site,
             mut sound,
-            language,
-            display_mode,
-            front_display_layout,
+            mut language,
+            mut display_mode,
+            mut front_display_layout,
         } = Default::default();
 
         if let Some(old_mode) = old.get("mode") {
@@ -396,6 +396,7 @@ impl Config {
             "show_behind_schedule_time",
             &mut show_behind_schedule_time,
         );
+        get_boolean_value(old, "confirm_score", &mut confirm_score);
         get_boolean_value(old, "audible_countdown", &mut audible_countdown);
         if let Some(old_source) = old.get("source") {
             if let Some(old_source) = old_source.as_str() {
@@ -441,6 +442,9 @@ impl Config {
                 sound = SoundSettings::migrate(old_sound);
             }
         }
+        get_serde_value(old, "language", &mut language);
+        get_serde_value(old, "display_mode", &mut display_mode);
+        get_serde_value(old, "front_display_layout", &mut front_display_layout);
 
         Self {
             mode,
@@ -536,6 +540,17 @@ fn get_string_value(table: &Table, key: &str, save: &mut String) {
     if let Some(value) = table.get(key) {
         if let Some(value) = value.as_str() {
             *save = value.to_string();
+        }
+    }
+}
+
+/// Reads a value that `Config` stores through serde rather than as a bare TOML scalar —
+/// the unit-variant enums, and `Option`s of them. `save` is left at its default if the
+/// key is absent or holds something that will not deserialize.
+fn get_serde_value<T: DeserializeOwned>(table: &Table, key: &str, save: &mut T) {
+    if let Some(value) = table.get(key) {
+        if let Ok(value) = value.clone().try_into() {
+            *save = value;
         }
     }
 }
@@ -1115,6 +1130,116 @@ mod test {
         );
         let config = Config::migrate(&old);
         assert!(!config.show_behind_schedule_time);
+    }
+
+    // The four settings below were dropped by `migrate` until 2026-08-11: they were
+    // destructured out of the defaults without `mut` and never read back from the old
+    // table, so any config file that needed migrating silently lost them and the reset
+    // was then written back over the file. `language` is the one that bites in practice,
+    // because a v0.4.0/v0.4.1 file always needs migrating (it has no
+    // `show_behind_schedule_time` key).
+
+    #[test]
+    fn test_migrate_confirm_score_defaults_true_when_absent() {
+        let old: Table = Default::default();
+        let config = Config::migrate(&old);
+        assert!(config.confirm_score);
+    }
+
+    #[test]
+    fn test_migrate_confirm_score_respects_present_false() {
+        let mut old: Table = Default::default();
+        old.insert("confirm_score".to_string(), toml::Value::Boolean(false));
+        let config = Config::migrate(&old);
+        assert!(
+            !config.confirm_score,
+            "an operator who turned score confirmation off must not get it back on"
+        );
+    }
+
+    #[test]
+    fn test_migrate_language_stays_unset_when_absent() {
+        let old: Table = Default::default();
+        let config = Config::migrate(&old);
+        assert_eq!(config.language, None);
+    }
+
+    #[test]
+    fn test_migrate_language_is_preserved() {
+        let mut old: Table = Default::default();
+        old.insert(
+            "language".to_string(),
+            toml::Value::String("German".to_string()),
+        );
+        let config = Config::migrate(&old);
+        assert_eq!(
+            config.language,
+            Some(Language::German),
+            "a chosen interface language must survive migration"
+        );
+    }
+
+    #[test]
+    fn test_migrate_display_mode_is_preserved() {
+        let mut old: Table = Default::default();
+        old.insert(
+            "display_mode".to_string(),
+            toml::Value::String("HighContrast".to_string()),
+        );
+        let config = Config::migrate(&old);
+        assert_eq!(
+            config.display_mode,
+            crate::app::theme::DisplayMode::HighContrast,
+            "High Contrast is chosen for poolside readability and must survive migration"
+        );
+    }
+
+    #[test]
+    fn test_migrate_front_display_layout_is_preserved() {
+        let mut old: Table = Default::default();
+        old.insert(
+            "front_display_layout".to_string(),
+            toml::Value::String("Corners".to_string()),
+        );
+        let config = Config::migrate(&old);
+        assert_eq!(
+            config.front_display_layout,
+            crate::sim_frame::FrontDisplayLayout::Corners
+        );
+    }
+
+    /// The realistic path: a config file written by v0.4.0/v0.4.1 has `confirm_score`
+    /// and `language` but no `show_behind_schedule_time`, so it fails to deserialize
+    /// against the current `Config` and `main.rs` falls back to `migrate`. Both
+    /// operator-set values must survive, and the key that did not exist yet must fall
+    /// back to its default.
+    #[test]
+    fn test_migrate_v041_shaped_config_keeps_operator_settings() {
+        let mut old: Table = Default::default();
+        old.insert("mode".to_string(), toml::Value::String("Rugby".to_string()));
+        old.insert("hide_time".to_string(), toml::Value::Boolean(true));
+        old.insert("confirm_score".to_string(), toml::Value::Boolean(false));
+        old.insert(
+            "language".to_string(),
+            toml::Value::String("German".to_string()),
+        );
+        // deliberately absent: show_behind_schedule_time, display_mode,
+        // front_display_layout — none of them existed in v0.4.1
+
+        let config = Config::migrate(&old);
+
+        assert!(!config.confirm_score, "confirm_score must survive");
+        assert_eq!(
+            config.language,
+            Some(Language::German),
+            "language must survive"
+        );
+        assert_eq!(config.mode, Mode::Rugby);
+        assert!(config.hide_time);
+        assert!(
+            config.show_behind_schedule_time,
+            "a key absent from the old format falls back to its default"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What changed

Updating the refbox to a newer version used to silently reset four saved settings. The two that
matter in practice are:

- **the interface language** — the saved choice is erased, so the refbox falls back to whatever the
  operating system's language is (English on the field Pis). Nothing is shown to the operator; the
  interface simply comes back in a different language.
- **CONFIRM SCORE AT GAME END** — turned back on, even if the operator had turned it off

The reset was then written back over the settings file, so it was permanent, and nothing on screen
said it had happened. This PR keeps all four settings across the upgrade.

The other two (display mode and front display layout) have the same underlying defect but no
released version can actually reach them — only a hand-edited or corrupted settings file could.
They are fixed by the same three lines.

## Why

When a new version needs a setting that the old settings file doesn't contain, the refbox falls
back to an upgrade routine that copies the old values across. That routine copied most settings but
skipped these four, so they fell back to factory defaults.

This is not a rare path. **Every settings file written by v0.4.0 or v0.4.1 takes it**, because
v0.4.2 added a setting that older files have no entry for. The field Raspberry Pis are still on
v0.3.0 and awaiting an update — this would fire on that update, on every one of them.

## Scope

One file: `refbox/src/config.rs`. Four lines that copy the missing values, three of them using a
small new helper for settings stored in a different shape from plain true/false. Plus seven tests.

The file contains four other upgrade routines. All four were checked for the same defect and are
clean.

## How to verify

The upgrade path is normally invisible, so the clearest check is to make it happen deliberately.
This was done before opening the PR, and the result is below.

Take a settings file in the old format — one with a language and CONFIRM SCORE set, but no
`show_behind_schedule_time` entry — and start the refbox on it. Compare a build of `master` against
a build of this branch, using an identical starting file:

| Setting, as the operator left it | On `master` after upgrade | On this branch after upgrade |
| --- | --- | --- |
| `confirm_score = false` | `true` — silently switched back on | `false` — kept |
| `language = "German"` | entry gone entirely — falls back to the OS language | `German` — kept |
| `mode = "Rugby"` | `Rugby` | `Rugby` |
| `hide_time = true` | `true` | `true` |

The refbox log confirms the upgrade routine ran rather than a normal load:
`Failed to use config file` followed by `Found old config file, attempting migration`.

On screen, the `master` behaviour is: update a Pi that was set to German, and it comes back in
English, with score confirmation switched on again — with no prompt and no message. The operator has
to go back into Settings and set both again.

## Testing

Seven tests, all in `refbox/src/config.rs`:

- each of the four settings survives when present in the old file
- the two that have "off" defaults still default correctly when absent
- one test builds a complete v0.4.1-shaped file and checks the operator's values survive while a
  setting that didn't exist back then falls back to its default

**Five of the seven fail without the fix.** That was confirmed by deliberately removing the four
copying lines and re-running, not assumed — the earlier commit message said four, which was one
short. The two "absent, so use the default" tests correctly pass either way.

Worth noting: the pre-existing `test_migrate_config` passes both with and without the fix. It never
covered these four settings, which is how the defect survived.

## Correction to an earlier version of this description

The first version of this text said the operator would be "asked to pick a language again". That is
wrong — there is no language picker at startup. `LANGUAGE_LOADER` in `main.rs` resolves the language
once, using the operating system's locale when no saved language is present, and the language-select
screen is only reachable through Settings → Language. Losing the saved language is therefore a
silent switch to the OS language, not a prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
