### PR TITLE
fix(refbox): make every queue mutation inert while the portal is dead

### DIFF
--- a/docs/superpowers/specs/2026-08-13-degraded-queue-persistence-design.md
+++ b/docs/superpowers/specs/2026-08-13-degraded-queue-persistence-design.md
@@ -91,9 +91,10 @@ real results, with no `portal_queue.corrupt.*` backup, and reports success.
 
 That made the first implementation *more* destructive than the healthy path, which already handles
 this case correctly: `new()` returns `Err`, and `app/mod.rs` falls back to the temp directory,
-leaving the file intact. **Fix:** on a failed load, the write target falls back to
-`std::env::temp_dir()` — no worse than today for that case, and the unreadable file is preserved
-byte-for-byte.
+leaving the file intact. **Fix:** on a failed load the write target moves elsewhere and the
+unreadable file is preserved byte-for-byte. The first attempt used `std::env::temp_dir()`, which a
+second review showed was the same bug one branch over — see "the guards were positional" below. It is
+now a fresh per-process directory.
 
 ---
 
@@ -148,6 +149,43 @@ tappable and REFRESH declines to spin. This deliberately does **not** touch `is_
 
 **No unit test:** the guard lives in `update()`, which this crate does not exercise directly. Stated
 here rather than covered by a test that only looks like coverage.
+
+### Second review: the guards were positional, so the class was not closed
+
+A second adversarial pass (after PR #2336 merged) found that each earlier fix closed the case it was
+pointed at and left a sibling of the same class:
+
+| Round | Closed | Sibling left open |
+| --- | --- | --- |
+| 1 | Row taps blocked in `update()` | **RETRY ALL still live** — its own button, no guard |
+| 2 | `config_dir` clobber on a failed read | **`temp_dir` clobber** — the fallback wrote to a queue it never read |
+
+**RETRY ALL was a genuine regression** introduced by adopting the queue. The button greys out unless
+something is unsent, so with the old always-empty degraded queue it was inert. Adopted results make
+it live — and `retry_all` resets `queued_at`, so red "Score send error" rows turn yellow with
+"attempt 0". The operator gets *positive confirmation of a success that cannot happen* (no background
+task exists), and the only record of when each game ended is destroyed — the input to both the
+30-minute escalation and the 120-hour expiry. It also contradicted the sweep gate added in the same
+commit, which exists precisely to stop a degraded session ageing the queue.
+
+**The structural fix: gate at the chokepoint, not at the routes.** `retry_all`, `discard`,
+`force_submit`, `force_immediate_retry` and `request_stats_retry` now return early while
+`startup_problem` is set. That closes every present *and future* UI route by construction, and — the
+reason it matters beyond tidiness — it is **unit-testable**, unlike the `update()` guard. The view
+additionally greys RETRY ALL and stops rendering pressable rows, so the operator sees inert controls
+rather than buttons that depress and do nothing.
+
+**The temp-dir fallback now uses a fresh per-process directory** (`refbox-degraded-<pid>`) rather
+than the bare temp dir, because `std::env::temp_dir()` is the healthy path's own second choice and can
+hold real undelivered results. A per-process directory is empty by construction, so there is nothing
+to destroy. This also stopped the test suite overwriting the real shared `/tmp/portal_queue.json` —
+which it had been doing, leaving a plausible fake result that a later fallback session would have
+adopted and tried to upload.
+
+**Correction to the sweep-gate rationale above:** "the next healthy session sweeps" is true but not
+harmless. A healthy session sweeps inside `new()`, *before* the background task attempts anything, so
+an adopted result already past 120 hours is archived **unattempted**, with the indicator Green. The
+gate is a real improvement while an outage is under 120 hours; past that, this promise ends quietly.
 
 ### What this delivers — stated precisely, not optimistically
 

--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -6078,7 +6078,12 @@ impl RefBoxApp {
             AppState::ConfirmScores(scores) =>
                 build_score_confirmation_page(data, scores, self.snapshot.conf_pause_time),
             AppState::PortalDetailPage { scroll_index } =>
-                build_portal_detail_page(data, self.portal_manager.detail_rows(), scroll_index,),
+                build_portal_detail_page(
+                    data,
+                    self.portal_manager.detail_rows(),
+                    scroll_index,
+                    !self.portal_manager.has_startup_problem(),
+                ),
             AppState::PortalAttentionAction {
                 ref item_id,
                 discard_armed,
@@ -6096,7 +6101,12 @@ impl RefBoxApp {
                     // Item was resolved or discarded while the operator
                     // was on this page. Fall back to the detail page so
                     // the operator sees the actual queue state.
-                    build_portal_detail_page(data, self.portal_manager.detail_rows(), 0)
+                    build_portal_detail_page(
+                        data,
+                        self.portal_manager.detail_rows(),
+                        0,
+                        !self.portal_manager.has_startup_problem(),
+                    )
                 }
             }
             AppState::BeepTestPage => {

--- a/refbox/src/app/view_builders/portal_detail.rs
+++ b/refbox/src/app/view_builders/portal_detail.rs
@@ -22,10 +22,17 @@ const PORTAL_DETAIL_LIST_LEN: usize = 4;
 /// (only one of the two can occur), then stuck items (oldest first), then
 /// young pending items (oldest first), then recent successes (newest
 /// first, capped at RECENT_SUCCESS_CAP).
+///
+/// `actionable` is false when the portal subsystem failed to start. Every row
+/// action is refused by `PortalManager` in that state, so the rows must not
+/// look pressable either — a button that visibly depresses and does nothing is
+/// worse than a plainly inert one. RETRY ALL greys out for the same reason: it
+/// would turn red rows yellow and report a success that cannot happen.
 pub(in super::super) fn build_portal_detail_page<'a>(
     data: ViewData<'_, '_>,
     rows: Vec<DetailRow>,
     scroll_index: usize,
+    actionable: bool,
 ) -> Element<'a, Message> {
     let ViewData {
         snapshot,
@@ -66,7 +73,7 @@ pub(in super::super) fn build_portal_detail_page<'a>(
         .chain([None].into_iter().cycle())
         .take(PORTAL_DETAIL_LIST_LEN)
         .map(|slot| match slot {
-            Some(row_data) => render_row(row_data),
+            Some(row_data) => render_row(row_data, actionable),
             None => container(horizontal_space())
                 .width(Length::Fill)
                 .height(Length::Fixed(MIN_BUTTON_SIZE))
@@ -93,7 +100,7 @@ pub(in super::super) fn build_portal_detail_page<'a>(
     // Blue safe-action button, anchored bottom-right opposite BACK.
     // Grayed (no on_press) when there is nothing unsent to retry.
     let retry_all = make_button(fl!("portal-retry-all"))
-        .on_press_maybe(has_unsent.then_some(Message::PortalRetryAll))
+        .on_press_maybe((has_unsent && actionable).then_some(Message::PortalRetryAll))
         .style(blue_button);
 
     column![
@@ -132,7 +139,7 @@ fn row_text_centered<'a>(label: String) -> Element<'a, Message> {
     .into()
 }
 
-fn render_row<'a>(r: DetailRow) -> Element<'a, Message> {
+fn render_row<'a>(r: DetailRow, actionable: bool) -> Element<'a, Message> {
     match r {
         DetailRow::StartupFailed => container(row_text_centered(fl!("portal-row-startup-failed")))
             .style(red_container)
@@ -153,7 +160,7 @@ fn render_row<'a>(r: DetailRow) -> Element<'a, Message> {
             "portal-row-stuck",
             game = game_number
         )))
-        .on_press(Message::PortalRowTapped(id))
+        .on_press_maybe(actionable.then_some(Message::PortalRowTapped(id)))
         .style(red_button)
         .padding(PADDING)
         .width(Length::Fill)
@@ -174,7 +181,7 @@ fn render_row<'a>(r: DetailRow) -> Element<'a, Message> {
                 fl!("portal-row-attempt-suffix", attempts = attempts),
             );
             button(row_text_centered(label))
-                .on_press(Message::PortalRowTapped(id))
+                .on_press_maybe(actionable.then_some(Message::PortalRowTapped(id)))
                 .style(yellow_button)
                 .padding(PADDING)
                 .width(Length::Fill)
@@ -185,7 +192,7 @@ fn render_row<'a>(r: DetailRow) -> Element<'a, Message> {
             "portal-row-stats-pending",
             game = game_number
         )))
-        .on_press(Message::PortalRowTapped(id))
+        .on_press_maybe(actionable.then_some(Message::PortalRowTapped(id)))
         .style(yellow_button)
         .padding(PADDING)
         .width(Length::Fill)

--- a/refbox/src/portal_manager/mod.rs
+++ b/refbox/src/portal_manager/mod.rs
@@ -10,6 +10,7 @@ pub mod queue;
 
 use serde::{Deserialize, Serialize};
 use std::collections::VecDeque;
+use std::process;
 use std::time::Instant;
 use time::{Duration as TimeDuration, OffsetDateTime};
 use tokio::sync::mpsc;
@@ -509,8 +510,10 @@ impl PortalManager {
     }
 
     /// Remove items past `EXPIRY_THRESHOLD` from the active queue, archiving
-    /// them first so nothing is silently lost. Runs at startup (in `new`) and
-    /// on every `ui_tick`; only touches disk when an item actually expires.
+    /// them first so nothing is silently lost. Runs at startup (in `new`) and on
+    /// every `ui_tick` EXCEPT while `startup_problem` is set — see `ui_tick` for
+    /// why a degraded session must not age the queue. Only touches disk when an
+    /// item actually expires.
     /// IO is ordered archive-then-remove so a failed write can never drop a
     /// score without a saved copy.
     fn sweep_expired(&mut self) -> std::io::Result<()> {
@@ -646,6 +649,12 @@ impl PortalManager {
     /// Writing them elsewhere is what this constructor used to do, from when
     /// its only caller was the both-directories-failed case.
     ///
+    /// If `config_dir`'s queue cannot be READ, this session writes to a fresh
+    /// per-process directory under the system temp dir instead, and the
+    /// unreadable file is left untouched. So a caller cannot assume results
+    /// always land in `config_dir` — only that nothing is ever overwritten
+    /// unread.
+    ///
     /// The returned receiver is a dummy that never emits events.
     pub(crate) fn new_degraded(
         config_dir: &std::path::Path,
@@ -658,28 +667,38 @@ impl PortalManager {
         let (_, rx) = mpsc::channel(1);
         let (command_tx, _command_rx) = mpsc::channel(1);
 
-        // Adopt whatever is already queued, best-effort. This must never fail
-        // the construction: one trigger for degraded mode IS an unreadable
-        // queue file, and the game has to keep running regardless.
+        // Adopt whatever is already queued, and only ever write where we could
+        // read. Best-effort by design: one trigger for degraded mode IS an
+        // unreadable queue file, and construction must never fail because the
+        // game has to keep running regardless.
         //
-        // Skipping this load would NOT be the safe option: `queue::save`
-        // rewrites the whole file, so an empty starting queue means the first
-        // enqueue overwrites — and destroys — results already waiting.
-        // Adopt whatever is already queued, and only write where we could
-        // read. If the load fails we must NOT keep `config_dir` as the write
-        // target: `queue::save` renames over the file, and a rename needs
-        // write permission on the *directory*, not on the file — so an
-        // unreadable-but-replaceable queue would be silently destroyed by the
-        // first enqueue. That is the exact failure this fallback exists for,
-        // and the healthy path already handles it by moving to the temp dir.
+        // The invariant matters in both directions. Skipping the load is not
+        // safe — `queue::save` rewrites the whole file, so an empty starting
+        // queue would mean the first enqueue destroys results already waiting.
+        // And on a FAILED load we must not keep writing here either: `save`
+        // renames over the target, and rename needs write permission on the
+        // *directory*, not on the file, so an unreadable-but-replaceable queue
+        // would be silently destroyed.
+        //
+        // The fallback is a fresh per-process directory, never the bare temp
+        // dir: `std::env::temp_dir()` is the healthy path's own second choice
+        // (see `RefBoxApp::new`), so real undelivered results can be sitting in
+        // a queue file there. Writing into it unread would reproduce this very
+        // bug one branch over. A per-process directory is empty by
+        // construction, so there is nothing there to destroy.
         let (queue, queue_dir) = match queue::load_or_empty(config_dir) {
             Ok(q) => (q, config_dir.to_path_buf()),
             Err(e) => {
+                let own = std::env::temp_dir().join(format!("refbox-degraded-{}", process::id()));
                 log::warn!(
-                    "could not read the portal queue ({e}); this session will not write to it, \
-                     so the existing file is left intact"
+                    "could not read the portal queue ({e}); leaving that file untouched and \
+                     using {} for this session instead",
+                    own.display()
                 );
-                (QueueFile::empty(), std::env::temp_dir())
+                // Best-effort: if this fails, saves fail and are logged. It
+                // must not stop the refbox starting.
+                std::fs::create_dir_all(&own).ok();
+                (QueueFile::empty(), own)
             }
         };
 
@@ -717,6 +736,15 @@ impl PortalManager {
     /// (tapped its row). Sends exactly one `RetryStats`. No-op if the id
     /// is not in the queue.
     pub fn request_stats_retry(&self, id: &ItemId) {
+        // Inert while the portal subsystem failed to start. There is no
+        // background task, so nothing here can actually reach the portal —
+        // and every one of these either destroys a result the operator was
+        // never able to send, or rewrites the queue's ageing and reports a
+        // success that did not happen. Gated here, at the one chokepoint, so
+        // no present or future UI route can reach them in that state.
+        if self.startup_problem {
+            return;
+        }
         if let Some(item) = self.find(id) {
             self.send_stats_retry(item);
         }
@@ -782,6 +810,15 @@ impl PortalManager {
     /// "now" so the item is no longer considered stuck (the operator
     /// has restarted its 30-minute clock by making a decision).
     pub fn force_submit(&mut self, id: &ItemId) -> std::io::Result<()> {
+        // Inert while the portal subsystem failed to start. There is no
+        // background task, so nothing here can actually reach the portal —
+        // and every one of these either destroys a result the operator was
+        // never able to send, or rewrites the queue's ageing and reports a
+        // success that did not happen. Gated here, at the one chokepoint, so
+        // no present or future UI route can reach them in that state.
+        if self.startup_problem {
+            return Ok(());
+        }
         if let Some(item) = self.find_mut(id) {
             item.force = true;
             item.attempts = 0;
@@ -811,6 +848,15 @@ impl PortalManager {
     /// `token_refreshed`/`force_submit`: the in-memory reset stands even
     /// if the disk write fails (the error propagates for logging).
     pub fn retry_all(&mut self) -> std::io::Result<()> {
+        // Inert while the portal subsystem failed to start. There is no
+        // background task, so nothing here can actually reach the portal —
+        // and every one of these either destroys a result the operator was
+        // never able to send, or rewrites the queue's ageing and reports a
+        // success that did not happen. Gated here, at the one chokepoint, so
+        // no present or future UI route can reach them in that state.
+        if self.startup_problem {
+            return Ok(());
+        }
         let now = OffsetDateTime::now_utc();
         // Reset every item; touching a stats-pending item's attempt/queued_at
         // fields is harmless (they are unused while score_sent == true) and
@@ -843,6 +889,15 @@ impl PortalManager {
     /// nothing. The item stays young-pending, so no indicator recompute
     /// is needed.
     pub fn force_immediate_retry(&mut self, id: &ItemId) -> std::io::Result<()> {
+        // Inert while the portal subsystem failed to start. There is no
+        // background task, so nothing here can actually reach the portal —
+        // and every one of these either destroys a result the operator was
+        // never able to send, or rewrites the queue's ageing and reports a
+        // success that did not happen. Gated here, at the one chokepoint, so
+        // no present or future UI route can reach them in that state.
+        if self.startup_problem {
+            return Ok(());
+        }
         if let Some(item) = self.find_mut(id) {
             item.last_attempt_at = None;
             queue::save(&self.config_dir, &self.queue)?;
@@ -855,6 +910,15 @@ impl PortalManager {
     /// Removes the item from the queue without submitting. Whatever the
     /// portal currently has for that game stands.
     pub fn discard(&mut self, id: &ItemId) -> std::io::Result<()> {
+        // Inert while the portal subsystem failed to start. There is no
+        // background task, so nothing here can actually reach the portal —
+        // and every one of these either destroys a result the operator was
+        // never able to send, or rewrites the queue's ageing and reports a
+        // success that did not happen. Gated here, at the one chokepoint, so
+        // no present or future UI route can reach them in that state.
+        if self.startup_problem {
+            return Ok(());
+        }
         self.queue.items.retain(|it| it.id != *id);
         queue::save(&self.config_dir, &self.queue)?;
         self.recompute_indicator();
@@ -1546,6 +1610,88 @@ mod tests {
         );
     }
 
+    /// Build a degraded manager over `dir` holding one long-stuck result, as a
+    /// session that adopted a previous session's queue would.
+    async fn degraded_with_one_stuck_item(
+        dir: &std::path::Path,
+    ) -> (PortalManager, mpsc::Receiver<PortalEvent>) {
+        let mut item = mk_stuck_item();
+        item.queued_at = OffsetDateTime::now_utc() - TimeDuration::hours(100);
+        queue::save(
+            dir,
+            &QueueFile {
+                version: 1,
+                items: vec![item],
+            },
+        )
+        .unwrap();
+        PortalManager::new_degraded(dir)
+    }
+
+    #[tokio::test]
+    async fn degraded_retry_all_is_inert_and_does_not_rewrite_ageing() {
+        // RETRY ALL was the sibling left open when row taps were blocked. With
+        // no background task nothing can be retried, but `retry_all` would
+        // reset queued_at — turning red rows yellow with "attempt 0", giving
+        // the operator positive confirmation of a success that never happened,
+        // and destroying the only record of when each game ended (which drives
+        // both the 30-minute escalation and the 120-hour expiry).
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (mut m, _rx) = degraded_with_one_stuck_item(tmp.path()).await;
+        let before = m.queue.items[0].queued_at;
+
+        m.retry_all().unwrap();
+
+        assert_eq!(
+            m.queue.items[0].queued_at, before,
+            "RETRY ALL must not rewrite the queue's ageing in degraded mode"
+        );
+        assert!(
+            matches!(m.detail_rows().get(1), Some(DetailRow::Stuck { .. })),
+            "the row must stay stuck, not flip to pending, got {:?}",
+            m.detail_rows()
+        );
+    }
+
+    #[tokio::test]
+    async fn degraded_discard_cannot_delete_an_adopted_result() {
+        // Discard is permanent and does not archive. In degraded mode the
+        // operator has had no chance to send these results, so the one action
+        // that always "works" must not be deletion.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (mut m, _rx) = degraded_with_one_stuck_item(tmp.path()).await;
+        let id = m.queue.items[0].id.clone();
+
+        m.discard(&id).unwrap();
+
+        assert_eq!(
+            m.queue.items.len(),
+            1,
+            "discard must be inert in degraded mode"
+        );
+        assert_eq!(
+            queue::load_or_empty(tmp.path()).unwrap().items.len(),
+            1,
+            "and must leave the result on disk"
+        );
+    }
+
+    #[tokio::test]
+    async fn degraded_force_submit_is_inert() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (mut m, _rx) = degraded_with_one_stuck_item(tmp.path()).await;
+        let id = m.queue.items[0].id.clone();
+        let before = m.queue.items[0].queued_at;
+
+        m.force_submit(&id).unwrap();
+
+        assert!(
+            !m.queue.items[0].force,
+            "force must not be set with no task to honour it"
+        );
+        assert_eq!(m.queue.items[0].queued_at, before);
+    }
+
     #[tokio::test]
     async fn degraded_ui_tick_does_not_archive_expired_items() {
         // The 1 Hz UI tick runs regardless of health, so without a guard a
@@ -1606,6 +1752,11 @@ mod tests {
         let path = tmp.path().join("portal_queue.json");
         let before = std::fs::read(&path).unwrap();
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o000)).unwrap();
+        if std::fs::read(&path).is_ok() {
+            // Running as root: permissions do not deny us, so the unreadable
+            // premise cannot be set up. Skip rather than fail spuriously.
+            return;
+        }
 
         // Degraded session cannot read it, then records a game of its own.
         {
@@ -1615,7 +1766,26 @@ mod tests {
                 tmp.path(),
                 "a queue that could not be read must not stay the write target"
             );
+            // Nor may the fallback be the bare temp dir: that is the healthy
+            // path's own second choice, so real undelivered results can live
+            // there — and writing into it unread would reproduce this very bug
+            // one branch over. It must be a fresh per-process directory.
+            assert_ne!(
+                degraded.config_dir.as_path(),
+                std::env::temp_dir().as_path(),
+                "the fallback must not be the shared temp dir"
+            );
+            assert!(
+                degraded
+                    .config_dir
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|n| n.starts_with("refbox-degraded-")),
+                "expected a per-process fallback dir, got {:?}",
+                degraded.config_dir
+            );
             let _ = degraded.enqueue_game_end("event".into(), "G3".into(), 3, 0, "{}".into());
+            std::fs::remove_dir_all(&degraded.config_dir).ok();
         }
 
         // Restore access and prove the original results are untouched.


### PR DESCRIPTION
> **Draft on purpose.** A review pass runs before this goes ready — the previous PR merged before its second review landed, which is how these findings reached master.

## What changed

While the refbox's uploading system is dead, every action on the connection page is now genuinely inert rather than merely useless.

## Why — three of these are consequences of the previous PR

**RETRY ALL was a regression.** The button greys out unless something is unsent, so when the degraded queue was always empty it could never be pressed. Once #2336 started keeping results, the button went live — and pressing it turned red "Score send error" rows yellow with "attempt 0" while **nothing was retried**, because there is no background task. The operator got positive confirmation of a success that cannot happen. It also rewrote each result's recorded age on disk, which is the only record of when the game ended and drives both the 30-minute escalation and the 120-hour expiry.

**The temp-directory fallback was the same bug one branch over.** #2336 fixed "don't write to a queue you couldn't read" for the config directory, then fell back to `std::env::temp_dir()` — which is the healthy path's *own* second choice, so real undelivered results can be sitting in a queue file there. It wrote into it without ever reading it. Now it uses a fresh per-process directory, empty by construction.

**Rows looked pressable.** The previous guard lived in the message handler, not the view, so rows visibly depressed and did nothing.

## The fix: the class, not the cases

Each earlier round closed the case it was pointed at and left a sibling. The guards were positional. Five queue-mutating methods — `retry_all`, `discard`, `force_submit`, `force_immediate_retry`, `request_stats_retry` — now return early at the single chokepoint inside `PortalManager`. That covers every present *and future* route by construction, and it is **unit-testable**, which the message-handler guard was not.

## Scope

`refbox` only: `portal_manager/mod.rs`, two guards in `app/mod.rs`, and the detail view. No shared types, no wire format, no translations.

## How to verify

`just check` exit 0, 558 tests. Three new tests, **each gate mutation-tested individually** — removing the `discard` gate fails exactly one test, the right one:

1. RETRY ALL leaves the result's recorded age untouched and the row stays red.
2. Discard cannot delete an adopted result, on disk or in memory.
3. Force-submit is inert.

Plus the fallback test now asserts the write target is a per-process directory and never the shared temp directory.

## Also fixed

- **The test suite was overwriting the real `/tmp/portal_queue.json`** and leaving a plausible fake result (event "event", game "G3", 3–0) that a later fallback session would have adopted and tried to upload. Verified byte-identical after a full run now.
- The expiry-sweep doc comment, which stopped being true when the sweep was gated.
- `new_degraded`'s contract now states that a failed read redirects every write.
- The permissions test skips when run as root, where `chmod 000` cannot deny access and its premise silently inverts.

## Known limitation, unchanged

Recovered results still need one RETRY ALL press *after the fault is fixed* — they do not upload unattended. See `docs/backlog/untried-result-labelled-as-send-error/NOTE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
