### PR TITLE
fix(refbox): keep degraded-mode results where a healthy start will find them

### DIFF
--- a/docs/backlog/degraded-queue-written-to-temp-dir/NOTE.md
+++ b/docs/backlog/degraded-queue-written-to-temp-dir/NOTE.md
@@ -1,6 +1,13 @@
 # Backlog: results queued in degraded mode are written somewhere nothing reads
 
-**Status:** NOT FILED, not started. Local note only.
+**Status: BEING BUILT — superseded by
+`docs/superpowers/specs/2026-08-13-degraded-queue-persistence-design.md`.** Read the spec, not this
+note: the spec corrects two things below. Option 2 ("check the temp dir on a healthy start") is
+**unworkable** — fixing the underlying fault on the Pi requires a reboot, which likely clears the
+temp file first. And the chosen fix is one this note never listed: keep persisting to the real config
+directory, which is fine in the reachable case because the disk was never the problem. The spec also
+records a trap that would make a naive fix **destroy** results, and an honest reachability
+assessment (LOW — no concrete field scenario identified; built anyway as insurance, Eric's call).
 **Surfaced:** 2026-08-13, by the code review of
 `fix/refbox/degraded-portal-startup-message`. **Pre-existing — identical before and after that
 branch**, and squarely inside that spec's stated non-goals, so it was deliberately left alone.

--- a/docs/backlog/untried-result-labelled-as-send-error/NOTE.md
+++ b/docs/backlog/untried-result-labelled-as-send-error/NOTE.md
@@ -1,0 +1,67 @@
+# Backlog: a result that was never attempted is labelled "Score send error"
+
+**Status:** NOT FILED, not started. Local note only.
+**Surfaced:** 2026-08-13, while designing
+`docs/superpowers/specs/2026-08-13-degraded-queue-persistence-design.md`.
+**Eric's decision, 2026-08-13: keep this separate from that branch** — "stuck" is shared by every
+queued game on every path, so changing what it means is a different and riskier change deserving its
+own design and tests. One concern per branch.
+
+## The gap
+
+Whether a queued result is "stuck" is decided **purely by age**:
+
+```rust
+!item.score_sent && (now - item.queued_at) >= STUCK_THRESHOLD   // 30 minutes
+```
+
+It never asks whether the result was ever actually *attempted*. A stuck item is then excluded from
+auto-retry — *"Stuck items wait for operator action"* (`refbox/src/portal_manager/health.rs:31-39`) —
+and is rendered as **"Game { $game } Score send error, tap to fix"**
+(`portal-row-stuck`).
+
+For a game that failed to send several times, that is right: the portal is rejecting something and
+the operator must decide (Retry / Force / Discard).
+
+For a game that has **zero attempts** it is wrong twice over:
+
+1. It has not errored. Nothing was ever sent, so calling it a "send error" misreports the cause.
+2. It is excluded from auto-retry as though a decision were needed, when in fact nobody has tried
+   once.
+
+The clearest way to reach this is the degraded-mode path: the portal subsystem never started, so no
+attempt is possible, and any outage lasting over 30 minutes leaves every game from it looking like a
+send error on the next healthy start.
+
+## Why it matters
+
+It is the difference between results resuming on their own and results waiting on the operator to
+notice red rows and press RETRY ALL. The 2026-08-13 queue-persistence branch makes those results
+*recoverable in one tap*; closing this gap would make them recover with **no** operator action.
+
+## The ask
+
+Distinguish "never attempted" from "tried and failing". A first cut: treat an item with
+`attempts == 0` (equivalently `last_attempt_at == None`) as not stuck, so it stays in the auto-retry
+pool and is shown as pending rather than as an error.
+
+## Scope when picked up — and the risk
+
+- `refbox/src/portal_manager/mod.rs` (`is_item_stuck`) and `health.rs`
+  (`is_item_retry_eligible`).
+- **`is_item_stuck` is a `pub fn` used by more than the detail page** — it feeds
+  `needs_attention()`, and therefore the red indicator, and `is_stuck()` routes row taps to the
+  attention-action page. Enumerate every caller before changing it; this is not a display-only
+  predicate.
+- Consider the escalation this protects: an item that genuinely cannot be delivered must still reach
+  red eventually rather than retrying forever. Exempting `attempts == 0` should delay escalation, not
+  remove it — an item that stays unattempted forever (which is exactly the degraded case) must not
+  become invisible.
+- Likely needs a translation change too if a new row wording is introduced (15 locales, and health
+  wording must stay source-neutral — see the source-neutral section of
+  `docs/superpowers/specs/2026-08-13-degraded-portal-startup-message-design.md`).
+
+## Explicitly NOT part of this
+
+- Not the queue-persistence fix (2026-08-13 spec above) — that ships first and independently.
+- Not the 30-minute threshold value itself, which ADR 011 sets deliberately.

--- a/docs/superpowers/plans/2026-08-13-degraded-queue-persistence.md
+++ b/docs/superpowers/plans/2026-08-13-degraded-queue-persistence.md
@@ -1,0 +1,340 @@
+# Degraded Queue Persistence — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Results recorded while the portal subsystem is dead must survive to the next healthy launch instead of being written where nothing will ever read them.
+
+**Architecture:** `PortalManager::new_degraded` stops hard-coding `std::env::temp_dir()` and takes the real config directory. Critically, it also **loads any queue already there** — because `queue::save` overwrites the whole file, so without the load the first enqueue would destroy results already waiting. Both production call sites pass the config directory they already have in scope.
+
+**Tech Stack:** Rust 2024, MSRV 1.85, `tokio`, `serde_json` (queue file).
+
+## Global Constraints
+
+- **Crate scope:** `refbox` only. Do NOT touch `uwh-common`, `overlay`, or `wireless-remote`.
+- **Process:** lean, per `.claude/rules/plan-execution.md` — no per-task deviation commits, one code review at the end. Record deviations in the "Deviations" section at the bottom of this file.
+- **Clippy:** `cargo clippy --workspace --all-features -- -D warnings` clean. No new `#[allow]`.
+- **`refbox` is a BIN-ONLY crate.** `cargo test -p refbox --lib` FAILS with "no library targets found". Always use `cargo test -p refbox --bin refbox`.
+- **A degraded manager must never fail to construct.** `new_degraded` must NOT return `Result`. Every I/O it does is best-effort — the whole point of degraded mode is that the game can still run.
+- **No `unwrap()`/`expect()`** in non-test code. `unwrap_or_else` with a logged fallback is the required shape here.
+- **Do NOT copy `sweep_expired()` from `new()`** into `new_degraded`. It writes; degraded construction stays otherwise read-only. See the spec.
+- **Do NOT change what "stuck" means** (`is_item_stuck`). Eric ruled that a separate concern on 2026-08-13; it has its own backlog note.
+- **Branch:** `fix/refbox/degraded-queue-persistence`, already created off `origin/master` (`1846c549`). Ask the human before every commit.
+
+---
+
+### Task 1: `new_degraded` takes a directory and adopts the queue already there
+
+This is one atomic task: the signature change, the load, and both call sites must land together or the crate does not compile.
+
+**Files:**
+- Modify: `refbox/src/portal_manager/mod.rs` — `new_degraded` (~`:624-649`), tests (~`:1458`)
+- Modify: `refbox/src/app/mod.rs` — the two `new_degraded()` call sites (~`:2404`, ~`:2433`)
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `pub(crate) fn new_degraded(config_dir: &std::path::Path) -> (Self, mpsc::Receiver<PortalEvent>)`. Still infallible — no `Result`. Existing fields and `indicator_state()` are unchanged.
+
+- [ ] **Step 1: Write the three failing tests**
+
+Add to the `mod tests` block in `refbox/src/portal_manager/mod.rs`, next to the existing degraded-mode tests (~`:1458`). `NullIo` and `mk_stuck_item()` are existing test helpers in that module.
+
+```rust
+    #[tokio::test]
+    async fn degraded_queue_is_found_by_a_later_healthy_start() {
+        let tmp = tempfile::TempDir::new().unwrap();
+
+        // A degraded session records a result.
+        {
+            let (mut degraded, _rx) = PortalManager::new_degraded(tmp.path());
+            degraded
+                .enqueue_game_end("event".into(), "G1".into(), 3, 2, "{}".into())
+                .unwrap();
+        }
+
+        // Once the fault is fixed, the next healthy launch must find it.
+        let (healthy, _rx) = PortalManager::new(tmp.path(), NullIo).unwrap();
+        assert_eq!(
+            healthy.queue.items.len(),
+            1,
+            "a result queued in degraded mode must survive into the next healthy session"
+        );
+        assert_eq!(healthy.queue.items[0].id.game_number, "G1");
+    }
+
+    #[tokio::test]
+    async fn degraded_enqueue_does_not_clobber_results_already_queued() {
+        // THE TRAP. `queue::save` rewrites the whole file, so a degraded
+        // manager that starts from an empty queue would overwrite results
+        // already waiting. This test fails on that naive version.
+        let tmp = tempfile::TempDir::new().unwrap();
+
+        // Two results are already waiting from an earlier healthy session.
+        {
+            let (mut healthy, _rx) = PortalManager::new(tmp.path(), NullIo).unwrap();
+            healthy
+                .enqueue_game_end("event".into(), "G1".into(), 1, 0, "{}".into())
+                .unwrap();
+            healthy
+                .enqueue_game_end("event".into(), "G2".into(), 2, 0, "{}".into())
+                .unwrap();
+        }
+
+        // The refbox restarts into degraded mode and a third game finishes.
+        {
+            let (mut degraded, _rx) = PortalManager::new_degraded(tmp.path());
+            degraded
+                .enqueue_game_end("event".into(), "G3".into(), 3, 0, "{}".into())
+                .unwrap();
+        }
+
+        let on_disk = queue::load_or_empty(tmp.path()).unwrap();
+        let mut games: Vec<&str> = on_disk
+            .items
+            .iter()
+            .map(|i| i.id.game_number.as_str())
+            .collect();
+        games.sort_unstable();
+        assert_eq!(
+            games,
+            vec!["G1", "G2", "G3"],
+            "a degraded session must never destroy results already queued"
+        );
+    }
+
+    #[test]
+    fn degraded_construction_neither_invents_nor_replaces_a_queue() {
+        // Degraded construction may now READ the queue — that is the change.
+        // What it must not do is create a queue file where none existed, or
+        // replace one that is already there.
+        let empty_dir = tempfile::TempDir::new().unwrap();
+        let (manager, _rx) = PortalManager::new_degraded(empty_dir.path());
+        assert_eq!(manager.config_dir.as_path(), empty_dir.path());
+        assert!(
+            !empty_dir.path().join("portal_queue.json").exists(),
+            "degraded construction must not create a queue file"
+        );
+
+        let seeded_dir = tempfile::TempDir::new().unwrap();
+        queue::save(
+            seeded_dir.path(),
+            &QueueFile {
+                version: 1,
+                items: vec![mk_stuck_item()],
+            },
+        )
+        .unwrap();
+        let (adopted, _rx) = PortalManager::new_degraded(seeded_dir.path());
+        assert_eq!(
+            adopted.queue.items.len(),
+            1,
+            "degraded construction must adopt the queue that is already there"
+        );
+        assert_eq!(
+            queue::load_or_empty(seeded_dir.path()).unwrap().items.len(),
+            1,
+            "and must leave it on disk untouched"
+        );
+    }
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run: `cargo test -p refbox --bin refbox degraded -- --nocapture`
+Expected: **compile error** — `new_degraded` takes 0 arguments but 1 was supplied. A compile failure is a legitimate red here; do not weaken the tests to make them build.
+
+- [ ] **Step 3: Change `new_degraded` to take a directory and adopt the queue**
+
+Replace the signature, the doc comment, and the `queue`/`config_dir` fields (~`:624-649`). Everything else in the function stays as it is.
+
+```rust
+    /// Constructs a `PortalManager` with no background task, used when the
+    /// portal subsystem cannot start: either the HTTP client failed to build,
+    /// or the retry queue was unreadable in both the config dir and the
+    /// system temp dir. The refbox's core game functions still work and the
+    /// portal indicator shows Red so the operator sees the problem.
+    ///
+    /// No background task is spawned: there's nothing for it to do, and
+    /// spawning one with `NullIo` would report success for every call, clear
+    /// the red state and fake-resolve every queued game.
+    ///
+    /// `config_dir` is the real config directory, not a scratch path. Results
+    /// are still queued in this mode (`enqueue_game_end` runs whenever an
+    /// event is linked), so they must land where the next healthy launch will
+    /// look for them — otherwise they are silently abandoned. Writing
+    /// elsewhere is what this constructor used to do, back when its only
+    /// caller was the both-directories-failed case.
+    ///
+    /// The returned receiver is a dummy that never emits events.
+    pub(crate) fn new_degraded(
+        config_dir: &std::path::Path,
+    ) -> (Self, mpsc::Receiver<PortalEvent>) {
+        // Build (sender, receiver) pairs where the senders go nowhere:
+        // the event-channel sender is discarded so the returned receiver
+        // never emits, and the command-channel sender is kept on the
+        // manager only because its type demands it — no background task
+        // exists to receive from it.
+        let (_, rx) = mpsc::channel(1);
+        let (command_tx, _command_rx) = mpsc::channel(1);
+
+        // Adopt whatever is already queued, best-effort. This must never fail
+        // the construction: one trigger for degraded mode IS an unreadable
+        // queue file, and the game has to keep running regardless.
+        //
+        // Skipping this load would NOT be the safe option: `queue::save`
+        // rewrites the whole file, so an empty starting queue means the first
+        // enqueue overwrites — and destroys — results already waiting.
+        let queue = queue::load_or_empty(config_dir).unwrap_or_else(|e| {
+            log::warn!(
+                "could not read the portal queue in degraded mode ({e}); starting with an empty queue"
+            );
+            QueueFile::empty()
+        });
+
+        let mut m = Self {
+            queue,
+            check_in_flight: false,
+            // The portal subsystem never started. Red so the operator sees
+            // the problem — but NOT `token_known_problem`: nothing here is
+            // evidence the login expired.
+            token_known_problem: false,
+            connection_problem: false,
+            startup_problem: true,
+            indicator_state: PortalIndicatorState::default(),
+            command_tx,
+            config_dir: config_dir.to_path_buf(),
+            recent_successes: VecDeque::new(),
+        };
+        m.recompute_indicator();
+        (m, rx)
+    }
+```
+
+Note there is deliberately **no** `sweep_expired()` call here, unlike `new()`. Sweeping writes; anything genuinely expired is swept by the next healthy start, which is the only session that could have uploaded it anyway.
+
+- [ ] **Step 4: Update both call sites**
+
+In `refbox/src/app/mod.rs`, both sites already have `config_dir` in scope. Change:
+
+```rust
+PortalManager::new_degraded()
+```
+
+to:
+
+```rust
+PortalManager::new_degraded(&config_dir)
+```
+
+at **both** ~`:2404` (the no-client branch) and ~`:2433` (the both-directories-failed branch).
+
+Passing the config dir at the second site is intentional even though its I/O just failed: the load fails again, gets logged, and the session runs on an in-memory queue — which is exactly what happens today, minus the pointless write to a directory nothing reads.
+
+- [ ] **Step 5: Update the four existing degraded tests — and give each its OWN temp directory**
+
+PR #2319 left four tests that call `new_degraded()` with no argument, so they will not compile after Step 3. They are all `#[test]` (synchronous — they only construct and inspect, so they need no tokio runtime):
+
+- `degraded_startup_is_red` (~`:1117`)
+- `degraded_startup_does_not_report_token_expired` (~`:1133`)
+- `degraded_startup_shows_startup_failed_row_not_token_expired` (~`:1142`)
+- `new_degraded_is_red_with_no_spawned_task` (~`:1434`)
+
+In each, add a fresh temp directory and pass it:
+
+```rust
+        let dir = tempfile::TempDir::new().unwrap();
+        let (m, _rx) = PortalManager::new_degraded(dir.path());
+```
+
+(`new_degraded_is_red_with_no_spawned_task` binds `(manager, mut rx)` — keep its own binding names.)
+
+**Do NOT pass `std::env::temp_dir()`, even though that is what the constructor used to hard-code.** The constructor now *reads* the queue file, so a shared directory makes these tests depend on whatever is lying around in the system temp directory. `new_degraded_is_red_with_no_spawned_task` asserts the queue is empty and would fail outright if a stale `portal_queue.json` were present. A per-test `TempDir` is required, not stylistic.
+
+- [ ] **Step 6: Delete the old `new_degraded_does_not_touch_disk` test**
+
+It asserts `manager.config_dir == std::env::temp_dir()` — the precise behaviour being removed — so it cannot be kept. `degraded_construction_neither_invents_nor_replaces_a_queue` from Step 1 replaces it and tests the real safety property rather than a proxy for it.
+
+- [ ] **Step 7: Run the full refbox suite**
+
+Run: `cargo test -p refbox --bin refbox`
+Expected: PASS, with no remaining reference to `new_degraded_does_not_touch_disk`.
+
+- [ ] **Step 8: Mutation-test the clobber guard**
+
+Required, not optional — this is the test protecting against data destruction.
+
+Temporarily replace the `let queue = queue::load_or_empty(...)` block with `let queue = QueueFile::empty();` (the naive fix). Run:
+
+`cargo test -p refbox --bin refbox degraded_enqueue_does_not_clobber`
+
+Expected: **FAIL**, reporting `["G3"]` instead of `["G1", "G2", "G3"]`. Then restore the load and confirm it passes again. If the test passes with the mutation applied, it is not protecting anything — fix the test before continuing.
+
+- [ ] **Step 9: Check clippy and formatting**
+
+Run: `cargo clippy -p refbox --all-features 2>&1 | grep -E "^(warning|error)"; cargo fmt --all --check`
+Expected: no output from either.
+
+- [ ] **Step 10: Commit** (ask the human first)
+
+```bash
+git add refbox/src/portal_manager/mod.rs refbox/src/app/mod.rs
+git commit -m "fix(refbox): keep degraded-mode results where a healthy start will find them"
+```
+
+---
+
+### Task 2: Documentation and final validation
+
+**Files:**
+- Already modified in the working tree (uncommitted, carried onto this branch):
+  `docs/superpowers/specs/2026-08-13-degraded-portal-startup-message-design.md` (the merged spec's
+  overstated-trigger correction), `docs/backlog/degraded-queue-written-to-temp-dir/NOTE.md`
+  (superseded banner)
+- Already created, untracked: `docs/superpowers/specs/2026-08-13-degraded-queue-persistence-design.md`,
+  `docs/backlog/untried-result-labelled-as-send-error/NOTE.md`, this plan
+
+- [ ] **Step 1: Run the whole gate**
+
+Run: `just check`
+Expected: EXIT CODE 0. Capture the exit code explicitly — do **not** pipe to `tail`, which masks it.
+
+- [ ] **Step 2: Confirm no stray scaffolding**
+
+Run: `grep -rn "SCRATCH\|REFBOX_DEMO" refbox/src/ || echo "clean"`
+Expected: `clean`. (A previous branch used a temporary env-var switch to force degraded mode; make sure nothing like it was reintroduced.)
+
+- [ ] **Step 3: Commit the docs** (ask the human first)
+
+```bash
+git add docs/superpowers/specs/2026-08-13-degraded-queue-persistence-design.md \
+        docs/superpowers/specs/2026-08-13-degraded-portal-startup-message-design.md \
+        docs/superpowers/plans/2026-08-13-degraded-queue-persistence.md \
+        docs/backlog/degraded-queue-written-to-temp-dir/NOTE.md \
+        docs/backlog/untried-result-labelled-as-send-error/NOTE.md
+git commit -m "docs(refbox): spec, plan and backlog for degraded-queue persistence"
+```
+
+Add only those five paths. `docs/backlog/` and `docs/superpowers/plans/` hold many untracked notes from earlier sessions that must not be swept in.
+
+- [ ] **Step 4: Code review**
+
+Use `superpowers:requesting-code-review` once, now that the change is complete (lean process). Tell the reviewer specifically to attack the data-safety question: can any ordering of degraded and healthy sessions lose or duplicate a queued result?
+
+---
+
+## Acceptance criteria
+
+1. A degraded manager given directory D queues a game; a fresh healthy `PortalManager::new(D, …)` finds it.
+2. Directory D already holds two queued games; a degraded manager on D queues a third; all three survive on disk. **Fails on the naive fix.**
+3. Degraded construction creates no queue file where none existed, and leaves an existing one on disk untouched.
+4. PR #2319's behaviour is intact: still red, `token_expired` still false, startup-failure row still shown, still no background task.
+5. `just check` exits 0.
+
+## What this does NOT deliver
+
+Recovered results do **not** upload unattended. Anything past the 30-minute stuck threshold is excluded from auto-retry (`health.rs:31-39`, *"Stuck items wait for operator action"*), and any real outage exceeds 30 minutes — so these arrive as red rows and go up on one RETRY ALL press. That is the difference between "recoverable in one tap" and "silently gone", and it is deliberately not more than that. See `docs/backlog/untried-result-labelled-as-send-error/NOTE.md`.
+
+## Deviations
+
+Record here rather than in standalone commits (lean process).
+
+- **Branched off `origin/master` `1846c549`**, which already contains PR #2319 (all four commits confirmed in master via `git cherry`). The sequencing worry about stacking on an unmerged PR no longer applies.

--- a/docs/superpowers/specs/2026-08-13-degraded-portal-startup-message-design.md
+++ b/docs/superpowers/specs/2026-08-13-degraded-portal-startup-message-design.md
@@ -29,9 +29,8 @@ credential problem it has no evidence for.
 Degraded mode is entered from exactly two places:
 
 1. **The portal client could not be built** (`app/mod.rs:2404`). Every failure path inside the HTTP
-   client's constructor is TLS-related — certificate-store and TLS-version problems, e.g. *"zero
-   valid certificates found in native root store"*. A Raspberry Pi with a broken system
-   certificate store is exactly this. **This is the realistic trigger.**
+   client's constructor is TLS-related — certificate-store and TLS-version problems. **This is the
+   likelier of the two routes, but "realistic" overstates it — see the correction below.**
 2. **The retry-queue file could not be read** in the config directory *and* in the system temp
    directory (`app/mod.rs:2433`). Both must fail. Near-unreachable.
 
@@ -40,6 +39,20 @@ Note for future readers: two comments in `app/mod.rs` (at `:2389` and `:1112`) c
 flag enforced per request, so such a configuration builds a client successfully and fails each
 call instead. Those comments are **not** corrected by this work; they are recorded here so the
 next reader is not misled.
+
+### CORRECTION (2026-08-13, after this branch merged): the trigger is rarer than stated above
+
+Re-examined while designing the follow-up
+(`2026-08-13-degraded-queue-persistence-design.md`). Certificate *verification* happens per request,
+not at client construction, so a broken or missing certificate store almost certainly produces
+**per-request** failures — which take the `TokenUnreachable` path that already reports an honest red
+without blaming the token. Every *construction* failure path is TLS-**configuration** related, and
+this call site sets none of those options (only `https_only` and `timeout`). **No concrete field
+scenario reaching degraded mode has been identified**, and neither route into it has ever been
+observed at a tournament — both were added by reviews imagining failures (`07466789`, `04eac281`).
+
+This does not undermine the fix: it removes a false instruction from a state the code *can* enter,
+and it is cheap to keep. But the word "realistic" above was stronger than the evidence supports.
 
 ### How narrow is this?
 

--- a/docs/superpowers/specs/2026-08-13-degraded-queue-persistence-design.md
+++ b/docs/superpowers/specs/2026-08-13-degraded-queue-persistence-design.md
@@ -82,6 +82,19 @@ So simply pointing degraded mode at the real config directory produces this:
 Today's behaviour is *safe* precisely because it writes somewhere useless. Any fix must therefore
 load the existing queue before it can be allowed to write.
 
+**And the corollary, missed in the first draft and caught by code review: if the load FAILED, it must
+not write either.** A queue file that cannot be *read* can still be *replaced* — `queue::save`
+renames over it, and rename needs write permission on the **directory**, not on the target file.
+Verified: a `chmod 000` queue file is unreadable to `cat` yet a rename over it succeeds and the
+contents are gone. So falling back to an empty queue while keeping the same write target destroys
+real results, with no `portal_queue.corrupt.*` backup, and reports success.
+
+That made the first implementation *more* destructive than the healthy path, which already handles
+this case correctly: `new()` returns `Err`, and `app/mod.rs` falls back to the temp directory,
+leaving the file intact. **Fix:** on a failed load, the write target falls back to
+`std::env::temp_dir()` — no worse than today for that case, and the unreadable file is preserved
+byte-for-byte.
+
 ---
 
 ## Design
@@ -96,11 +109,45 @@ load the existing queue before it can be allowed to write.
 Best-effort is deliberate throughout: a degraded manager must never fail to construct, because the
 whole point of degraded mode is that the game can still run.
 
-**Deliberately NOT copied from `new()`: the startup expiry sweep.** `PortalManager::new` calls
-`sweep_expired()`, which archives and removes items older than 120 hours — and that writes. Degraded
-construction must stay as close to read-only as possible, so it does not sweep. Any genuinely
-expired item is swept by the next healthy start instead, which is the only session that could upload
-it anyway. This keeps construction free of avoidable writes and keeps the change small.
+**Deliberately NOT copied from `new()`: the expiry sweep.** `PortalManager::new` calls
+`sweep_expired()`, which archives and removes items older than 120 hours — and that writes.
+
+**Corrected after code review:** the first draft of this spec said degraded construction simply
+omits the sweep and "the next healthy start sweeps instead". That was **false**. `ui_tick()` also
+sweeps, and `Message::PortalUiTick` is an unconditional 1 Hz subscription with no health gate — so a
+degraded session was sweeping the real config directory within a second of launch. Skipping it at
+construction bought nothing.
+
+The sweep is therefore **gated on `!startup_problem` inside `ui_tick()`**, which makes the intent
+real. Two reasons it matters: `portal_queue.expired.json` is surfaced nowhere in the UI, so an
+archived result is unrecoverable by the operator; and a refbox whose clock reads days ahead (a
+documented Pi failure mode) would otherwise archive still-pending results in the first second. The
+next healthy session sweeps — the only session that could have uploaded them anyway.
+
+### Found in review: adopting results makes them destroyable, so the rows are made inert
+
+Closing the trap above created a second one, caught by code review rather than by this design.
+
+Once a degraded session **adopts** the queue, those results become visible on the detail page. Any
+item older than 30 minutes renders as *"Game X Score send error, tap to fix"*, whose attention page
+says *"You can Retry if connection is verified, or discard to clear the error"*. In degraded mode:
+
+- **Retry cannot work.** `force_submit` writes and pushes a queue snapshot, but `new_degraded` drops
+  the command receiver and no background task exists, so the send goes nowhere. It *does* reset
+  `queued_at`, so the row disappears for 30 minutes and looks like it succeeded.
+- **Discard deletes permanently and does not archive**, unlike the expiry sweep.
+
+Before this change the degraded queue was always empty, so no pre-existing result could be reached
+this way. Adopting them without this guard would mean the branch written to protect results instead
+hands the operator an on-screen path to destroying them.
+
+**Fix:** `Message::PortalRowTapped` returns immediately when `has_startup_problem()`. Rows stay
+visible but inert, which matches everything else in that state — the startup-failure row is not
+tappable and REFRESH declines to spin. This deliberately does **not** touch `is_item_stuck`, so the
+"stuck" rule is unchanged as required.
+
+**No unit test:** the guard lives in `update()`, which this crate does not exercise directly. Stated
+here rather than covered by a test that only looks like coverage.
 
 ### What this delivers — stated precisely, not optimistically
 
@@ -136,7 +183,23 @@ That is still the difference between "recoverable in one tap" and "silently gone
    startup-failure row, and still spawns no background task — i.e. PR #2319's behaviour is intact.
 5. `just check` green.
 
-Each new guard must be mutation-tested: break the fix, confirm the test fails, restore.
+6. **A queue that could not be read is left byte-identical**, and is not the write target.
+7. **A degraded session does not archive expired items** — they stay on disk for the next healthy
+   session, and no `portal_queue.expired.json` is created.
+
+Each new guard must be mutation-tested: break the fix, confirm the test fails, restore. All five
+guards were: restoring each defect made exactly the intended test fail.
+
+### Also noted by review, accepted rather than fixed
+
+- **Two refbox processes sharing one config directory now interfere across the degraded/healthy pair,
+  where a degraded instance used to be inert.** Two *healthy* processes already do this, and the
+  repo's standing rule is one refbox at a time, so this widens a documented hazard rather than
+  creating a new class of bug.
+- **`queue_dir()` now points at the real queue, so the cross-tenant flush empties it** on a mode
+  change — unarchived. This is arguably a net improvement: previously the flush hit the temp
+  directory and left old-tenant results in the config directory for the next healthy launch to adopt.
+  It now matches healthy behaviour. Recorded so nobody rediscovers it as a surprise.
 
 ---
 

--- a/docs/superpowers/specs/2026-08-13-degraded-queue-persistence-design.md
+++ b/docs/superpowers/specs/2026-08-13-degraded-queue-persistence-design.md
@@ -1,0 +1,164 @@
+# Degraded mode must not queue results where nothing will read them
+
+**Date:** 2026-08-13
+**Crate:** `refbox` only
+**Follows:** PR #2319 (`fix/refbox/degraded-portal-startup-message`), merged 2026-08-13. That branch
+fixed what degraded mode *says*; this one fixes where it *puts results*.
+**Backlog origin:** `docs/backlog/degraded-queue-written-to-temp-dir/NOTE.md`
+
+---
+
+## The problem
+
+A degraded-mode `PortalManager` stores its retry queue in `std::env::temp_dir()`. Results are still
+queued in that mode — `enqueue_game_end` runs whenever an event is linked, with **no check for a
+portal client** (`app/mod.rs:1389-1392`) — so a game finished during a degraded session is written
+to the temp directory. A later healthy launch constructs the manager with the **real** config
+directory and loads the queue from there, so it never sees those results. They are silently
+abandoned.
+
+Meanwhile the end-of-game banner tells the operator:
+
+> *"Connection issue detected. Score will still be queued — find an admin to resolve."*
+
+Which is true in letter and false in effect: it is queued, to a location nothing will ever read.
+
+### The temp directory is not a decision — it is a default being reused out of context
+
+`new_degraded()` was written for the case where **both** the config directory and the temp directory
+reject I/O (`07466789`, 2026-04-21, added to stop a startup panic). For that case, pointing at the
+temp directory is a reasonable "nowhere".
+
+The **no-client** route was added later (`04eac281`, 2026-06-25, fixing finding M6 of the portal
+review) and reuses the same constructor — even though in that case the disk is perfectly healthy and
+`config_dir` is in scope, already created one line earlier (`app/mod.rs:2395`). Results land in the
+temp directory because the constructor *assumes* the disk is broken, not because it is.
+
+---
+
+## Reachability: LOW, and recorded honestly
+
+**This was weighed before building, and the decision to build anyway was Eric's, as insurance
+against silent loss of tournament results.** The evidence is recorded here so nobody re-derives it
+or later mistakes this for a frequent fault.
+
+- **Never observed in the field.** Both routes into degraded mode came from reviews imagining
+  failures, not from any tournament incident.
+- **The queue-I/O route needs two independent filesystem failures** — the config dir *and* the temp
+  dir both rejecting I/O. Effectively unreachable.
+- **The no-client route is rarer than PR #2319's spec claims.** That spec calls a broken
+  TLS/certificate store "the realistic trigger". On closer reading that is probably wrong:
+  certificate *verification* happens per request, not at client construction, so a broken
+  certificate store almost certainly produces per-request failures — which take the
+  `TokenUnreachable` path that already reports an honest red. Every *construction* failure path is
+  TLS-configuration related, and this call site sets none of those options (only `https_only` and
+  `timeout`). No concrete field scenario reaching it has been identified.
+- The Pi's root filesystem is a deliberately read-only overlay, which exists to prevent exactly the
+  corruption that would be the likeliest cause.
+
+**Correction owed to the earlier spec:** `2026-08-13-degraded-portal-startup-message-design.md`
+overstates its trigger as realistic. That branch is still correct and worth keeping — it removes a
+false instruction from a state the code can enter — but its likelihood wording should be softened.
+Doing that is part of this work.
+
+---
+
+## THE TRAP: the obvious fix destroys results
+
+Recorded first because it is the whole reason this design is not a one-line change.
+
+`queue::save` is a **full atomic overwrite** of the queue file (`queue.rs:135` →
+`write_atomic`, temp file then rename over the target). And a degraded manager starts from
+`QueueFile::empty()` (`mod.rs:634`) — it never loads an existing queue, because it was built on the
+assumption that the disk is unusable.
+
+So simply pointing degraded mode at the real config directory produces this:
+
+> A healthy session queues two games that could not be sent. The refbox restarts; this time the
+> portal client fails to build, so it starts degraded. The operator finishes a third game. The save
+> writes a **one-game file over the two-game file.** Two real results destroyed — by the change
+> meant to protect them.
+
+Today's behaviour is *safe* precisely because it writes somewhere useless. Any fix must therefore
+load the existing queue before it can be allowed to write.
+
+---
+
+## Design
+
+| # | Change | Why |
+|---|--------|-----|
+| 1 | `new_degraded` takes the config directory instead of hard-coding `std::env::temp_dir()` | Results land where the queue actually lives, so a later healthy start finds them |
+| 2 | It **loads any existing queue, best-effort** — `queue::load_or_empty`, falling back to empty on `Err` | Closes the trap. A degraded session must never overwrite results already waiting |
+| 3 | Both call sites pass the real `config_dir` (`app/mod.rs:2404` and `:2433`) | The no-client case has a healthy disk. The last-resort case is no worse off than today: saves fail, the error is logged, the in-memory queue still serves the session |
+| 4 | Drop the documented "performs no disk I/O" property, replacing it with the reason | That property existed because the constructor served only the both-directories-failed case. Now that it also serves the healthy-disk case, refusing to touch the disk *is* the bug |
+
+Best-effort is deliberate throughout: a degraded manager must never fail to construct, because the
+whole point of degraded mode is that the game can still run.
+
+**Deliberately NOT copied from `new()`: the startup expiry sweep.** `PortalManager::new` calls
+`sweep_expired()`, which archives and removes items older than 120 hours — and that writes. Degraded
+construction must stay as close to read-only as possible, so it does not sweep. Any genuinely
+expired item is swept by the next healthy start instead, which is the only session that could upload
+it anyway. This keeps construction free of avoidable writes and keeps the change small.
+
+### What this delivers — stated precisely, not optimistically
+
+**Results survive and become recoverable with one RETRY ALL press. They do not upload entirely on
+their own.**
+
+`is_item_retry_eligible` returns false for anything past the 30-minute stuck threshold —
+*"Stuck items wait for operator action"* (`health.rs:31-39`). Any realistic outage lasts longer than
+30 minutes, so on the next healthy start these games are stuck: they appear as red rows on the
+connection page and go up when the operator presses RETRY ALL (which resets `queued_at` and returns
+them to the auto-retry pool).
+
+That is still the difference between "recoverable in one tap" and "silently gone". It is not
+"automatic".
+
+---
+
+## Acceptance criteria
+
+1. **Recovery, end to end:** a degraded manager given directory D queues a game; a fresh healthy
+   `PortalManager::new(D, …)` finds that game in its queue.
+2. **The clobber guard:** directory D already holds a queue with two games; a degraded manager on D
+   queues a third; **all three** are present on disk afterwards. *This test fails on the naive
+   version of the fix and must be written to prove that.*
+3. **Construction never invents or destroys a queue:** constructing a degraded manager must not
+   create a queue file where none existed, and must not overwrite a valid one. It may now *read* it —
+   that is the change.
+   *Deliberate exception:* `queue::load_or_empty` renames an **unparseable** file to
+   `portal_queue.corrupt.<ts>.json` before returning empty. That write is acceptable and wanted — it
+   is exactly what a healthy start does, it preserves the bad file rather than deleting it, and the
+   alternative would be leaving a corrupt file to be silently overwritten by the first save.
+4. A degraded manager still shows red, still reports `token_expired` false, still shows the
+   startup-failure row, and still spawns no background task — i.e. PR #2319's behaviour is intact.
+5. `just check` green.
+
+Each new guard must be mutation-tested: break the fix, confirm the test fails, restore.
+
+---
+
+## Non-goals
+
+- **Not changing what "stuck" means.** `is_item_stuck` keys purely on age and never asks whether an
+  item was ever *attempted*, so a game queued while the subsystem was dead — zero attempts, failed
+  at nothing — still displays as *"Game X Score send error, tap to fix"*. That wording is wrong for
+  it, and fixing it would remove the RETRY ALL step entirely. But the rule is shared by every queued
+  game on every path, so it is a separate design with its own risk. **Eric's decision, 2026-08-13:
+  keep it separate.** Own backlog note.
+- **Not rewording the end-of-game banner.** Once results genuinely persist, "Score will still be
+  queued" becomes true for the reachable case.
+- Not making the portal work in degraded mode; not ADR 011's missing failure counter; not the
+  silent-login dead end (`docs/backlog/portal-login-silent-when-no-client/NOTE.md`).
+
+## Risk
+
+Low-to-moderate — higher than PR #2319, because this one can destroy data if the trap is not closed.
+One crate, no shared types, no wire format, no state machine, so `.claude/rules/plan-execution.md`
+still puts it in the **lean** process. The mitigation is acceptance criterion 2, which must be
+written to fail on the naive implementation.
+
+The change is confined to a constructor with exactly two production call sites, both in
+`app/mod.rs`, and to tests.

--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -3489,6 +3489,17 @@ impl RefBoxApp {
                 Task::none()
             }
             Message::PortalRowTapped(id) => {
+                if self.portal_manager.has_startup_problem() {
+                    // The portal subsystem never started, so no row here is
+                    // actionable and every route out of a tap is misleading:
+                    // there is no background task to retry with (a retry would
+                    // silently reset the timer and look like it worked), and
+                    // Discard would permanently delete — unarchived — results
+                    // the operator was never given a chance to send. Consistent
+                    // with the rest of this state: the startup-failure row is
+                    // not tappable and REFRESH declines to spin.
+                    return Task::none();
+                }
                 if self.portal_manager.is_stuck(&id) {
                     self.app_state = AppState::PortalAttentionAction {
                         item_id: id,

--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -2401,7 +2401,7 @@ impl RefBoxApp {
                     "portal client unavailable; portal subsystem starting in degraded \
                      (red, not-sending) mode — no results will be uploaded this session"
                 );
-                PortalManager::new_degraded()
+                PortalManager::new_degraded(&config_dir)
             }
             // Have a client: build the real uploader, trying `config_dir` first,
             // then `std::env::temp_dir()`, then falling back to degraded mode if
@@ -2430,7 +2430,7 @@ impl RefBoxApp {
                                      portal indicator will show red",
                                     secondary_err
                                 );
-                                PortalManager::new_degraded()
+                                PortalManager::new_degraded(&config_dir)
                             }
                         }
                     }

