### PR TITLE
fix(refbox): report a startup failure instead of an expired access token

### DIFF
--- a/docs/backlog/degraded-queue-written-to-temp-dir/NOTE.md
+++ b/docs/backlog/degraded-queue-written-to-temp-dir/NOTE.md
@@ -1,0 +1,63 @@
+# Backlog: results queued in degraded mode are written somewhere nothing reads
+
+**Status:** NOT FILED, not started. Local note only.
+**Surfaced:** 2026-08-13, by the code review of
+`fix/refbox/degraded-portal-startup-message`. **Pre-existing — identical before and after that
+branch**, and squarely inside that spec's stated non-goals, so it was deliberately left alone.
+**Verified by reading the call chain, not assumed.**
+
+## The gap
+
+A degraded-mode `PortalManager` sets `config_dir` to `std::env::temp_dir()`
+(`refbox/src/portal_manager/mod.rs`, in `new_degraded`). Game results are still queued in that mode:
+`enqueue_game_end` is called at game end whenever an event is linked, with **no check for a portal
+client** (`refbox/src/app/mod.rs:1389-1392`) — and a degraded session can absolutely have an event
+linked, either restored from a portal link note or adopted from a custom site's URL.
+
+So the queue file is written to the system temp directory. The next healthy launch constructs the
+manager with the **real** config dir and loads the queue from there, so it never sees that file. The
+queued results are effectively abandoned.
+
+Meanwhile the end-of-game banner tells the operator the opposite:
+
+> *"Connection issue detected. Score will still be queued — find an admin to resolve."*
+
+In degraded mode the first half of that promise is technically true and practically false: it is
+queued, to a location nothing will ever read.
+
+## Why this is not a lost game, but is still a real problem
+
+The score itself is not gone from the machine — the tournament manager still holds the game record
+and the scoresheet is unaffected. What is lost is the **portal submission**, silently, after the
+operator was told it was safely queued. Nobody learns that the result needs entering by hand.
+
+Note that the new startup-failure row added by the 2026-08-13 branch —
+*"Connection unavailable — results will not upload"* — is now the **more accurate** of the two
+messages on this path. The game-end banner is the one that overpromises.
+
+## The ask
+
+Either make the promise true, or stop making it. Options to weigh with the human:
+
+1. Keep degraded mode's queue in memory only and say so, rather than writing a file that is never
+   read again.
+2. Have a healthy startup also check the temp dir and adopt any queue file it finds there.
+3. Change the game-end banner wording so it does not promise queueing when the subsystem never
+   started.
+
+Option 3 is the smallest; option 2 is the only one that actually preserves the results.
+
+## Scope when picked up
+
+- `refbox/src/portal_manager/mod.rs` (`new_degraded`'s `config_dir`, and `queue::load_or_empty`).
+- Possibly `refbox/translations/` if the banner wording changes (15 locales, and the wording must
+  stay source-neutral — see the 2026-08-13 spec's "wording must be source-neutral" section).
+- **Check first** whether a queue file left in the temp dir by an earlier degraded run could be
+  picked up by an *unrelated* refbox install or a different user account on a shared machine. Not
+  traced — verify before choosing option 2.
+
+## Explicitly NOT part of this
+
+- Not the degraded-startup message (shipped on `fix/refbox/degraded-portal-startup-message`).
+- Not the silent portal login with no client — that is
+  `docs/backlog/portal-login-silent-when-no-client/NOTE.md`.

--- a/docs/backlog/portal-login-silent-when-no-client/NOTE.md
+++ b/docs/backlog/portal-login-silent-when-no-client/NOTE.md
@@ -1,0 +1,68 @@
+# Backlog: the portal login silently does nothing when the refbox has no client
+
+**Status:** NOT FILED, not started. Local note only.
+**Surfaced:** 2026-08-13, while source-tracing finding 3 of the code-quality inventory
+(`git show 87be104b:docs/audit-archive/2026-08-11-ai-slop-inventory.md`) and designing the fix in
+`docs/superpowers/specs/2026-08-13-degraded-portal-startup-message-design.md`.
+**Raised by:** Claude, during the trace. Every claim below was read in code, not assumed.
+
+## The gap
+
+If the refbox starts without a portal client — the "degraded mode" path, realistically caused by a
+broken system certificate store on a Pi — the portal login flow is still fully reachable from
+Settings, and it **fails completely silently**.
+
+What happens when the operator enters their code:
+
+1. The login keypad marks the request as sent (`refbox/src/app/mod.rs:4268`, `*requested = true`).
+2. It calls `request_uwhportal_token` (`refbox/src/app/mod.rs:991-1011`), which is wrapped in
+   `if let Some(client)` and returns `Task::none()` when there is no client.
+3. No network request is made, so no reply message is ever produced.
+4. Nothing updates the screen. No success, no error, no timeout, no log line the operator sees.
+
+The comment at `refbox/src/app/mod.rs:4288` states the reply "will replace this once the network
+request completes". It never completes. The operator types a code from the portal website, presses
+Done, and the refbox behaves as though they did nothing at all.
+
+## Why this is NOT covered by the degraded-startup fix
+
+The 2026-08-13 fix stops the refbox *pushing* the operator into this login — it removes the false
+"Access token expired — tap to re-login" prompt. It does not close the dead end itself. An operator
+who sees the red dot and goes looking in Settings for a way to fix it will still land here.
+
+## The ask
+
+When there is no portal client, the login attempt should tell the operator something instead of
+nothing. Anything truthful is an improvement: an error state on the keypad, or the login entry
+point being unavailable with a reason.
+
+## Scope when picked up
+
+- `refbox/src/app/mod.rs` only, around the keypad-Done handler and `request_uwhportal_token`.
+- Decide with the human whether the better shape is (a) the login attempt reporting a failure, or
+  (b) the login entry point being closed off while no client exists. This is an operator-experience
+  call, not a technical one.
+- Check the same silent-no-op shape in the sibling request helpers in that file: `request_schedule`
+  and the event-list fetch use the identical `if let Some(client) … else Task::none()` pattern.
+  Whether their silence is equally harmful was **not** traced — verify before assuming.
+
+## Related, and deliberately not fixed in the 2026-08-13 branch
+
+Two code comments misdescribe when degraded mode is entered, and would mislead the next reader:
+
+- `refbox/src/app/mod.rs:2389` — "only possible on a bad https-only config"
+- `refbox/src/app/mod.rs:1112` — "only reachable from a bad https-only config"
+
+Both are wrong. The https-only setting is a stored flag enforced per request
+(`reqwest 0.12.23`, `src/async_impl/client.rs:2135-2136` sets it, `:2511-2512` enforces it), so
+such a configuration builds a client successfully and fails each individual call instead. Every
+real failure path inside that constructor is TLS/certificate related — e.g. "zero valid
+certificates found in native root store". Correcting the comments is a two-line documentation fix
+that belongs with whichever branch next touches this area.
+
+## Explicitly NOT part of this
+
+- Not the degraded-startup message itself (that is the 2026-08-13 spec, in progress).
+- Not making the portal work without a client — it cannot; this is about honest feedback.
+- Not ADR 011's missing failure counter (inventory finding 5) or the unreachable yellow indicator
+  state (finding 4).

--- a/docs/superpowers/plans/2026-08-13-degraded-portal-startup-message.md
+++ b/docs/superpowers/plans/2026-08-13-degraded-portal-startup-message.md
@@ -1,0 +1,502 @@
+# Degraded Portal Startup Message — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When the portal subsystem cannot start, the refbox must report a system fault instead of claiming the operator's access token expired.
+
+**Architecture:** Add a `startup_problem` flag to `PortalManager`, set only by `new_degraded()`. It drives the Red indicator but leaves `token_expired` false, so the false re-login row and the REFRESH lockout both disappear. A new non-tappable `DetailRow::StartupFailed` gives the operator honest wording in its place. One guard is completed in `app/mod.rs` so the now-live REFRESH button cannot stick.
+
+**Tech Stack:** Rust 2024, MSRV 1.85, `iced` 0.13, Fluent (`.ftl`) translations.
+
+## Global Constraints
+
+- **Crate scope:** `refbox` only. Do NOT touch `uwh-common`, `overlay`, or `wireless-remote`.
+- **Process:** lean, per `.claude/rules/plan-execution.md` — no per-task deviation commits, one code review at the end. Record deviations in the "Deviations" section at the bottom of this file.
+- **Clippy:** `cargo clippy --workspace --all-features -- -D warnings` must be clean. No new `#[allow]`.
+- **No `unwrap()`/`expect()`** in non-test code without a comment explaining why it cannot panic.
+- **Translations:** every new key must exist in **all 15** locales (`de-DE en-US es fr id-ID it-IT ja-JP ko-KR ms-MY nl-NL pt-PT th-TH tl-PH tr-TR zh-CN`). No placeholders, no English left in a non-English file. A missing key is caught by `refbox/build.rs`, not by a test.
+- **Literal copy, exactly:** English row text is `Portal unavailable — results will not upload`. Use the spaced em-dash `—`, matching the neighbouring `portal-row-token-expired` key in every locale.
+- **Do NOT fix** the two misleading "https-only config" comments at `app/mod.rs:2389` and `:1112`. They are wrong, they are recorded in `docs/backlog/portal-login-silent-when-no-client/NOTE.md`, and they are out of scope for this branch.
+- **Branch:** `fix/refbox/degraded-portal-startup-message`. Ask the human before creating it and before every commit.
+
+---
+
+### Task 1: The `startup_problem` flag and the indicator
+
+**Files:**
+- Modify: `refbox/src/portal_manager/mod.rs` (struct ~`:390-411`, `new_for_test` ~`:416-434`, `recompute_indicator` ~`:513-529`, `new` ~`:561-587`, `new_degraded` ~`:600-622`, tests ~`:1349-1371`)
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: private field `startup_problem: bool` on `PortalManager`, readable by later tasks in the same module. No public API change — `indicator_state()` keeps its signature and `PortalIndicatorState` gains no field.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `mod tests` block in `refbox/src/portal_manager/mod.rs`, next to the existing `connection_problem_is_red_but_not_token_expired` test (~`:1069`):
+
+```rust
+    #[test]
+    fn degraded_startup_is_red() {
+        let (m, _rx) = PortalManager::new_degraded();
+        assert_eq!(
+            m.indicator_state().health,
+            HealthState::Red,
+            "a portal subsystem that never started must show red"
+        );
+    }
+
+    #[test]
+    fn degraded_startup_does_not_report_token_expired() {
+        // The triggers are a system fault (the HTTP client failed to build,
+        // realistically a TLS/certificate-store problem) or an unreadable
+        // queue file. Neither is evidence about the operator's login.
+        // Reporting token_expired greys out the schedule REFRESH button and
+        // shows a "tap to re-login" row — and with no client a re-login
+        // cannot even send a request, so the operator is sent nowhere.
+        let (m, _rx) = PortalManager::new_degraded();
+        assert!(
+            !m.indicator_state().token_expired,
+            "degraded startup must not blame the operator's access token"
+        );
+    }
+
+    #[test]
+    fn genuine_token_rejection_still_reports_token_expired() {
+        // Guard the path this change must NOT disturb: a real rejection
+        // from the portal still greys REFRESH and still offers re-login.
+        let mut m = PortalManager::new_for_test(QueueFile::empty(), false, false);
+        m.on_token_status(false);
+        assert_eq!(m.indicator_state().health, HealthState::Red);
+        assert!(m.indicator_state().token_expired);
+    }
+```
+
+- [ ] **Step 2: Rewrite the test that asserts the removed behaviour**
+
+The existing test at ~`:1349` is named for, and documents, the exact behaviour being removed. Replace it wholesale (name included) — do not leave the old name in place:
+
+```rust
+    #[test]
+    fn new_degraded_is_red_with_no_spawned_task() {
+        let (manager, mut rx) = PortalManager::new_degraded();
+
+        // Red so the operator sees the problem — via `startup_problem`,
+        // not by claiming the access token expired.
+        let state = manager.indicator_state();
+        assert_eq!(
+            state.health,
+            HealthState::Red,
+            "degraded mode must surface the failure to the operator via a red dot"
+        );
+
+        // The queue should be empty (no persistence attempted).
+        assert_eq!(manager.queue.items.len(), 0);
+
+        // The returned receiver should not receive any events (no spawned task,
+        // and the sender half was dropped at construction).
+        assert!(
+            rx.try_recv().is_err(),
+            "degraded mode must not produce portal events"
+        );
+    }
+```
+
+- [ ] **Step 3: Run the tests and verify they fail**
+
+Run: `cargo test -p refbox portal_manager -- --nocapture`
+Expected: `degraded_startup_does_not_report_token_expired` FAILS (`token_expired` is currently true in degraded mode). The other three should already pass — they are regression guards, and a guard that never fails is still worth keeping here.
+
+- [ ] **Step 4: Add the field to the struct**
+
+In the `pub struct PortalManager` block (~`:390`), directly after the `connection_problem` field and its doc comment:
+
+```rust
+    /// Set true only by `new_degraded()`: the portal subsystem could not
+    /// start at all. Either the HTTP client failed to build (realistically
+    /// a TLS/certificate-store fault) or the retry queue was unreadable in
+    /// both the config dir and the system temp dir.
+    ///
+    /// Drives the Red indicator like the other two problem flags, but
+    /// deliberately leaves `token_expired` false: neither trigger is
+    /// evidence about the operator's login, and claiming otherwise sends
+    /// them into a re-login that — with no client — cannot even send a
+    /// request.
+    ///
+    /// There is deliberately no setter. Neither trigger can heal without a
+    /// restart (no client can appear mid-session — see `repoint_client` in
+    /// `app/mod.rs`), so this stays true for the life of the process.
+    startup_problem: bool,
+```
+
+- [ ] **Step 5: Initialise it in the three other constructors**
+
+All three must compile. Add `startup_problem: false,` next to `connection_problem: false,` in:
+- `new_for_test` (~`:426`)
+- `new` (~`:573`)
+
+And in `new_degraded` (~`:613`), replace the `token_known_problem: true` line and its comment with:
+
+```rust
+            // The portal subsystem never started. Red so the operator sees
+            // the problem — but NOT `token_known_problem`: nothing here is
+            // evidence the login expired.
+            token_known_problem: false,
+            connection_problem: false,
+            startup_problem: true,
+```
+
+(Delete the now-duplicated `connection_problem: false,` line that followed it.)
+
+- [ ] **Step 6: Make the indicator treat it as a red cause**
+
+In `recompute_indicator` (~`:514`), extend the Red condition only:
+
+```rust
+        let health = if self.needs_attention() || self.connection_problem || self.startup_problem {
+            HealthState::Red
+```
+
+Leave the `token_expired: self.token_known_problem` line at `:524` untouched — that is what makes the fix work.
+
+- [ ] **Step 7: Run the tests and verify they pass**
+
+Run: `cargo test -p refbox portal_manager`
+Expected: PASS, including all four tests above.
+
+- [ ] **Step 8: Mutation-test the new guard**
+
+This is required, not optional. The original defect survived because a test passed both ways.
+
+1. Temporarily revert Step 6 (drop `|| self.startup_problem`). Run `cargo test -p refbox portal_manager`. Expected: `degraded_startup_is_red` and `new_degraded_is_red_with_no_spawned_task` FAIL. Restore.
+2. Temporarily set `token_known_problem: true` in `new_degraded` again. Run the tests. Expected: `degraded_startup_does_not_report_token_expired` FAILS. Restore.
+
+If either mutation leaves the suite green, the test is not discriminating — fix the test before continuing.
+
+- [ ] **Step 9: Commit** (ask the human first)
+
+```bash
+git add refbox/src/portal_manager/mod.rs
+git commit -m "fix(refbox): stop degraded startup blaming the access token"
+```
+
+---
+
+### Task 2: The honest detail row
+
+**Files:**
+- Modify: `refbox/src/portal_manager/mod.rs` (`DetailRow` enum ~`:321-354`, `detail_rows` ~`:930-935`, tests)
+
+**Interfaces:**
+- Consumes: `startup_problem: bool` from Task 1.
+- Produces: new variant `DetailRow::StartupFailed` (no fields). Task 3 renders it. It is emitted first in the `Vec<DetailRow>` returned by `detail_rows()`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the tests module:
+
+```rust
+    #[test]
+    fn degraded_startup_shows_startup_failed_row_not_token_expired() {
+        let (m, _rx) = PortalManager::new_degraded();
+        let rows = m.detail_rows();
+        assert!(
+            matches!(rows.first(), Some(DetailRow::StartupFailed)),
+            "the degraded detail page must lead with the startup-failure row, got {rows:?}"
+        );
+        assert!(
+            !rows.iter().any(|r| matches!(r, DetailRow::TokenExpired)),
+            "degraded startup must never offer a re-login that cannot send a request"
+        );
+    }
+```
+
+- [ ] **Step 2: Run it and verify it fails**
+
+Run: `cargo test -p refbox degraded_startup_shows_startup_failed_row -- --nocapture`
+Expected: FAIL to compile — `no variant named StartupFailed found for enum DetailRow`. A compile failure is a legitimate red here; do not "fix" it by weakening the test.
+
+- [ ] **Step 3: Add the enum variant**
+
+In `pub enum DetailRow` (~`:321`), as the first variant, above `TokenExpired`:
+
+```rust
+    /// Shown at the top when the portal subsystem could not start at all
+    /// (`startup_problem`). Deliberately NOT tappable: there is nothing
+    /// the operator can do from the refbox, and the fault cannot heal
+    /// without a restart.
+    StartupFailed,
+```
+
+- [ ] **Step 4: Emit it from `detail_rows`**
+
+In `detail_rows` (~`:931`), before the existing `token_known_problem` check:
+
+```rust
+        if self.startup_problem {
+            out.push(DetailRow::StartupFailed);
+        }
+
+        if self.token_known_problem {
+            out.push(DetailRow::TokenExpired);
+        }
+```
+
+Then update the ordering doc comment above the function (~`:923-929`) so item 1 reads:
+
+```rust
+    /// 1. `StartupFailed`, if the portal subsystem never started; then the
+    ///    `TokenExpired` banner, if a token problem is flagged. In practice
+    ///    only one can occur — degraded startup no longer sets the token
+    ///    flag — but the order is defined so the page is deterministic.
+```
+
+- [ ] **Step 5: Run the tests and verify they pass**
+
+Run: `cargo test -p refbox portal_manager`
+Expected: PASS. `render_row` in `portal_detail.rs` will now fail to compile with a non-exhaustive match — that is Task 3's job. If the build breaks here, that is expected; proceed to Task 3 before judging the crate broken.
+
+`render_row` (`portal_detail.rs:134`) is the **only** exhaustive match on `DetailRow` in the codebase — verified. The other site (`portal_detail.rs:54-59`) is a `matches!` listing only `Stuck`/`Pending`/`StatsPending`, and the existing test assertions all use `matches!` too, so none of them need touching.
+
+- [ ] **Step 6: Mutation-test the emission**
+
+Temporarily delete the `if self.startup_problem { out.push(DetailRow::StartupFailed); }` block. Run `cargo test -p refbox portal_manager`. Expected: `degraded_startup_shows_startup_failed_row_not_token_expired` FAILS. Restore it.
+
+- [ ] **Step 7: Commit** (ask the human first)
+
+```bash
+git add refbox/src/portal_manager/mod.rs
+git commit -m "fix(refbox): add an honest startup-failure row to portal detail"
+```
+
+---
+
+### Task 3: Render the row, and translate it
+
+**Files:**
+- Modify: `refbox/src/app/view_builders/portal_detail.rs` (`render_row` ~`:134-201`)
+- Modify: all 15 of `refbox/translations/<locale>/refbox.ftl`
+
+**Interfaces:**
+- Consumes: `DetailRow::StartupFailed` from Task 2.
+- Produces: translation key `portal-row-startup-failed` (no variables).
+
+- [ ] **Step 1: Render the variant**
+
+In `render_row`, add an arm. Model it on the existing `RecentSuccess` arm (~`:187`), which is the codebase's established shape for a **non-tappable** informational strip — a `container`, not a `button`. Do not give it `.on_press`: a button with no press handler looks disabled, and this row is informational, not broken.
+
+```rust
+        DetailRow::StartupFailed => container(row_text_centered(fl!("portal-row-startup-failed")))
+            .style(red_container)
+            .padding(PADDING)
+            .width(Length::Fill)
+            .height(Length::Fixed(MIN_BUTTON_SIZE))
+            .into(),
+```
+
+`red_container` is exported from `refbox/src/app/theme/mod.rs:361`. `portal_detail.rs` begins with `use super::*`, so it is very likely already in scope; if the compiler disagrees, add it to that glob's module rather than importing `theme` directly here.
+
+**Do not touch `has_unsent` at `portal_detail.rs:54-59`.** That `matches!` decides whether RETRY ALL is actionable, and it deliberately lists only `Stuck`/`Pending`/`StatsPending`. Leaving `StartupFailed` out of it is correct: in degraded mode there is nothing queued and nothing to retry, so RETRY ALL must stay inactive.
+
+- [ ] **Step 2: Add the English string**
+
+In `refbox/translations/en-US/refbox.ftl`, in the `# Portal Health Indicator` section, directly after the `portal-row-token-expired` line:
+
+```
+portal-row-startup-failed = Portal unavailable — results will not upload
+```
+
+- [ ] **Step 3: Add the other 14 translations**
+
+Same position in each file — immediately after that locale's `portal-row-token-expired` line, so the section order stays identical across locales. Use exactly these:
+
+```
+de-DE   portal-row-startup-failed = Portal nicht verfügbar — Ergebnisse werden nicht hochgeladen
+es      portal-row-startup-failed = Portal no disponible — los resultados no se subirán
+fr      portal-row-startup-failed = Portail indisponible — les résultats ne seront pas envoyés
+id-ID   portal-row-startup-failed = Portal tidak tersedia — hasil tidak akan diunggah
+it-IT   portal-row-startup-failed = Portale non disponibile — i risultati non verranno caricati
+ja-JP   portal-row-startup-failed = ポータルを利用できません — 結果はアップロードされません
+ko-KR   portal-row-startup-failed = 포털을 사용할 수 없습니다 — 결과가 업로드되지 않습니다
+ms-MY   portal-row-startup-failed = Portal tidak tersedia — keputusan tidak akan dimuat naik
+nl-NL   portal-row-startup-failed = Portaal niet beschikbaar — resultaten worden niet geüpload
+pt-PT   portal-row-startup-failed = Portal indisponível — os resultados não serão enviados
+th-TH   portal-row-startup-failed = ไม่สามารถใช้พอร์ทัลได้ — ผลการแข่งขันจะไม่ถูกอัปโหลด
+tl-PH   portal-row-startup-failed = Hindi available ang portal — hindi mai-a-upload ang mga resulta
+tr-TR   portal-row-startup-failed = Portal kullanılamıyor — sonuçlar yüklenmeyecek
+zh-CN   portal-row-startup-failed = 无法使用门户 — 成绩将不会上传
+```
+
+(The locale name is a label showing which file each line belongs in — write only the `portal-row-startup-failed = …` line into each `.ftl`.)
+
+- [ ] **Step 4: Verify the key exists in all 15 locales**
+
+Run: `grep -rc "portal-row-startup-failed" refbox/translations/*/refbox.ftl`
+Expected: every one of the 15 files reports `1`. A `0` anywhere means a missing translation, which `refbox/build.rs` will also complain about.
+
+- [ ] **Step 5: Run the enforcing translation tests**
+
+Run: `cargo test -p refbox translation_consistency`
+Expected: PASS. `refbox/src/translation_consistency.rs` landed on master on 2026-08-13 and enforces three rules that matter here:
+1. every `en-US` key exists in every locale — so all 15 must be added;
+2. every key uses the same `{ $variables }` as English — trivially satisfied, this key has none;
+3. **every `en-US` key is referenced in source** — so the `fl!("portal-row-startup-failed")` call from Step 1 must land in the same commit as the key, or this test fails.
+
+This replaces the older warning-only `build.rs` check as the real gate.
+
+- [ ] **Step 6: Commit** (ask the human first)
+
+```bash
+git add refbox/src/app/view_builders/portal_detail.rs refbox/translations/
+git commit -m "fix(refbox): show an honest message when the portal cannot start"
+```
+
+---
+
+### Task 4: Stop REFRESH sticking when there is no client
+
+**Files:**
+- Modify: `refbox/src/app/mod.rs` (`Message::RequestPortalRefresh` arm, ~`:3555-3572`)
+
+**Interfaces:**
+- Consumes: nothing. Independent of Tasks 1–3, but required *because* of Task 1 — without it this branch introduces a new bug.
+- Produces: no new API.
+
+**Why this task exists.** Today REFRESH is greyed out in degraded mode because `token_expired` is true. Task 1 makes it live again. In a no-client session with a restored portal link, pressing it sets the spinner and calls `request_schedule`, which returns `Task::none()` when there is no client — so nothing ever arrives to clear the flag and the button reads "Refreshing…" indefinitely.
+
+- [ ] **Step 1: Replace the guard**
+
+The existing arm already refuses to spin when no event is linked. Extend the same reasoning to the client:
+
+```rust
+            Message::RequestPortalRefresh => {
+                // Only spin the REFRESH button when there is actually an event
+                // to refresh AND a client to fetch it with; otherwise nothing
+                // would arrive to clear the flag. The no-client case is real:
+                // a degraded startup (see PortalManager::new_degraded) can
+                // still have an event linked from a restored link note, and
+                // `request_schedule` returns Task::none() with no client, so
+                // without this the button sticks on "Refreshing..." forever.
+                match (
+                    self.current_event_id.clone(),
+                    self.uwhportal_client.is_some(),
+                ) {
+                    (Some(event_id), true) => {
+                        if let AppState::GameDetailsPage(ref mut is_refreshing) = self.app_state {
+                            *is_refreshing = true;
+                        }
+                        // request_schedule yields NoAction when the fetch fails;
+                        // translate that into a refresh-finished signal so the
+                        // "Refreshing..." button cannot stick on a network error.
+                        self.request_schedule(event_id).map(|msg| match msg {
+                            Message::NoAction => Message::PortalRefreshFinished,
+                            other => other,
+                        })
+                    }
+                    _ => Task::none(),
+                }
+            }
+```
+
+- [ ] **Step 2: Build**
+
+Run: `cargo build -p refbox`
+Expected: compiles clean.
+
+- [ ] **Step 3: Record the test gap honestly**
+
+This guard lives inside `update()`, which this codebase does not exercise directly in unit tests. **Do not invent a test that does not really cover it, and do not claim coverage in the commit message.** Note it in the Deviations section below, and verify it in Task 5's walkthrough instead.
+
+- [ ] **Step 4: Commit** (ask the human first)
+
+```bash
+git add refbox/src/app/mod.rs
+git commit -m "fix(refbox): don't spin REFRESH when there is no portal client"
+```
+
+---
+
+### Task 5: Full validation and the before/after walkthrough
+
+**Files:** none modified.
+
+- [ ] **Step 1: Run the full gate**
+
+Run: `just check`
+Expected: fmt, lint, tests and audit all clean. Do NOT pipe this to `tail` — that masks the exit code.
+
+- [ ] **Step 2: Build a real binary**
+
+Run: `cargo build -p refbox`
+Expected: success. `just check` builds a *test* binary; a walkthrough needs this one.
+
+- [ ] **Step 3: Force degraded mode for the walkthrough**
+
+There is no setting or environment switch for degraded mode. Reaching it needs the portal client to be absent, so use a scratch, uncommitted edit in `build_site_client` (`app/mod.rs:501`) returning `None` unconditionally. **This is walkthrough scaffolding and must never be committed** — no env-gated fakes in production source.
+
+- [ ] **Step 4: Run both builds against a throwaway config**
+
+Isolate completely so the real portal link is never touched:
+
+```bash
+XDG_CONFIG_HOME=/tmp/refbox-walkthrough WAYLAND_DISPLAY= ./target/debug/refbox
+```
+
+The config file created there is `default-config.toml`. A linked event is required for the portal dot to appear at all, so seed the throwaway config accordingly.
+
+Compare `master` against the branch and capture, for the human:
+1. The detail page row — was *"Access token expired — tap to re-login"*, now *"Portal unavailable — results will not upload"*.
+2. The game-info REFRESH button — was greyed out, now live; pressing it must NOT leave it stuck on "Refreshing…".
+3. The new row rendered in **German and Japanese**, checking the text fits the row without clipping. Translation fit has bitten this repo before and cannot be settled by reading code.
+
+- [ ] **Step 5: Remove the scaffolding**
+
+Run: `git status --porcelain refbox/src/app/mod.rs`
+Expected: no uncommitted change. Confirm the forced-`None` edit from Step 3 is gone.
+
+- [ ] **Step 6: Code review**
+
+Use `superpowers:requesting-code-review` once, now that the feature is complete (lean process — not after every task).
+
+---
+
+## Acceptance criteria
+
+Restated from the spec so this plan stands alone:
+
+1. A degraded manager reports the indicator as Red.
+2. A degraded manager reports `token_expired` as false.
+3. A degraded manager's detail rows contain `StartupFailed` and not `TokenExpired`.
+4. A genuine token rejection still reports `token_expired` true and still shows the `TokenExpired` row.
+5. In a forced-degraded walkthrough: the honest row appears, no re-login row appears, REFRESH is live and does not stick.
+6. Normal operation with a working portal is unchanged.
+
+## Deviations
+
+Record here rather than in standalone commits (lean process).
+
+- **Branched from `origin/master` (`adef2f6d`), not local master (`ba1d2c7d`, 6 behind).** The plan's
+  line numbers were derived against the older commit. Re-checked before editing: the three Rust
+  files this plan touches were **not** modified by those 6 commits (`token_known_problem: true` is
+  still at `mod.rs:613`). The `.ftl` files each lost one line (the `using-portal` key removal ×15),
+  so `portal-row-token-expired` moved from `en-US:429` to `:428`. All translation steps are
+  positional, so no plan step needed changing.
+- **Task 3 Step 5 rewritten.** The plan assumed translation coverage was only a warning-only
+  `build.rs` check. `refbox/src/translation_consistency.rs` landed in those 6 commits and is a real
+  enforcing test. Its third assertion — every English key must be *referenced in source* — means the
+  key and its `fl!` call must land together, which Task 3 already does.
+- **Row text changed after the walkthrough, and the spec was amended.** The approved string was
+  *"Portal unavailable — results will not upload"*. Eric asked during the walkthrough what happens
+  on a **custom site**, which exposed that the wording names the wrong system and would have
+  reintroduced what PR #2219 removed the day before. Final text, all 15 locales:
+  **"Connection unavailable — results will not upload"**. See the new "wording must be
+  source-neutral" section in the spec. This was caught by review, not by this plan.
+- **Tasks 1 and 2 committed together.** The plan gave them separate commits, but both edit
+  `portal_manager/mod.rs`, and interactive hunk staging is unavailable in this environment. Splitting
+  them would have required a commit that does not compile (the new enum variant breaks the renderer
+  until Task 3). Final structure is two commits: manager + row + rendering + translations, then the
+  REFRESH guard.
+- **Walkthrough exceeded the plan's step 4.** Verified in three configurations, not one: English
+  portal, German portal (fit confirmed — wraps to two lines at full size, no clipping or shrink), and
+  a third-party custom site (globe emblem, neutral wording). REFRESH was press-tested by Eric and
+  does not stick. Degraded mode was forced with a temporary env-var switch in `build_site_client`,
+  now removed and verified absent by grep.

--- a/docs/superpowers/plans/2026-08-13-degraded-portal-startup-message.md
+++ b/docs/superpowers/plans/2026-08-13-degraded-portal-startup-message.md
@@ -15,7 +15,7 @@
 - **Clippy:** `cargo clippy --workspace --all-features -- -D warnings` must be clean. No new `#[allow]`.
 - **No `unwrap()`/`expect()`** in non-test code without a comment explaining why it cannot panic.
 - **Translations:** every new key must exist in **all 15** locales (`de-DE en-US es fr id-ID it-IT ja-JP ko-KR ms-MY nl-NL pt-PT th-TH tl-PH tr-TR zh-CN`). No placeholders, no English left in a non-English file. A missing key is caught by `refbox/build.rs`, not by a test.
-- **Literal copy, exactly:** English row text is `Portal unavailable — results will not upload`. Use the spaced em-dash `—`, matching the neighbouring `portal-row-token-expired` key in every locale.
+- **Literal copy, exactly:** English row text is `Connection unavailable — results will not upload`. Use the spaced em-dash `—`, matching the neighbouring `portal-row-token-expired` key in every locale.
 - **Do NOT fix** the two misleading "https-only config" comments at `app/mod.rs:2389` and `:1112`. They are wrong, they are recorded in `docs/backlog/portal-login-silent-when-no-client/NOTE.md`, and they are out of scope for this branch.
 - **Branch:** `fix/refbox/degraded-portal-startup-message`. Ask the human before creating it and before every commit.
 
@@ -302,28 +302,28 @@ In `render_row`, add an arm. Model it on the existing `RecentSuccess` arm (~`:18
 In `refbox/translations/en-US/refbox.ftl`, in the `# Portal Health Indicator` section, directly after the `portal-row-token-expired` line:
 
 ```
-portal-row-startup-failed = Portal unavailable — results will not upload
+portal-row-startup-failed = Connection unavailable — results will not upload
 ```
 
 - [ ] **Step 3: Add the other 14 translations**
 
-Same position in each file — immediately after that locale's `portal-row-token-expired` line, so the section order stays identical across locales. Use exactly these:
+Same position in each file — immediately after that locale's `portal-row-token-expired` line, so the section order stays identical across locales. Each reuses its own locale's established word for "connection", taken from `portal-advisory-at-game-end`, so the health block reads as one vocabulary. Use exactly these:
 
 ```
-de-DE   portal-row-startup-failed = Portal nicht verfügbar — Ergebnisse werden nicht hochgeladen
-es      portal-row-startup-failed = Portal no disponible — los resultados no se subirán
-fr      portal-row-startup-failed = Portail indisponible — les résultats ne seront pas envoyés
-id-ID   portal-row-startup-failed = Portal tidak tersedia — hasil tidak akan diunggah
-it-IT   portal-row-startup-failed = Portale non disponibile — i risultati non verranno caricati
-ja-JP   portal-row-startup-failed = ポータルを利用できません — 結果はアップロードされません
-ko-KR   portal-row-startup-failed = 포털을 사용할 수 없습니다 — 결과가 업로드되지 않습니다
-ms-MY   portal-row-startup-failed = Portal tidak tersedia — keputusan tidak akan dimuat naik
-nl-NL   portal-row-startup-failed = Portaal niet beschikbaar — resultaten worden niet geüpload
-pt-PT   portal-row-startup-failed = Portal indisponível — os resultados não serão enviados
-th-TH   portal-row-startup-failed = ไม่สามารถใช้พอร์ทัลได้ — ผลการแข่งขันจะไม่ถูกอัปโหลด
-tl-PH   portal-row-startup-failed = Hindi available ang portal — hindi mai-a-upload ang mga resulta
-tr-TR   portal-row-startup-failed = Portal kullanılamıyor — sonuçlar yüklenmeyecek
-zh-CN   portal-row-startup-failed = 无法使用门户 — 成绩将不会上传
+de-DE   portal-row-startup-failed = Keine Verbindung — Ergebnisse werden nicht hochgeladen
+es      portal-row-startup-failed = Conexión no disponible — los resultados no se subirán
+fr      portal-row-startup-failed = Connexion indisponible — les résultats ne seront pas envoyés
+id-ID   portal-row-startup-failed = Koneksi tidak tersedia — hasil tidak akan diunggah
+it-IT   portal-row-startup-failed = Connessione non disponibile — i risultati non verranno caricati
+ja-JP   portal-row-startup-failed = 接続できません — 結果はアップロードされません
+ko-KR   portal-row-startup-failed = 연결할 수 없습니다 — 결과가 업로드되지 않습니다
+ms-MY   portal-row-startup-failed = Sambungan tidak tersedia — keputusan tidak akan dimuat naik
+nl-NL   portal-row-startup-failed = Geen verbinding — resultaten worden niet geüpload
+pt-PT   portal-row-startup-failed = Ligação indisponível — os resultados não serão enviados
+th-TH   portal-row-startup-failed = ไม่สามารถเชื่อมต่อได้ — ผลการแข่งขันจะไม่ถูกอัปโหลด
+tl-PH   portal-row-startup-failed = Walang koneksyon — hindi mai-a-upload ang mga resulta
+tr-TR   portal-row-startup-failed = Bağlantı yok — sonuçlar yüklenmeyecek
+zh-CN   portal-row-startup-failed = 无法连接 — 成绩将不会上传
 ```
 
 (The locale name is a label showing which file each line belongs in — write only the `portal-row-startup-failed = …` line into each `.ftl`.)
@@ -444,7 +444,7 @@ XDG_CONFIG_HOME=/tmp/refbox-walkthrough WAYLAND_DISPLAY= ./target/debug/refbox
 The config file created there is `default-config.toml`. A linked event is required for the portal dot to appear at all, so seed the throwaway config accordingly.
 
 Compare `master` against the branch and capture, for the human:
-1. The detail page row — was *"Access token expired — tap to re-login"*, now *"Portal unavailable — results will not upload"*.
+1. The detail page row — was *"Access token expired — tap to re-login"*, now *"Connection unavailable — results will not upload"*.
 2. The game-info REFRESH button — was greyed out, now live; pressing it must NOT leave it stuck on "Refreshing…".
 3. The new row rendered in **German and Japanese**, checking the text fits the row without clipping. Translation fit has bitten this repo before and cannot be settled by reading code.
 

--- a/docs/superpowers/specs/2026-08-13-degraded-portal-startup-message-design.md
+++ b/docs/superpowers/specs/2026-08-13-degraded-portal-startup-message-design.md
@@ -1,0 +1,241 @@
+# Degraded portal startup: stop blaming the operator's login
+
+**Date:** 2026-08-13
+**Crate:** `refbox` only
+**Origin:** finding 3 of `docs/audit-archive/2026-08-11-ai-slop-inventory.md` (reachable only via
+`git show 87be104b:docs/audit-archive/2026-08-11-ai-slop-inventory.md`)
+
+---
+
+## The problem in one sentence
+
+When the portal subsystem fails to start because of a fault in the machine, the refbox tells the
+operator that their access token expired and pushes them into a re-login that cannot even send a
+request.
+
+## What actually happens today
+
+The refbox has a "degraded mode" for when the portal subsystem cannot start. It is deliberate and
+correct in spirit: the game clock and scoring keep working, which is what matters at the pool, and
+the portal dot turns red so the operator knows something is wrong.
+
+The defect is in *what the red dot says*. Degraded startup sets the flag that means "the portal
+rejected our saved token" (`portal_manager/mod.rs:613`). Nothing about either trigger concerns the
+login, but that flag is what drives the operator-facing wording, so the refbox reports a
+credential problem it has no evidence for.
+
+### The two triggers, and which one matters
+
+Degraded mode is entered from exactly two places:
+
+1. **The portal client could not be built** (`app/mod.rs:2404`). Every failure path inside the HTTP
+   client's constructor is TLS-related — certificate-store and TLS-version problems, e.g. *"zero
+   valid certificates found in native root store"*. A Raspberry Pi with a broken system
+   certificate store is exactly this. **This is the realistic trigger.**
+2. **The retry-queue file could not be read** in the config directory *and* in the system temp
+   directory (`app/mod.rs:2433`). Both must fail. Near-unreachable.
+
+Note for future readers: two comments in `app/mod.rs` (at `:2389` and `:1112`) claim trigger 1 is
+"only possible on a bad https-only config". That is wrong — the https-only setting is a stored
+flag enforced per request, so such a configuration builds a client successfully and fails each
+call instead. Those comments are **not** corrected by this work; they are recorded here so the
+next reader is not misled.
+
+### How narrow is this?
+
+Narrower than the audit report implies, and the narrowing is what makes this a small fix rather
+than an urgent one. The portal dot is only displayed when the portal is in use **and** an event is
+linked (`app/mod.rs:5909-5920`). With no linked event there is no dot, no false row, and no greyed
+REFRESH — the defect is invisible.
+
+There are two realistic paths to it, and **the second is the more reachable one** — found by Eric's
+question during the walkthrough, not by this design:
+
+> **Portal path.** A Pi that was linked to an event recently. Its saved link note is restored at
+> startup with no network required (`app/mod.rs:2549`), so an event *is* linked. That day the
+> certificate store is broken, so the client fails to build and the refbox starts degraded.
+
+> **Custom-site path — more reachable.** A refbox pointed at a third-party site adopts its event
+> straight out of the saved URL at startup (`app/mod.rs:2584-2585` → `adopt_custom_event`,
+> `app/mod.rs:1183`), with no network and no client. Verified live: the log shows
+> `Adopted custom site event events/1234-A` with the client forced absent and the portal link note
+> deleted.
+
+The difference matters. The portal path needs a link note **less than 120 hours old**; the custom
+path needs only a URL sitting in the config file, which never expires. So a refbox configured for a
+third-party site with a broken certificate store shows this red dot **on every launch,
+indefinitely**.
+
+### What the operator sees on that path
+
+- A red portal dot.
+- On the detail page: **"Access token expired — tap to re-login"**
+  (`translations/en-US/refbox.ftl:429`).
+- REFRESH greyed out on the game-info screen (`view_builders/game_info.rs:33,45`).
+- At game end, a red banner: *"Connection issue detected. Score will still be queued — find an
+  admin to resolve."*
+- **If they obey the instruction:** the login keypad marks the request as sent
+  (`app/mod.rs:4268`) and calls a function that, with no client, returns nothing at all
+  (`app/mod.rs:991-1011`). No success, no error, no timeout. They enter the code from the portal
+  website and nothing whatsoever happens. The comment at `app/mod.rs:4288` says the reply "will
+  replace this once the network request completes" — it never completes.
+
+That dead-end is the harm being fixed: at poolside, the operator burns time on a login that cannot
+work, when what they need to know is that results are not uploading.
+
+### What is NOT wrong (checked, and contrary to the audit report)
+
+The report escalates this to a "permanently green" indicator: re-login clears the flag, and in
+degraded mode nothing can set it again, so the dot supposedly goes green forever while nothing
+uploads. **That escalation cannot occur on the realistic trigger.** Clearing the flag requires a
+successful re-login, a re-login requires a client, and the realistic trigger *is* having no client
+(`app/mod.rs:991-1011`; a client cannot appear mid-session either — `repoint_client` at
+`app/mod.rs:1109-1119` bails out and says a restart is needed).
+
+And even where it is reachable, "permanently green" is overstated: the indicator is recomputed
+every second by a UI tick that needs no background task (`app/mod.rs:6242-6245`), so green lasts
+only until the first game is queued — then yellow, then red 30 minutes later.
+
+This design therefore addresses the wrong-message half only. The escalation needs no separate work
+because the fix removes the flag it depends on.
+
+---
+
+## Goal
+
+A system fault reports itself as a system fault. Specifically:
+
+- Keep the red dot. Something *is* wrong and the operator must know.
+- Stop claiming the access token expired.
+- Stop pushing the operator into a re-login that cannot send a request.
+- Stop greying out REFRESH for a reason that is not true.
+- Tell the operator the one thing they can act on: results are not uploading.
+
+## Non-goals
+
+- Not hardening the false-green escalation separately — the fix removes its precondition.
+- Not correcting the two misleading "bad https-only config" comments (recorded above).
+- Not touching ADR 011's missing failure counter (finding 5) or the unreachable yellow state
+  (finding 4).
+- Not changing the queue-I/O fallback ordering or the degraded-mode design itself.
+- Not making the portal work in degraded mode. It cannot; the point is to say so honestly.
+
+---
+
+## Design
+
+### Approach chosen
+
+A **separate flag for "the portal subsystem never started"**, rather than reusing the existing
+`connection_problem` flag.
+
+Reusing `connection_problem` was the audit report's suggestion and was rejected for two reasons:
+it would report a connection fault when the trigger can be a local disk failure, and it draws no
+detail row at all — trading a wrong message for a blank page. A third option (collapsing both
+flags into a single "reason the dot is red" value) was rejected as scope creep: it rewrites
+behaviour that is currently correct and tested.
+
+### Changes
+
+| # | Where | Change |
+|---|-------|--------|
+| 1 | `portal_manager/mod.rs` | New field `startup_problem: bool`. Set `true` **only** by `new_degraded()`; `false` in every other constructor. `new_degraded()` no longer sets `token_known_problem`. |
+| 2 | `portal_manager/mod.rs` | `recompute_indicator` treats `startup_problem` as a red cause, alongside `needs_attention()` and `connection_problem`. `token_expired` stays driven by `token_known_problem` alone, so it is now `false` in degraded mode. |
+| 3 | `portal_manager/mod.rs` | New `DetailRow::StartupFailed`. `detail_rows()` emits it first when `startup_problem` is set (the position the token row used to hold). |
+| 4 | `view_builders/portal_detail.rs` | Render `StartupFailed` as a **non-tappable** red strip, mirroring the existing `RecentSuccess` container shape — there is nothing for the operator to tap. |
+| 5 | `translations/` ×15 locales | New key `portal-row-startup-failed`. English, literally: **"Connection unavailable — results will not upload"** |
+| 6 | `app/mod.rs:3556` | Complete the existing REFRESH guard: it already refuses to spin when no event is linked; it must also refuse when there is no client. |
+
+### Why change 6 is required, not optional
+
+It is not a nicety — without it this fix introduces a new bug. Today REFRESH is greyed out in
+degraded mode because `token_expired` is true. Change 2 makes it live again. In a no-client
+session with a restored link, pressing it sets the spinner and calls `request_schedule`, which
+returns nothing when there is no client — so the button sticks on "Refreshing…" indefinitely.
+
+The guard mirrors the reasoning already written at `app/mod.rs:3556`: *"Only spin the REFRESH
+button when there is actually an event to refresh; otherwise nothing would arrive to clear the
+flag."* The same sentence applies word-for-word to the client. With the guard, pressing REFRESH in
+a no-client session does nothing — which is already the established behaviour when no event is
+linked.
+
+### The wording must be source-neutral — this is a rule, not a preference
+
+**The row must never name the Portal.** This design's first draft said *"Portal unavailable"* and
+that was wrong: the refbox can be pointed at a third-party site, and the custom-site path above is
+the *more* reachable route to this very screen. Naming the Portal there reports the wrong system.
+
+It would also have reintroduced the exact defect **PR #2219 removed on 2026-08-12**, one day before
+this work. Every other string in this block is deliberately neutral — `CONNECTION STATUS`,
+*"Access token expired"*, *"Connection issue detected."* — while the **key names** stay `portal-*`
+by an explicit decision recorded in that branch. A new `portal-*` key is therefore fine; new
+Portal-*wording* is not.
+
+Each locale reuses its own established word for "connection", taken from
+`portal-advisory-at-game-end`, so the page reads as one vocabulary: `Verbindung`, `Conexión`,
+`Connexion`, `Koneksi`, `Connessione`, `接続`, `연결`, `Sambungan`, `verbinding`, `Ligação`,
+`เชื่อมต่อ`, `koneksyon`, `Bağlantı`, `连接`.
+
+**Check the values, not the lines.** A `grep` for "portal" over matching lines gives a false pass,
+because the key name contains it. Cut the value after the `=` first — that mistake was made and
+caught here.
+
+### Flag lifecycle
+
+`startup_problem` has **no setter other than the constructor**. That is deliberate and correct:
+neither trigger can heal without a restart. A missing TLS certificate store does not repair itself
+mid-session, and no client can appear mid-session. So the red dot stays red for the whole session,
+which is the truth.
+
+This also means the fix cannot regress into the false-green behaviour the audit report worried
+about: `token_refreshed()` clears `token_known_problem`, and after this change degraded mode never
+sets that flag.
+
+---
+
+## Acceptance criteria
+
+What the human can observe or run to confirm this worked.
+
+**Automated (tests that fail before the change, pass after):**
+
+1. A degraded manager reports the indicator as **Red**.
+2. A degraded manager reports `token_expired` as **false**.
+3. A degraded manager's detail rows contain `StartupFailed` and **do not** contain `TokenExpired`.
+4. A non-degraded manager with a genuine token rejection still reports `token_expired` true and
+   still shows the `TokenExpired` row — i.e. the real token path is untouched.
+
+Each guard must be mutation-tested: delete the fix, confirm the test fails, restore. A test that
+passes both ways is worthless here, and that is precisely how the original defect survived.
+
+**Observable at the machine:**
+
+5. Start the refbox so that the portal client cannot be built, with an event linked. The portal
+   dot is red; the detail page reads "Portal unavailable — results will not upload"; there is no
+   "tap to re-login" row; the REFRESH button on game info is **not** greyed out; pressing REFRESH
+   does not leave the button stuck on "Refreshing…".
+6. Normal operation is unchanged: with a working portal, the dot behaves exactly as before.
+
+**How to produce the failure for step 5 without breaking the machine:** run the refbox against a
+throwaway config directory via `XDG_CONFIG_HOME`, so the real portal link is untouched. The
+degraded path itself may be easier to reach through a temporary forced-`None` client in a scratch
+build than by breaking a real certificate store; if a genuine trigger cannot be produced safely,
+say so plainly rather than claiming the walkthrough passed.
+
+---
+
+## Testing notes
+
+- Tests 1–4 are unit tests in `portal_manager/mod.rs`, alongside the existing
+  `new_degraded_indicator_has_token_known_problem_and_no_spawned_task` test — **which must be
+  renamed and rewritten**, since it currently asserts the very behaviour being removed.
+- The REFRESH guard (change 6) lives in `update()` and may not be unit-testable in this codebase's
+  current shape. If it is not, say so and verify it in the walkthrough rather than claiming
+  coverage that does not exist.
+
+## Risk
+
+Low. One crate, no shared types, no wire format, no state machine, no embedded code. Per
+`.claude/rules/plan-execution.md` this is the **lean** process. The only behaviour reaching
+existing healthy installations is that a degraded startup now shows a different message and leaves
+REFRESH live; no path that works today stops working.

--- a/docs/superpowers/specs/2026-08-13-degraded-portal-startup-message-design.md
+++ b/docs/superpowers/specs/2026-08-13-degraded-portal-startup-message-design.md
@@ -211,7 +211,7 @@ passes both ways is worthless here, and that is precisely how the original defec
 **Observable at the machine:**
 
 5. Start the refbox so that the portal client cannot be built, with an event linked. The portal
-   dot is red; the detail page reads "Portal unavailable — results will not upload"; there is no
+   dot is red; the detail page reads "Connection unavailable — results will not upload"; there is no
    "tap to re-login" row; the REFRESH button on game info is **not** greyed out; pressing REFRESH
    does not leave the button stuck on "Refreshing…".
 6. Normal operation is unchanged: with a working portal, the dot behaves exactly as before.

--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -3576,6 +3576,14 @@ impl RefBoxApp {
                             other => other,
                         })
                     }
+                    (Some(_), false) => {
+                        // Degraded mode: the button is live (the login is not
+                        // the problem) but there is nothing to fetch with. Log
+                        // it — a press that does nothing is otherwise invisible
+                        // in a support log.
+                        warn!("REFRESH pressed but no portal client was started; nothing to fetch");
+                        Task::none()
+                    }
                     _ => Task::none(),
                 }
             }

