### PR TITLE
fix(refbox): make the build script's missing-key error actually fail

### DIFF
--- a/refbox/build.rs
+++ b/refbox/build.rs
@@ -69,8 +69,13 @@ fn main() {
 
     if missing_keys != HashMap::new() {
         for (file, missing) in &missing_keys {
+            // Two colons, not one. `cargo:error=` is not a recognised
+            // directive: cargo silently ignores it, so the release branch above
+            // reported nothing at all and this check was warning-only in every
+            // build. `cargo::error=` does fail the build, and both spellings
+            // work for `warning`. Verified on rustc 1.85, the MSRV.
             println!(
-                "cargo:{}=Missing keys in {}: {}",
+                "cargo::{}=Missing keys in {}: {}",
                 msg_type,
                 file,
                 missing.join(", ")


### PR DESCRIPTION
## What changed

One character in `refbox/build.rs`: `cargo:error=` becomes `cargo::error=`.

## Why

The build script checks that every language has every translation key, and is written to warn in
debug builds but **fail** in release builds. The release half has never worked.

`cargo:error=` with one colon is not a recognised cargo directive. Cargo silently discards it —
exit 0, nothing printed at all. So a release build with a language missing a key has always built
clean, and the check has effectively been warning-only in every build since it was written.

Two colons is the recognised spelling. Both spellings work for `warning`, so the debug path is
unchanged.

This does not touch the directory walk or the per-file `cargo:rerun-if-changed` lines, which are
what make a build notice an edited translation.

## How to verify

Proven on rustc 1.85, the project's MSRV, in three steps:

1. **Isolated crate.** A throwaway crate whose `build.rs` prints `cargo:error=…` builds clean,
   exit 0, with nothing printed. The same crate printing `cargo::error=…` fails with
   `error: build script logged errors`, exit 101.
2. **refbox, debug.** Delete `back = ZURÜCK` from `de-DE` and run `cargo build -p refbox`:
   still warns, `warning: refbox@0.4.9: Missing keys in translations/de-DE/refbox.ftl: back`.
3. **refbox, release.** The same tree with `cargo check --release -p refbox` now fails:
   `error: refbox@0.4.9: Missing keys in translations/de-DE/refbox.ftl: back`, then
   `error: build script logged errors`, exit 101. **Before this change it built clean.**

The deleted key was restored afterwards; `just check` passes and the translation-consistency tests
merged in #2269 are unaffected.

## Scope

`refbox/build.rs` only. No behaviour change in the application, no translation text changed, no
dependency change.

## Note

This commit was originally part of #2269 but never reached master — it was pushed to that branch
after the PR had already merged, so it was orphaned. `git cherry` showed six of seven commits
landed and this one did not. Same content, landed properly this time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