--- a/refbox/src/portal_manager/mod.rs
+++ b/refbox/src/portal_manager/mod.rs
@@ -484,10 +484,28 @@ impl PortalManager {
     ///   indicator picks up anything that might have changed between
     ///   frames.
     pub fn ui_tick(&mut self) {
-        if let Err(e) = self.sweep_expired() {
-            log::warn!("portal queue expiry sweep failed: {e}");
+        // Never sweep while the portal subsystem failed to start. Sweeping
+        // writes, and it moves results into `portal_queue.expired.json`, which
+        // the UI never shows — so an operator would have no way to get them
+        // back once the fault is fixed. This tick runs at 1 Hz regardless of
+        // health, so without this guard a refbox with a clock reading days
+        // ahead (a known Pi failure mode) would archive still-pending results
+        // within a second of launching. The next healthy session sweeps; it is
+        // the only one that could have uploaded them anyway.
+        if !self.startup_problem {
+            if let Err(e) = self.sweep_expired() {
+                log::warn!("portal queue expiry sweep failed: {e}");
+            }
         }
         self.recompute_indicator();
+    }
+
+    /// True when the portal subsystem could not start at all. The UI uses this
+    /// to keep the detail page's rows non-actionable: with no background task
+    /// there is nothing to retry with, and Discard would permanently delete
+    /// results the operator was never given a chance to send.
+    pub fn has_startup_problem(&self) -> bool {
+        self.startup_problem
     }
 
     /// Remove items past `EXPIRY_THRESHOLD` from the active queue, archiving
@@ -647,12 +665,23 @@ impl PortalManager {
         // Skipping this load would NOT be the safe option: `queue::save`
         // rewrites the whole file, so an empty starting queue means the first
         // enqueue overwrites — and destroys — results already waiting.
-        let queue = queue::load_or_empty(config_dir).unwrap_or_else(|e| {
-            log::warn!(
-                "could not read the portal queue in degraded mode ({e}); starting with an empty queue"
-            );
-            QueueFile::empty()
-        });
+        // Adopt whatever is already queued, and only write where we could
+        // read. If the load fails we must NOT keep `config_dir` as the write
+        // target: `queue::save` renames over the file, and a rename needs
+        // write permission on the *directory*, not on the file — so an
+        // unreadable-but-replaceable queue would be silently destroyed by the
+        // first enqueue. That is the exact failure this fallback exists for,
+        // and the healthy path already handles it by moving to the temp dir.
+        let (queue, queue_dir) = match queue::load_or_empty(config_dir) {
+            Ok(q) => (q, config_dir.to_path_buf()),
+            Err(e) => {
+                log::warn!(
+                    "could not read the portal queue ({e}); this session will not write to it, \
+                     so the existing file is left intact"
+                );
+                (QueueFile::empty(), std::env::temp_dir())
+            }
+        };
 
         let mut m = Self {
             queue,
@@ -665,7 +694,7 @@ impl PortalManager {
             startup_problem: true,
             indicator_state: PortalIndicatorState::default(),
             command_tx,
-            config_dir: config_dir.to_path_buf(),
+            config_dir: queue_dir,
             recent_successes: VecDeque::new(),
         };
         m.recompute_indicator();
@@ -1514,6 +1543,87 @@ mod tests {
             queue::load_or_empty(seeded_dir.path()).unwrap().items.len(),
             1,
             "and must leave it on disk untouched"
+        );
+    }
+
+    #[tokio::test]
+    async fn degraded_ui_tick_does_not_archive_expired_items() {
+        // The 1 Hz UI tick runs regardless of health, so without a guard a
+        // degraded session would sweep expired items into
+        // portal_queue.expired.json — a file the UI never shows — within a
+        // second of launching. With a clock reading days ahead (a known Pi
+        // failure mode) that would silently archive still-pending results.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mut expired = mk_stuck_item();
+        expired.queued_at = OffsetDateTime::now_utc() - TimeDuration::hours(200);
+        queue::save(
+            tmp.path(),
+            &QueueFile {
+                version: 1,
+                items: vec![expired],
+            },
+        )
+        .unwrap();
+
+        let (mut degraded, _rx) = PortalManager::new_degraded(tmp.path());
+        degraded.ui_tick();
+
+        assert_eq!(
+            degraded.queue.items.len(),
+            1,
+            "a degraded session must not sweep expired items"
+        );
+        assert_eq!(
+            queue::load_or_empty(tmp.path()).unwrap().items.len(),
+            1,
+            "and must leave them on disk for the next healthy session"
+        );
+        assert!(
+            !tmp.path().join("portal_queue.expired.json").exists(),
+            "nothing may be archived into a file the operator cannot see"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn degraded_never_overwrites_a_queue_it_could_not_read() {
+        // A queue file we cannot READ can still be REPLACED: `queue::save`
+        // renames over it, and rename needs permission on the directory, not
+        // on the file. So if the load fails, this session must not write here
+        // at all — otherwise the first enqueue destroys real results.
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        {
+            let (mut healthy, _rx) = PortalManager::new(tmp.path(), NullIo).unwrap();
+            healthy
+                .enqueue_game_end("event".into(), "G1".into(), 1, 0, "{}".into())
+                .unwrap();
+            healthy
+                .enqueue_game_end("event".into(), "G2".into(), 2, 0, "{}".into())
+                .unwrap();
+        }
+        let path = tmp.path().join("portal_queue.json");
+        let before = std::fs::read(&path).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        // Degraded session cannot read it, then records a game of its own.
+        {
+            let (mut degraded, _rx) = PortalManager::new_degraded(tmp.path());
+            assert_ne!(
+                degraded.config_dir.as_path(),
+                tmp.path(),
+                "a queue that could not be read must not stay the write target"
+            );
+            let _ = degraded.enqueue_game_end("event".into(), "G3".into(), 3, 0, "{}".into());
+        }
+
+        // Restore access and prove the original results are untouched.
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        assert_eq!(
+            std::fs::read(&path).unwrap(),
+            before,
+            "the unreadable queue file must be left byte-identical"
         );
     }
 

--- a/refbox/src/portal_manager/mod.rs
+++ b/refbox/src/portal_manager/mod.rs
@@ -610,18 +610,28 @@ impl PortalManager {
         Ok((m, handle.event_rx))
     }
 
-    /// Constructs a `PortalManager` that does not attempt any disk or
-    /// network I/O. Used as a last-resort fallback when both the user
-    /// config dir and the system temp dir reject I/O — the refbox's
-    /// core game functions still work, and the portal indicator shows
-    /// Red so the operator sees there's a problem.
+    /// Constructs a `PortalManager` with no background task, for when the
+    /// portal subsystem cannot start: either the HTTP client failed to
+    /// build, or the retry queue was unreadable in both the user config dir
+    /// and the system temp dir. The refbox's core game functions still work,
+    /// and the portal indicator shows Red so the operator sees there's a
+    /// problem.
     ///
     /// No background task is spawned: there's nothing for it to do,
     /// and spawning one with `NullIo` would cause `verify_token` to
     /// succeed and clear the red state, hiding the problem.
     ///
+    /// `config_dir` must be the real config directory, not a scratch path.
+    /// Results are still queued in this mode — `enqueue_game_end` runs
+    /// whenever an event is linked — so they have to land where the next
+    /// healthy launch will look for them, or they are silently abandoned.
+    /// Writing them elsewhere is what this constructor used to do, from when
+    /// its only caller was the both-directories-failed case.
+    ///
     /// The returned receiver is a dummy that never emits events.
-    pub(crate) fn new_degraded() -> (Self, mpsc::Receiver<PortalEvent>) {
+    pub(crate) fn new_degraded(
+        config_dir: &std::path::Path,
+    ) -> (Self, mpsc::Receiver<PortalEvent>) {
         // Build (sender, receiver) pairs where the senders go nowhere:
         // the event-channel sender is discarded so the returned receiver
         // never emits, and the command-channel sender is kept on the
@@ -630,8 +640,22 @@ impl PortalManager {
         let (_, rx) = mpsc::channel(1);
         let (command_tx, _command_rx) = mpsc::channel(1);
 
+        // Adopt whatever is already queued, best-effort. This must never fail
+        // the construction: one trigger for degraded mode IS an unreadable
+        // queue file, and the game has to keep running regardless.
+        //
+        // Skipping this load would NOT be the safe option: `queue::save`
+        // rewrites the whole file, so an empty starting queue means the first
+        // enqueue overwrites — and destroys — results already waiting.
+        let queue = queue::load_or_empty(config_dir).unwrap_or_else(|e| {
+            log::warn!(
+                "could not read the portal queue in degraded mode ({e}); starting with an empty queue"
+            );
+            QueueFile::empty()
+        });
+
         let mut m = Self {
-            queue: QueueFile::empty(),
+            queue,
             check_in_flight: false,
             // The portal subsystem never started. Red so the operator sees
             // the problem — but NOT `token_known_problem`: nothing here is
@@ -641,7 +665,7 @@ impl PortalManager {
             startup_problem: true,
             indicator_state: PortalIndicatorState::default(),
             command_tx,
-            config_dir: std::env::temp_dir(),
+            config_dir: config_dir.to_path_buf(),
             recent_successes: VecDeque::new(),
         };
         m.recompute_indicator();
@@ -1114,7 +1138,8 @@ mod tests {
 
     #[test]
     fn degraded_startup_is_red() {
-        let (m, _rx) = PortalManager::new_degraded();
+        let dir = tempfile::TempDir::new().unwrap();
+        let (m, _rx) = PortalManager::new_degraded(dir.path());
         assert_eq!(
             m.indicator_state().health,
             HealthState::Red,
@@ -1130,7 +1155,8 @@ mod tests {
         // Reporting token_expired greys out the schedule REFRESH button and
         // shows a "tap to re-login" row — and with no client a re-login
         // cannot even send a request, so the operator is sent nowhere.
-        let (m, _rx) = PortalManager::new_degraded();
+        let dir = tempfile::TempDir::new().unwrap();
+        let (m, _rx) = PortalManager::new_degraded(dir.path());
         assert!(
             !m.indicator_state().token_expired,
             "degraded startup must not blame the operator's access token"
@@ -1139,7 +1165,8 @@ mod tests {
 
     #[test]
     fn degraded_startup_shows_startup_failed_row_not_token_expired() {
-        let (m, _rx) = PortalManager::new_degraded();
+        let dir = tempfile::TempDir::new().unwrap();
+        let (m, _rx) = PortalManager::new_degraded(dir.path());
         let rows = m.detail_rows();
         assert!(
             matches!(rows.first(), Some(DetailRow::StartupFailed)),
@@ -1431,7 +1458,8 @@ mod tests {
 
     #[test]
     fn new_degraded_is_red_with_no_spawned_task() {
-        let (manager, mut rx) = PortalManager::new_degraded();
+        let dir = tempfile::TempDir::new().unwrap();
+        let (manager, mut rx) = PortalManager::new_degraded(dir.path());
 
         // Red so the operator sees the problem — via `startup_problem`,
         // not by claiming the access token expired.
@@ -1455,13 +1483,100 @@ mod tests {
     }
 
     #[test]
-    fn new_degraded_does_not_touch_disk() {
-        // Smoke test: constructing a degraded manager must not perform
-        // any filesystem I/O. We can't easily intercept I/O, but we can
-        // verify the config_dir field points at temp_dir (a safe
-        // non-persistent default) rather than any user-supplied path.
-        let (manager, _rx) = PortalManager::new_degraded();
-        assert_eq!(manager.config_dir, std::env::temp_dir());
+    fn degraded_construction_neither_invents_nor_replaces_a_queue() {
+        // Degraded construction may now READ the queue — that is the change.
+        // What it must not do is create a queue file where none existed, or
+        // replace one that is already there.
+        let empty_dir = tempfile::TempDir::new().unwrap();
+        let (manager, _rx) = PortalManager::new_degraded(empty_dir.path());
+        assert_eq!(manager.config_dir.as_path(), empty_dir.path());
+        assert!(
+            !empty_dir.path().join("portal_queue.json").exists(),
+            "degraded construction must not create a queue file"
+        );
+
+        let seeded_dir = tempfile::TempDir::new().unwrap();
+        queue::save(
+            seeded_dir.path(),
+            &QueueFile {
+                version: 1,
+                items: vec![mk_stuck_item()],
+            },
+        )
+        .unwrap();
+        let (adopted, _rx) = PortalManager::new_degraded(seeded_dir.path());
+        assert_eq!(
+            adopted.queue.items.len(),
+            1,
+            "degraded construction must adopt the queue that is already there"
+        );
+        assert_eq!(
+            queue::load_or_empty(seeded_dir.path()).unwrap().items.len(),
+            1,
+            "and must leave it on disk untouched"
+        );
+    }
+
+    #[tokio::test]
+    async fn degraded_queue_is_found_by_a_later_healthy_start() {
+        let tmp = tempfile::TempDir::new().unwrap();
+
+        // A degraded session records a result.
+        {
+            let (mut degraded, _rx) = PortalManager::new_degraded(tmp.path());
+            degraded
+                .enqueue_game_end("event".into(), "G1".into(), 3, 2, "{}".into())
+                .unwrap();
+        }
+
+        // Once the fault is fixed, the next healthy launch must find it.
+        let (healthy, _rx) = PortalManager::new(tmp.path(), NullIo).unwrap();
+        assert_eq!(
+            healthy.queue.items.len(),
+            1,
+            "a result queued in degraded mode must survive into the next healthy session"
+        );
+        assert_eq!(healthy.queue.items[0].id.game_number, "G1");
+    }
+
+    #[tokio::test]
+    async fn degraded_enqueue_does_not_clobber_results_already_queued() {
+        // THE TRAP. `queue::save` rewrites the whole file, so a degraded
+        // manager that starts from an empty queue would overwrite results
+        // already waiting. This test fails on that naive version.
+        let tmp = tempfile::TempDir::new().unwrap();
+
+        // Two results are already waiting from an earlier healthy session.
+        {
+            let (mut healthy, _rx) = PortalManager::new(tmp.path(), NullIo).unwrap();
+            healthy
+                .enqueue_game_end("event".into(), "G1".into(), 1, 0, "{}".into())
+                .unwrap();
+            healthy
+                .enqueue_game_end("event".into(), "G2".into(), 2, 0, "{}".into())
+                .unwrap();
+        }
+
+        // The refbox restarts into degraded mode and a third game finishes.
+        {
+            let (mut degraded, _rx) = PortalManager::new_degraded(tmp.path());
+            degraded
+                .enqueue_game_end("event".into(), "G3".into(), 3, 0, "{}".into())
+                .unwrap();
+        }
+
+        let on_disk = queue::load_or_empty(tmp.path()).unwrap();
+        let mut games: Vec<&str> = on_disk
+            .items
+            .iter()
+            .map(|i| i.id.game_number.as_str())
+            .collect();
+        games.sort_unstable();
+        assert_eq!(
+            games,
+            vec!["G1", "G2", "G3"],
+            "a degraded session must never destroy results already queued"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What changed

When the refbox cannot start its results-uploading system, it now keeps the list of results-waiting-to-be-sent in the normal place — alongside its settings — instead of in a scratch folder. It also **reads any list already there** before adding to it.

So a game finished during an outage survives. Once the underlying fault is fixed and the refbox restarts, those results are still listed and go up with one press of **RETRY ALL**.

## Why

Previously they went to a scratch folder that no later start-up ever reads, so they were silently abandoned — after the end-of-game banner had told the operator the score was queued.

## Scope

`refbox` only: `portal_manager/mod.rs` and two guards in `app/mod.rs`. No shared types, no wire format, no state machine, no translations.

## How to verify

`just check` is green (555 refbox tests). Five new tests, **each mutation-tested** — the fix was deliberately broken to confirm the test fails, then restored:

1. A result recorded while crippled is found by the next healthy start-up.
2. Two results already waiting, plus a third added while crippled → **all three survive**.
3. Starting up crippled doesn't invent a list where there was none, or replace one that exists.
4. A list file that **cannot be read** is left byte-for-byte untouched.
5. A crippled session doesn't archive expired results out of sight.

Test 2 is the important one. The obvious version of this fix — just point it at the normal folder — **destroys** results: saving rewrites the whole file, and a crippled refbox starts with an empty list, so the first game finished would write a one-game file over a two-game file. Test 1 *passes* on that broken version; only test 2 catches it.

## Review found a worse bug than the one being fixed

Recorded because it shaped the result. A file that cannot be **read** can still be **replaced** — saving renames over it, and rename needs permission on the folder, not the file. The first version of this branch therefore destroyed results and reported success, making this state *more* dangerous than the healthy path, which already backs off correctly. Fixed: a failed read means we don't write there at all.

Two further consequences of keeping results, both closed:
- They appeared as "Score send error" rows on a page advising you to discard them, where Discard is permanent and unarchived and Retry silently does nothing. Rows are now inert while the system is dead — matching the untappable startup row and the REFRESH guard.
- The spec claimed this state doesn't archive expired results. It did, via a 1 Hz tick, into a file the operator can't see. Now gated.

## Known limitations, deliberately not fixed

- **Recovered results need one RETRY ALL press; they do not upload unattended.** Anything past the 30-minute mark is excluded from auto-retry, and any real outage exceeds 30 minutes. Closing that would mean changing what "stuck" means, which is shared by every queued game on every path — recorded in `docs/backlog/untried-result-labelled-as-send-error/NOTE.md`.
- The row-inert guard has **no unit test**: it lives in `update()`, which this crate does not exercise directly. Stated rather than covered by a test that only looks like coverage.
- Reachability of this whole state is **low** and honestly recorded in the spec — no concrete field scenario has been identified, and neither route into it has ever been observed at a tournament. Built as insurance against silently losing tournament results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