--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -3554,20 +3554,29 @@ impl RefBoxApp {
             }
             Message::RequestPortalRefresh => {
                 // Only spin the REFRESH button when there is actually an event
-                // to refresh; otherwise nothing would arrive to clear the flag.
-                if let Some(event_id) = self.current_event_id.clone() {
-                    if let AppState::GameDetailsPage(ref mut is_refreshing) = self.app_state {
-                        *is_refreshing = true;
+                // to refresh AND a client to fetch it with; otherwise nothing
+                // would arrive to clear the flag. The no-client case is real:
+                // a degraded startup (see PortalManager::new_degraded) can
+                // still have an event linked from a restored link note, and
+                // `request_schedule` returns Task::none() with no client, so
+                // without this the button sticks on "Refreshing..." forever.
+                match (
+                    self.current_event_id.clone(),
+                    self.uwhportal_client.is_some(),
+                ) {
+                    (Some(event_id), true) => {
+                        if let AppState::GameDetailsPage(ref mut is_refreshing) = self.app_state {
+                            *is_refreshing = true;
+                        }
+                        // request_schedule yields NoAction when the fetch fails;
+                        // translate that into a refresh-finished signal so the
+                        // "Refreshing..." button cannot stick on a network error.
+                        self.request_schedule(event_id).map(|msg| match msg {
+                            Message::NoAction => Message::PortalRefreshFinished,
+                            other => other,
+                        })
                     }
-                    // request_schedule yields NoAction when the fetch fails;
-                    // translate that into a refresh-finished signal so the
-                    // "Refreshing..." button cannot stick on a network error.
-                    self.request_schedule(event_id).map(|msg| match msg {
-                        Message::NoAction => Message::PortalRefreshFinished,
-                        other => other,
-                    })
-                } else {
-                    Task::none()
+                    _ => Task::none(),
                 }
             }
             Message::PortalRefreshFinished => {

--- a/refbox/src/app/view_builders/game_info.rs
+++ b/refbox/src/app/view_builders/game_info.rs
@@ -25,11 +25,14 @@ pub(in super::super) fn build_game_info_page<'a>(
         ..
     } = data;
 
-    // A refresh re-fetches the schedule from the portal, which can only
-    // fail while the saved login token is expired — so grey the button out
-    // in that one case and leave the operator to re-login via the
-    // connection indicator. A Red caused merely by a stuck submission
-    // leaves `token_expired` false and keeps refresh usable.
+    // A refresh re-fetches the schedule from the portal. Grey the button out
+    // only when the saved login token is expired — the one case a re-login
+    // fixes — and leave the operator to re-login via the connection
+    // indicator. Every other Red cause leaves `token_expired` false and keeps
+    // refresh usable: a stuck submission, a connectivity drop, or a startup
+    // failure. In that last case there is no client to fetch with, so the
+    // button stays live but its handler declines to spin (see
+    // `Message::RequestPortalRefresh`).
     let token_expired = portal_indicator.is_some_and(|s| s.token_expired);
 
     let middle_item: Element<_> = if uses_remote {

--- a/refbox/src/app/view_builders/portal_detail.rs
+++ b/refbox/src/app/view_builders/portal_detail.rs
@@ -18,9 +18,10 @@ const PORTAL_DETAIL_LIST_LEN: usize = 4;
 /// the bottom row left blank.
 ///
 /// Rows produced by `PortalManager::detail_rows()` come in
-/// fixed order: the token-expired row first (if present), then stuck
-/// items (oldest first), then young pending items (oldest first),
-/// then recent successes (newest first, capped at RECENT_SUCCESS_CAP).
+/// fixed order: the startup-failure row first, then the token-expired row
+/// (only one of the two can occur), then stuck items (oldest first), then
+/// young pending items (oldest first), then recent successes (newest
+/// first, capped at RECENT_SUCCESS_CAP).
 pub(in super::super) fn build_portal_detail_page<'a>(
     data: ViewData<'_, '_>,
     rows: Vec<DetailRow>,

--- a/refbox/src/app/view_builders/portal_detail.rs
+++ b/refbox/src/app/view_builders/portal_detail.rs
@@ -133,6 +133,12 @@ fn row_text_centered<'a>(label: String) -> Element<'a, Message> {
 
 fn render_row<'a>(r: DetailRow) -> Element<'a, Message> {
     match r {
+        DetailRow::StartupFailed => container(row_text_centered(fl!("portal-row-startup-failed")))
+            .style(red_container)
+            .padding(PADDING)
+            .width(Length::Fill)
+            .height(Length::Fixed(MIN_BUTTON_SIZE))
+            .into(),
         DetailRow::TokenExpired => button(row_text_centered(fl!("portal-row-token-expired")))
             .on_press(Message::EditGameConfigPage(ConfigPage::Game))
             .style(red_button)

--- a/refbox/src/portal_manager/mod.rs
+++ b/refbox/src/portal_manager/mod.rs
@@ -248,9 +248,10 @@ pub struct PortalIndicatorState {
     /// True when the saved login token is known to be expired/rejected.
     /// This is the specific Red cause that makes a schedule refresh
     /// pointless (it can only fail until the operator re-logs-in), so
-    /// the game-info REFRESH button greys out on it. A Red caused only
-    /// by a stuck queue item — or by a connectivity problem (the portal
-    /// is unreachable, but the login may be fine) — leaves this `false`.
+    /// the game-info REFRESH button greys out on it. Every other Red cause
+    /// leaves this `false`, because the login may be fine: a stuck queue
+    /// item, a connectivity problem (the portal is unreachable), or a
+    /// startup failure (the portal subsystem never started at all).
     pub token_expired: bool,
     /// True when this indicator is reporting on a third-party site rather than
     /// the built-in portal. Set by the view layer from the committed game
@@ -314,10 +315,11 @@ pub enum PortalEvent {
 }
 
 /// One row rendered on the portal detail page. The ordering of the
-/// returned `Vec<DetailRow>` is the on-screen order: token-expired
-/// banner first (if present), then stuck items (oldest first), then
-/// young pending items (oldest first), then recent successes (newest
-/// first, capped at `RECENT_SUCCESS_CAP`).
+/// returned `Vec<DetailRow>` is the on-screen order: startup-failure
+/// banner first, then the token-expired banner (only one of the two can
+/// occur), then stuck items (oldest first), then young pending items
+/// (oldest first), then recent successes (newest first, capped at
+/// `RECENT_SUCCESS_CAP`).
 #[derive(Debug, Clone)]
 pub enum DetailRow {
     /// Shown at the top when the portal subsystem could not start at all

--- a/refbox/src/portal_manager/mod.rs
+++ b/refbox/src/portal_manager/mod.rs
@@ -320,6 +320,11 @@ pub enum PortalEvent {
 /// first, capped at `RECENT_SUCCESS_CAP`).
 #[derive(Debug, Clone)]
 pub enum DetailRow {
+    /// Shown at the top when the portal subsystem could not start at all
+    /// (`startup_problem`). Deliberately NOT tappable: there is nothing
+    /// the operator can do from the refbox, and the fault cannot heal
+    /// without a restart.
+    StartupFailed,
     /// Shown at the top when `token_known_problem` is true. Tapping
     /// drives the operator through the portal re-login flow.
     TokenExpired,
@@ -401,6 +406,21 @@ pub struct PortalManager {
     /// nor shows the re-login row. Cleared by the next probe that reaches
     /// the portal (whether it accepts or rejects the token).
     connection_problem: bool,
+    /// Set true only by `new_degraded()`: the portal subsystem could not
+    /// start at all. Either the HTTP client failed to build (realistically
+    /// a TLS/certificate-store fault) or the retry queue was unreadable in
+    /// both the config dir and the system temp dir.
+    ///
+    /// Drives the Red indicator like the other two problem flags, but
+    /// deliberately leaves `token_expired` false: neither trigger is
+    /// evidence about the operator's login, and claiming otherwise sends
+    /// them into a re-login that — with no client — cannot even send a
+    /// request.
+    ///
+    /// There is deliberately no setter. Neither trigger can heal without a
+    /// restart (no client can appear mid-session — see `repoint_client` in
+    /// `app/mod.rs`), so this stays true for the life of the process.
+    startup_problem: bool,
     indicator_state: PortalIndicatorState,
     command_tx: mpsc::Sender<health::PortalCommand>,
     config_dir: std::path::PathBuf,
@@ -424,6 +444,7 @@ impl PortalManager {
             check_in_flight,
             token_known_problem,
             connection_problem: false,
+            startup_problem: false,
             indicator_state: PortalIndicatorState::default(),
             command_tx: tx,
             config_dir: std::env::temp_dir(),
@@ -511,7 +532,7 @@ impl PortalManager {
     }
 
     fn recompute_indicator(&mut self) {
-        let health = if self.needs_attention() || self.connection_problem {
+        let health = if self.needs_attention() || self.connection_problem || self.startup_problem {
             HealthState::Red
         } else if self.check_in_flight || self.has_score_pending_items() {
             HealthState::Yellow
@@ -571,6 +592,7 @@ impl PortalManager {
             check_in_flight: false,
             token_known_problem: false,
             connection_problem: false,
+            startup_problem: false,
             indicator_state: PortalIndicatorState::default(),
             command_tx,
             config_dir: config_dir.to_path_buf(),
@@ -609,9 +631,12 @@ impl PortalManager {
         let mut m = Self {
             queue: QueueFile::empty(),
             check_in_flight: false,
-            // Key: indicator will show Red so the operator sees the problem.
-            token_known_problem: true,
+            // The portal subsystem never started. Red so the operator sees
+            // the problem — but NOT `token_known_problem`: nothing here is
+            // evidence the login expired.
+            token_known_problem: false,
             connection_problem: false,
+            startup_problem: true,
             indicator_state: PortalIndicatorState::default(),
             command_tx,
             config_dir: std::env::temp_dir(),
@@ -922,13 +947,20 @@ impl PortalManager {
 
     /// Compute the ordered list of rows displayed on the portal detail
     /// page. Ordering:
-    /// 1. `TokenExpired` banner, if a token problem is flagged.
+    /// 1. `StartupFailed`, if the portal subsystem never started; then the
+    ///    `TokenExpired` banner, if a token problem is flagged. In practice
+    ///    only one can occur — degraded startup no longer sets the token
+    ///    flag — but the order is defined so the page is deterministic.
     /// 2. `Stuck` items (queued ≥ 30 min ago), oldest first.
     /// 3. `Pending` items (queued < 30 min ago), oldest first.
     /// 4. `RecentSuccess` rows, newest first, capped at
     ///    `RECENT_SUCCESS_CAP`.
     pub fn detail_rows(&self) -> Vec<DetailRow> {
         let mut out: Vec<DetailRow> = Vec::new();
+
+        if self.startup_problem {
+            out.push(DetailRow::StartupFailed);
+        }
 
         if self.token_known_problem {
             out.push(DetailRow::TokenExpired);
@@ -1076,6 +1108,55 @@ mod tests {
         m.on_token_unreachable();
         assert_eq!(m.indicator_state().health, HealthState::Red);
         assert!(!m.indicator_state().token_expired);
+    }
+
+    #[test]
+    fn degraded_startup_is_red() {
+        let (m, _rx) = PortalManager::new_degraded();
+        assert_eq!(
+            m.indicator_state().health,
+            HealthState::Red,
+            "a portal subsystem that never started must show red"
+        );
+    }
+
+    #[test]
+    fn degraded_startup_does_not_report_token_expired() {
+        // The triggers are a system fault (the HTTP client failed to build,
+        // realistically a TLS/certificate-store problem) or an unreadable
+        // queue file. Neither is evidence about the operator's login.
+        // Reporting token_expired greys out the schedule REFRESH button and
+        // shows a "tap to re-login" row — and with no client a re-login
+        // cannot even send a request, so the operator is sent nowhere.
+        let (m, _rx) = PortalManager::new_degraded();
+        assert!(
+            !m.indicator_state().token_expired,
+            "degraded startup must not blame the operator's access token"
+        );
+    }
+
+    #[test]
+    fn degraded_startup_shows_startup_failed_row_not_token_expired() {
+        let (m, _rx) = PortalManager::new_degraded();
+        let rows = m.detail_rows();
+        assert!(
+            matches!(rows.first(), Some(DetailRow::StartupFailed)),
+            "the degraded detail page must lead with the startup-failure row, got {rows:?}"
+        );
+        assert!(
+            !rows.iter().any(|r| matches!(r, DetailRow::TokenExpired)),
+            "degraded startup must never offer a re-login that cannot send a request"
+        );
+    }
+
+    #[test]
+    fn genuine_token_rejection_still_reports_token_expired() {
+        // Guard the path this change must NOT disturb: a real rejection
+        // from the portal still greys REFRESH and still offers re-login.
+        let mut m = PortalManager::new_for_test(QueueFile::empty(), false, false);
+        m.on_token_status(false);
+        assert_eq!(m.indicator_state().health, HealthState::Red);
+        assert!(m.indicator_state().token_expired);
     }
 
     #[test]
@@ -1347,10 +1428,11 @@ mod tests {
     }
 
     #[test]
-    fn new_degraded_indicator_has_token_known_problem_and_no_spawned_task() {
+    fn new_degraded_is_red_with_no_spawned_task() {
         let (manager, mut rx) = PortalManager::new_degraded();
 
-        // The indicator should reflect token_known_problem (Red state).
+        // Red so the operator sees the problem — via `startup_problem`,
+        // not by claiming the access token expired.
         let state = manager.indicator_state();
         assert_eq!(
             state.health,

--- a/refbox/translations/de-DE/refbox.ftl
+++ b/refbox/translations/de-DE/refbox.ftl
@@ -396,6 +396,7 @@ false-start = Fehlstart
 portal-summary-title = VERBINDUNGSSTATUS
 portal-retry-all = ALLE WIEDERHOLEN
 portal-row-token-expired = Zugriffstoken abgelaufen — zum erneuten Anmelden tippen
+portal-row-startup-failed = Keine Verbindung — Ergebnisse werden nicht hochgeladen
 portal-row-stuck = Spiel { $game } Übermittlungsfehler, zum Beheben tippen
 portal-row-pending = Spiel { $game } Spielstand nicht gesendet, zum erneuten Versuch tippen
 portal-row-stats-pending = Spiel { $game } Statistik nicht gesendet, zum erneuten Versuch tippen

--- a/refbox/translations/en-US/refbox.ftl
+++ b/refbox/translations/en-US/refbox.ftl
@@ -426,6 +426,7 @@ false-start = False Start
 portal-summary-title = CONNECTION STATUS
 portal-retry-all = RETRY ALL
 portal-row-token-expired = Access token expired — tap to re-login
+portal-row-startup-failed = Connection unavailable — results will not upload
 portal-row-stuck = Game { $game } Score send error, tap to fix
 portal-row-pending = Game { $game } Score not sent, tap to retry
 portal-row-stats-pending = Game { $game } Stats not sent, tap to retry

--- a/refbox/translations/es/refbox.ftl
+++ b/refbox/translations/es/refbox.ftl
@@ -408,6 +408,7 @@ false-start = Saque nulo
 portal-summary-title = ESTADO DE CONEXIÓN
 portal-retry-all = REINTENTAR TODO
 portal-row-token-expired = Token de acceso expirado — toca para iniciar sesión
+portal-row-startup-failed = Conexión no disponible — los resultados no se subirán
 portal-row-stuck = Juego { $game } · Error al enviar resultado, toca para corregir
 portal-row-pending = Juego { $game } · Resultado no enviado, toca para reintentar
 portal-row-stats-pending = Juego { $game } · Estadísticas no enviadas, toca para reintentar

--- a/refbox/translations/fr/refbox.ftl
+++ b/refbox/translations/fr/refbox.ftl
@@ -400,6 +400,7 @@ false-start = Faux départs
 portal-summary-title = STATUT DE CONNEXION
 portal-retry-all = TOUT RÉESSAYER
 portal-row-token-expired = Jeton d'accès expiré — touchez pour vous reconnecter
+portal-row-startup-failed = Connexion indisponible — les résultats ne seront pas envoyés
 portal-row-stuck = Match { $game } · Erreur d'envoi du résultat, touchez pour corriger
 portal-row-pending = Match { $game } · Résultat non envoyé, touchez pour réessayer
 portal-row-stats-pending = Match { $game } · Statistiques non envoyées, touchez pour réessayer

--- a/refbox/translations/id-ID/refbox.ftl
+++ b/refbox/translations/id-ID/refbox.ftl
@@ -396,6 +396,7 @@ false-start = Start Curang
 portal-summary-title = STATUS KONEKSI
 portal-retry-all = ULANGI SEMUA
 portal-row-token-expired = Token akses kedaluwarsa — ketuk untuk login ulang
+portal-row-startup-failed = Koneksi tidak tersedia — hasil tidak akan diunggah
 portal-row-stuck = Pertandingan { $game } Galat kirim skor, ketuk untuk perbaiki
 portal-row-pending = Pertandingan { $game } Skor belum terkirim, ketuk untuk coba lagi
 portal-row-stats-pending = Pertandingan { $game } Statistik belum terkirim, ketuk untuk coba lagi

--- a/refbox/translations/it-IT/refbox.ftl
+++ b/refbox/translations/it-IT/refbox.ftl
@@ -396,6 +396,7 @@ false-start = Falsa Partenza
 portal-summary-title = STATO CONNESSIONE
 portal-retry-all = RIPROVA TUTTO
 portal-row-token-expired = Token di accesso scaduto — tocca per accedere di nuovo
+portal-row-startup-failed = Connessione non disponibile — i risultati non verranno caricati
 portal-row-stuck = Partita { $game } Errore invio punteggio, tocca per correggere
 portal-row-pending = Partita { $game } Punteggio non inviato, tocca per riprovare
 portal-row-stats-pending = Partita { $game } Statistiche non inviate, tocca per riprovare

--- a/refbox/translations/ja-JP/refbox.ftl
+++ b/refbox/translations/ja-JP/refbox.ftl
@@ -396,6 +396,7 @@ false-start = 不正スタート
 portal-summary-title = 接続状態
 portal-retry-all = すべて再試行
 portal-row-token-expired = アクセストークンの有効期限が切れました — タップして再ログイン
+portal-row-startup-failed = 接続できません — 結果はアップロードされません
 portal-row-stuck = 試合 { $game } のスコア送信エラー、タップして修正
 portal-row-pending = 試合 { $game } のスコアが未送信、タップして再試行
 portal-row-stats-pending = 試合 { $game } の統計が未送信、タップして再試行

--- a/refbox/translations/ko-KR/refbox.ftl
+++ b/refbox/translations/ko-KR/refbox.ftl
@@ -398,6 +398,7 @@ false-start = 부정 출발
 portal-summary-title = 연결 상태
 portal-retry-all = 모두 재시도
 portal-row-token-expired = 액세스 토큰 만료됨 — 탭하여 다시 로그인
+portal-row-startup-failed = 연결할 수 없습니다 — 결과가 업로드되지 않습니다
 portal-row-stuck = 경기 { $game } 점수 전송 오류, 탭하여 수정
 portal-row-pending = 경기 { $game } 점수 전송 안 됨, 탭하여 재시도
 portal-row-stats-pending = 경기 { $game } 통계 전송 안 됨, 탭하여 재시도

--- a/refbox/translations/ms-MY/refbox.ftl
+++ b/refbox/translations/ms-MY/refbox.ftl
@@ -396,6 +396,7 @@ false-start = Permulaan Palsu
 portal-summary-title = STATUS SAMBUNGAN
 portal-retry-all = CUBA SEMULA SEMUA
 portal-row-token-expired = Token akses tamat tempoh — ketik untuk log masuk semula
+portal-row-startup-failed = Sambungan tidak tersedia — keputusan tidak akan dimuat naik
 portal-row-stuck = Perlawanan { $game } Ralat hantar markah, ketik untuk perbaiki
 portal-row-pending = Perlawanan { $game } Markah belum dihantar, ketik untuk cuba semula
 portal-row-stats-pending = Perlawanan { $game } Statistik belum dihantar, ketik untuk cuba semula

--- a/refbox/translations/nl-NL/refbox.ftl
+++ b/refbox/translations/nl-NL/refbox.ftl
@@ -396,6 +396,7 @@ false-start = Vals Vertrek
 portal-summary-title = VERBINDINGSSTATUS
 portal-retry-all = ALLES OPNIEUW
 portal-row-token-expired = Toegangstoken verlopen — tik om opnieuw in te loggen
+portal-row-startup-failed = Geen verbinding — resultaten worden niet geüpload
 portal-row-stuck = Wedstrijd { $game } Fout bij verzenden score, tik om te herstellen
 portal-row-pending = Wedstrijd { $game } Score niet verzonden, tik om opnieuw te proberen
 portal-row-stats-pending = Wedstrijd { $game } Statistieken niet verzonden, tik om opnieuw te proberen

--- a/refbox/translations/pt-PT/refbox.ftl
+++ b/refbox/translations/pt-PT/refbox.ftl
@@ -396,6 +396,7 @@ false-start = Saída Falsa
 portal-summary-title = ESTADO DA LIGAÇÃO
 portal-retry-all = REPETIR TUDO
 portal-row-token-expired = Token de acesso expirou — toque para iniciar sessão novamente
+portal-row-startup-failed = Ligação indisponível — os resultados não serão enviados
 portal-row-stuck = Jogo { $game } Erro no envio do resultado, toque para corrigir
 portal-row-pending = Jogo { $game } Resultado não enviado, toque para tentar novamente
 portal-row-stats-pending = Jogo { $game } Estatísticas não enviadas, toque para tentar novamente

--- a/refbox/translations/th-TH/refbox.ftl
+++ b/refbox/translations/th-TH/refbox.ftl
@@ -395,6 +395,7 @@ false-start = การออกตัวผิด
 portal-summary-title = สถานะการเชื่อมต่อ
 portal-retry-all = ลองใหม่ทั้งหมด
 portal-row-token-expired = โทเค็นการเข้าถึงหมดอายุ — แตะเพื่อเข้าสู่ระบบใหม่
+portal-row-startup-failed = ไม่สามารถเชื่อมต่อได้ — ผลการแข่งขันจะไม่ถูกอัปโหลด
 portal-row-stuck = เกม { $game } ส่งคะแนนผิดพลาด แตะเพื่อแก้ไข
 portal-row-pending = เกม { $game } ยังไม่ส่งคะแนน แตะเพื่อลองอีกครั้ง
 portal-row-stats-pending = เกม { $game } ยังไม่ส่งสถิติ แตะเพื่อลองอีกครั้ง

--- a/refbox/translations/tl-PH/refbox.ftl
+++ b/refbox/translations/tl-PH/refbox.ftl
@@ -396,6 +396,7 @@ false-start = Maling Simula
 portal-summary-title = STATUS NG KONEKSYON
 portal-retry-all = ULITIN LAHAT
 portal-row-token-expired = Nag-expire ang access token — pindutin para mag-login muli
+portal-row-startup-failed = Walang koneksyon — hindi mai-a-upload ang mga resulta
 portal-row-stuck = Laro { $game } Error sa pagpapadala ng puntos, pindutin para ayusin
 portal-row-pending = Laro { $game } Hindi naipadala ang puntos, pindutin para subukan muli
 portal-row-stats-pending = Laro { $game } Hindi naipadala ang estadistika, pindutin para subukan muli

--- a/refbox/translations/tr-TR/refbox.ftl
+++ b/refbox/translations/tr-TR/refbox.ftl
@@ -396,6 +396,7 @@ false-start = Hatalı Başlangıç
 portal-summary-title = BAĞLANTI DURUMU
 portal-retry-all = TÜMÜNÜ TEKRAR DENE
 portal-row-token-expired = Erişim tokeni sona erdi — yeniden giriş için dokunun
+portal-row-startup-failed = Bağlantı yok — sonuçlar yüklenmeyecek
 portal-row-stuck = Oyun { $game } Skor gönderme hatası, düzeltmek için dokunun
 portal-row-pending = Oyun { $game } Skor gönderilmedi, tekrar denemek için dokunun
 portal-row-stats-pending = Oyun { $game } İstatistikler gönderilmedi, tekrar denemek için dokunun

--- a/refbox/translations/zh-CN/refbox.ftl
+++ b/refbox/translations/zh-CN/refbox.ftl
@@ -395,6 +395,7 @@ false-start = 抢跑
 portal-summary-title = 连接状态
 portal-retry-all = 全部重试
 portal-row-token-expired = 访问令牌已过期 — 点击重新登录
+portal-row-startup-failed = 无法连接 — 成绩将不会上传
 portal-row-stuck = 比赛 { $game } 比分发送错误，点击修复
 portal-row-pending = 比赛 { $game } 比分未发送，点击重试
 portal-row-stats-pending = 比赛 { $game } 统计未发送，点击重试


### PR DESCRIPTION
## What changed

When the refbox cannot start its results-uploading system, it no longer tells the operator that their access token expired.

The red warning dot stays — something *is* wrong and the operator must know. But tapping it now says **"Connection unavailable — results will not upload"** instead of *"Access token expired — tap to re-login"*, and the REFRESH button on the game-info screen is no longer greyed out.

## Why

Two things put the refbox into this state, and neither has anything to do with the operator's login: the machine's security certificates are broken (the realistic cause), or the results queue file cannot be read in either the config directory or the system temp directory.

Blaming the login sent the operator on an errand that cannot work. With no client, the login request is never actually sent — they enter the code from the site and **nothing happens at all**: no success, no error, no timeout. Greying out REFRESH for the same false reason compounded it.

The wording is deliberately source-neutral. This screen is reachable when the refbox points at a third-party site — in fact *more* reachable than for the Portal, because a custom site takes its event from the saved URL with no network and no expiry, while the Portal path needs a link note under 120 hours old. Saying "Portal" there would name the wrong system and would undo #2219.

## Scope

`refbox` crate only: `portal_manager/mod.rs`, `app/mod.rs`, two view builders, and the new translation key in all 15 locales. Nothing in `uwh-common`, `overlay`, or `wireless-remote`. No shared types, no wire format, no state machine.

## How to verify

**Automated** — `just check` is green (551 refbox tests). Four new tests:
- a degraded refbox still shows red
- it no longer reports the token as expired ← fails without the fix
- its detail page shows the startup-failure row and *not* the re-login row ← fails without the fix
- a genuine token rejection still reports expiry and still offers re-login (guards against over-reach)

Both halves of the fix were mutation-tested — the fix was deliberately reverted to confirm the tests fail, then restored. The reviewer re-ran both mutations independently.

**On screen** — walked through in three configurations against a throwaway config directory:
1. English, Portal, link restored → red dot, new row, no re-login row
2. German → text wraps to two lines at full size, no clipping
3. Third-party custom site → globe emblem, source-neutral wording

REFRESH was press-tested by hand and does not stick on "Refreshing…". That guard lives in `update()`, which this crate does not exercise directly in tests, so it carries no unit test by design rather than by omission.

## Known limitations, deliberately not fixed here

Both recorded under `docs/backlog/`:
- With no client, the portal login still accepts a code and silently does nothing. This branch stops *recommending* that path but does not close it.
- Degraded mode writes its results queue to the temp directory, which no healthy restart reads, while the game-end banner still promises the score is queued. Pre-existing and unchanged by this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
