### PR TITLE
fix(refbox): stop RETRY ALL reporting a success it cannot deliver

### DIFF
--- a/refbox/src/app/message.rs
+++ b/refbox/src/app/message.rs
@@ -122,6 +122,10 @@ pub enum Message {
     /// every queued game (including stuck ones) so the background task
     /// re-attempts them all on its next tick. A plain resend — never a
     /// force-overwrite.
+    ///
+    /// Not emitted when the portal subsystem failed to start: there is no
+    /// background task to retry with, so the button is greyed out (and
+    /// `retry_all` refuses as well).
     PortalRetryAll,
     ShowWarnings,
     ShowParameterHelp,

--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -6078,7 +6078,12 @@ impl RefBoxApp {
             AppState::ConfirmScores(scores) =>
                 build_score_confirmation_page(data, scores, self.snapshot.conf_pause_time),
             AppState::PortalDetailPage { scroll_index } =>
-                build_portal_detail_page(data, self.portal_manager.detail_rows(), scroll_index,),
+                build_portal_detail_page(
+                    data,
+                    self.portal_manager.detail_rows(),
+                    scroll_index,
+                    !self.portal_manager.has_startup_problem(),
+                ),
             AppState::PortalAttentionAction {
                 ref item_id,
                 discard_armed,
@@ -6096,7 +6101,12 @@ impl RefBoxApp {
                     // Item was resolved or discarded while the operator
                     // was on this page. Fall back to the detail page so
                     // the operator sees the actual queue state.
-                    build_portal_detail_page(data, self.portal_manager.detail_rows(), 0)
+                    build_portal_detail_page(
+                        data,
+                        self.portal_manager.detail_rows(),
+                        0,
+                        !self.portal_manager.has_startup_problem(),
+                    )
                 }
             }
             AppState::BeepTestPage => {

--- a/refbox/src/app/view_builders/portal_detail.rs
+++ b/refbox/src/app/view_builders/portal_detail.rs
@@ -22,10 +22,16 @@ const PORTAL_DETAIL_LIST_LEN: usize = 4;
 /// (only one of the two can occur), then stuck items (oldest first), then
 /// young pending items (oldest first), then recent successes (newest
 /// first, capped at RECENT_SUCCESS_CAP).
+///
+/// `can_retry` is false when the portal subsystem failed to start. RETRY ALL
+/// greys out in that state: with no background task it cannot retry anything,
+/// and pressing it would flip red rows to yellow "attempt 0" — reporting a
+/// success that cannot happen.
 pub(in super::super) fn build_portal_detail_page<'a>(
     data: ViewData<'_, '_>,
     rows: Vec<DetailRow>,
     scroll_index: usize,
+    can_retry: bool,
 ) -> Element<'a, Message> {
     let ViewData {
         snapshot,
@@ -93,7 +99,7 @@ pub(in super::super) fn build_portal_detail_page<'a>(
     // Blue safe-action button, anchored bottom-right opposite BACK.
     // Grayed (no on_press) when there is nothing unsent to retry.
     let retry_all = make_button(fl!("portal-retry-all"))
-        .on_press_maybe(has_unsent.then_some(Message::PortalRetryAll))
+        .on_press_maybe((has_unsent && can_retry).then_some(Message::PortalRetryAll))
         .style(blue_button);
 
     column![

--- a/refbox/src/portal_manager/mod.rs
+++ b/refbox/src/portal_manager/mod.rs
@@ -811,6 +811,16 @@ impl PortalManager {
     /// `token_refreshed`/`force_submit`: the in-memory reset stands even
     /// if the disk write fails (the error propagates for logging).
     pub fn retry_all(&mut self) -> std::io::Result<()> {
+        // Inert while the portal subsystem failed to start. There is no
+        // background task, so nothing can be retried — but the unguarded
+        // version still reset every item's `queued_at`, which flips red
+        // "Score send error" rows to yellow "attempt 0". That reports a
+        // success that cannot happen, and destroys the only record of when
+        // each game ended: the input to both the 30-minute stuck escalation
+        // and the 120-hour expiry.
+        if self.startup_problem {
+            return Ok(());
+        }
         let now = OffsetDateTime::now_utc();
         // Reset every item; touching a stats-pending item's attempt/queued_at
         // fields is harmless (they are unused while score_sent == true) and
@@ -1547,6 +1557,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn degraded_retry_all_is_inert_and_does_not_rewrite_ageing() {
+        // RETRY ALL greys out only when nothing is unsent, so while the
+        // degraded queue was always empty it could never be pressed. Now that
+        // a degraded session adopts the queue, the button goes live — and
+        // `retry_all` resets `queued_at`, flipping red "Score send error" rows
+        // to yellow "attempt 0". Nothing is retried (no background task), so
+        // the operator gets confirmation of a success that cannot happen, and
+        // the record of when each game ended is destroyed.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mut item = mk_stuck_item();
+        item.queued_at = OffsetDateTime::now_utc() - TimeDuration::hours(100);
+        queue::save(
+            tmp.path(),
+            &QueueFile {
+                version: 1,
+                items: vec![item],
+            },
+        )
+        .unwrap();
+
+        let (mut m, _rx) = PortalManager::new_degraded(tmp.path());
+        let before = m.queue.items[0].queued_at;
+
+        m.retry_all().unwrap();
+
+        assert_eq!(
+            m.queue.items[0].queued_at, before,
+            "RETRY ALL must not rewrite the queue's ageing in degraded mode"
+        );
+        assert!(
+            matches!(m.detail_rows().get(1), Some(DetailRow::Stuck { .. })),
+            "the row must stay stuck, not flip to pending, got {:?}",
+            m.detail_rows()
+        );
+    }
+
+    #[tokio::test]
     async fn degraded_ui_tick_does_not_archive_expired_items() {
         // The 1 Hz UI tick runs regardless of health, so without a guard a
         // degraded session would sweep expired items into
@@ -1607,6 +1654,16 @@ mod tests {
         let before = std::fs::read(&path).unwrap();
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o000)).unwrap();
 
+        // This test drives the failed-load fallback, whose write target is the
+        // shared system temp dir — which is also the healthy path's SECOND
+        // choice of queue directory (see `RefBoxApp::new`). Writing there would
+        // leave a fabricated result that a real fallback session would adopt
+        // and try to upload, so note whether a queue file was already there and
+        // remove only one we created ourselves. Never delete a pre-existing
+        // file: on a developer's machine it could hold real results.
+        let shared = std::env::temp_dir().join("portal_queue.json");
+        let shared_existed = shared.exists();
+
         // Degraded session cannot read it, then records a game of its own.
         {
             let (mut degraded, _rx) = PortalManager::new_degraded(tmp.path());
@@ -1616,6 +1673,10 @@ mod tests {
                 "a queue that could not be read must not stay the write target"
             );
             let _ = degraded.enqueue_game_end("event".into(), "G3".into(), 3, 0, "{}".into());
+        }
+
+        if !shared_existed {
+            std::fs::remove_file(&shared).ok();
         }
 
         // Restore access and prove the original results are untouched.

--- a/refbox/src/portal_manager/mod.rs
+++ b/refbox/src/portal_manager/mod.rs
@@ -449,7 +449,15 @@ impl PortalManager {
             startup_problem: false,
             indicator_state: PortalIndicatorState::default(),
             command_tx: tx,
-            config_dir: std::env::temp_dir(),
+            // Deliberately a path that does not exist. `queue::save` creates no
+            // directories, so any mutator called on a manager built here fails
+            // its write loudly instead of quietly landing a fabricated result in
+            // the shared system temp dir — which is the healthy path's second
+            // choice of queue directory (see `RefBoxApp::new`), so a real
+            // session would adopt it and try to upload it. A test that needs a
+            // save to succeed should build the manager over its own `TempDir`
+            // (see `enqueue_game_end_appends_item_and_turns_yellow`).
+            config_dir: std::env::temp_dir().join("uwh-refbox-new-for-test-must-not-write"),
             recent_successes: VecDeque::new(),
         };
         m.recompute_indicator();
@@ -650,6 +658,22 @@ impl PortalManager {
     pub(crate) fn new_degraded(
         config_dir: &std::path::Path,
     ) -> (Self, mpsc::Receiver<PortalEvent>) {
+        Self::new_degraded_with_fallback(config_dir, &std::env::temp_dir())
+    }
+
+    /// `new_degraded` with the failed-load fallback directory injected.
+    ///
+    /// Production always passes `std::env::temp_dir()` (via `new_degraded`).
+    /// Tests pass a directory of their own: the fallback is the *shared*
+    /// system temp dir, which is also the healthy path's second choice of
+    /// queue directory (see `RefBoxApp::new`), so a test that let an enqueue
+    /// land there would overwrite a real queue file on the machine running it
+    /// — and leave a fabricated result for a real fallback session to adopt
+    /// and try to upload.
+    fn new_degraded_with_fallback(
+        config_dir: &std::path::Path,
+        fallback_dir: &std::path::Path,
+    ) -> (Self, mpsc::Receiver<PortalEvent>) {
         // Build (sender, receiver) pairs where the senders go nowhere:
         // the event-channel sender is discarded so the returned receiver
         // never emits, and the command-channel sender is kept on the
@@ -679,7 +703,7 @@ impl PortalManager {
                     "could not read the portal queue ({e}); this session will not write to it, \
                      so the existing file is left intact"
                 );
-                (QueueFile::empty(), std::env::temp_dir())
+                (QueueFile::empty(), fallback_dir.to_path_buf())
             }
         };
 
@@ -810,6 +834,11 @@ impl PortalManager {
     /// No-op-safe on an empty queue. Persistence is best-effort, matching
     /// `token_refreshed`/`force_submit`: the in-memory reset stands even
     /// if the disk write fails (the error propagates for logging).
+    ///
+    /// Refuses outright — returning `Ok(())` having changed nothing — when the
+    /// portal subsystem failed to start. See the guard below for why. The UI
+    /// greys RETRY ALL out in that state, so this is the second line of
+    /// defence, not the visible one.
     pub fn retry_all(&mut self) -> std::io::Result<()> {
         // Inert while the portal subsystem failed to start. There is no
         // background task, so nothing can be retried — but the unguarded
@@ -819,6 +848,13 @@ impl PortalManager {
         // each game ended: the input to both the 30-minute stuck escalation
         // and the 120-hour expiry.
         if self.startup_problem {
+            // Logged so "I pressed RETRY ALL and nothing happened" is
+            // diagnosable from the log: the caller only reports `Err`, and this
+            // path deliberately returns `Ok`.
+            log::warn!(
+                "RETRY ALL ignored: the portal subsystem failed to start, so there is no \
+                 background task to retry with"
+            );
             return Ok(());
         }
         let now = OffsetDateTime::now_utc();
@@ -1568,6 +1604,10 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         let mut item = mk_stuck_item();
         item.queued_at = OffsetDateTime::now_utc() - TimeDuration::hours(100);
+        // A prior session's attempt history, which must also survive: it drives
+        // the "(attempt N)" counter the next healthy session shows.
+        item.attempts = 4;
+        item.last_attempt_at = Some(OffsetDateTime::now_utc() - TimeDuration::hours(1));
         queue::save(
             tmp.path(),
             &QueueFile {
@@ -1576,20 +1616,38 @@ mod tests {
             },
         )
         .unwrap();
+        // Catches a guard that leaves the on-disk queue holding CHANGED values.
+        // A rewrite with byte-identical content is invisible to this (verified
+        // by mutation), which is acceptable: the field assertions below prove
+        // nothing changed, and re-writing the same bytes loses nothing.
+        let on_disk_before = std::fs::read(tmp.path().join("portal_queue.json")).unwrap();
 
         let (mut m, _rx) = PortalManager::new_degraded(tmp.path());
-        let before = m.queue.items[0].queued_at;
+        let before = m.queue.items[0].clone();
 
         m.retry_all().unwrap();
 
         assert_eq!(
-            m.queue.items[0].queued_at, before,
+            m.queue.items[0].queued_at, before.queued_at,
             "RETRY ALL must not rewrite the queue's ageing in degraded mode"
+        );
+        assert_eq!(
+            m.queue.items[0].attempts, before.attempts,
+            "RETRY ALL must not clear the attempt counter in degraded mode"
+        );
+        assert_eq!(
+            m.queue.items[0].last_attempt_at, before.last_attempt_at,
+            "RETRY ALL must not clear the last-attempt time in degraded mode"
         );
         assert!(
             matches!(m.detail_rows().get(1), Some(DetailRow::Stuck { .. })),
             "the row must stay stuck, not flip to pending, got {:?}",
             m.detail_rows()
+        );
+        assert_eq!(
+            std::fs::read(tmp.path().join("portal_queue.json")).unwrap(),
+            on_disk_before,
+            "RETRY ALL must not rewrite the queue file in degraded mode"
         );
     }
 
@@ -1654,19 +1712,19 @@ mod tests {
         let before = std::fs::read(&path).unwrap();
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o000)).unwrap();
 
-        // This test drives the failed-load fallback, whose write target is the
-        // shared system temp dir — which is also the healthy path's SECOND
-        // choice of queue directory (see `RefBoxApp::new`). Writing there would
-        // leave a fabricated result that a real fallback session would adopt
-        // and try to upload, so note whether a queue file was already there and
-        // remove only one we created ourselves. Never delete a pre-existing
-        // file: on a developer's machine it could hold real results.
-        let shared = std::env::temp_dir().join("portal_queue.json");
-        let shared_existed = shared.exists();
+        // This test drives the failed-load fallback, whose production write
+        // target is the shared system temp dir — which is also the healthy
+        // path's SECOND choice of queue directory (see `RefBoxApp::new`).
+        // Letting the enqueue below land there would overwrite a real queue
+        // file on the machine running the test suite, and leave a fabricated
+        // result for a real fallback session to adopt and try to upload. So
+        // inject a fallback of our own: the test never touches the shared path.
+        let fallback = tempfile::TempDir::new().unwrap();
 
         // Degraded session cannot read it, then records a game of its own.
         {
-            let (mut degraded, _rx) = PortalManager::new_degraded(tmp.path());
+            let (mut degraded, _rx) =
+                PortalManager::new_degraded_with_fallback(tmp.path(), fallback.path());
             assert_ne!(
                 degraded.config_dir.as_path(),
                 tmp.path(),
@@ -1675,9 +1733,11 @@ mod tests {
             let _ = degraded.enqueue_game_end("event".into(), "G3".into(), 3, 0, "{}".into());
         }
 
-        if !shared_existed {
-            std::fs::remove_file(&shared).ok();
-        }
+        // The result went to the fallback, so it is not silently dropped.
+        assert!(
+            fallback.path().join("portal_queue.json").exists(),
+            "the degraded session's own result must land in the fallback dir"
+        );
 
         // Restore access and prove the original results are untouched.
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();


### PR DESCRIPTION
## What changed

Two things that are live on master today.

**1. RETRY ALL claimed a success it cannot deliver.** When the refbox's uploading system is dead there is no background task, so nothing can be sent. But pressing RETRY ALL turned the red "Score send error" rows yellow with "attempt 0" — telling the operator it had done something. It also rewrote each result's recorded age, which is the only record of when the game ended, and drives both the 30-minute escalation and the 120-hour expiry.

This was a regression from #2336: the button greys out unless something is unsent, so while the queue in that state was always empty the button was harmless. Once #2336 started keeping results, it went live.

**2. The test suite planted a fake result where the refbox looks for real ones.** Every run wrote a fabricated "G3, 3–0" into the system temp directory's queue file — which is the healthy path's *second-choice* queue directory. A real config-directory read failure would make the refbox adopt that fake result and try to upload it.

## Review round

The first commit's fix for (2) was itself incomplete, and a review pass before going ready caught it. It stopped the test *deleting* a pre-existing queue file in the shared temp directory, but the test still *overwrote* it first and then deliberately left the fabricated result in place — the same destruction this PR exists to prevent, in code whose own comment claimed to protect against it. Demonstrated by planting a sentinel file and running the test: the sentinel was replaced by "G3 3–0".

The second commit fixes that by giving the test its own fallback directory, so it never touches the shared path, and addresses four smaller findings:

- The test-only constructor still defaulted its write target to the shared temp directory. No current test saves, which is the only reason it stayed clean — one added line in any future test would have re-planted a result there. It now points at a path that does not exist, so an accidental write fails loudly instead of landing where a real session would find it.
- A refused RETRY ALL is now logged. The caller only reports errors, so it previously left nothing in the log to diagnose "I pressed it and nothing happened".
- The new test asserted only `queued_at` and the row kind, so a guard covering part of the reset would have passed. It now also asserts `attempts`, `last_attempt_at` and the on-disk file.
- `retry_all` and `PortalRetryAll` still documented unconditional behaviour.

## Scope

`refbox` only, 4 files.

## How to verify

`just check` exit 0, 556 tests.

The guard is mutation-proven twice over: removing it makes the test fail on the intended assertion, and a *partial* guard (covering only `queued_at`) fails on the attempt counter. A byte-identical rewrite of the queue file is not detected — that limit is stated in the test rather than overclaimed.

For the temp-directory fix, both directions were checked by hand:

```
printf '{"sentinel":1}' > /tmp/portal_queue.json
cargo test -p refbox --bins        # file comes back byte-identical
rm /tmp/portal_queue.json
cargo test -p refbox --bins        # nothing is created
```

## What is NOT here, on purpose

A third review round found more defects of the same class in this area — including one inside the previous round's own fix. Rather than add a seventh guard, that is being handled by a redesign so that a dead uploading system has **no write target at all**, making the whole class impossible by construction. Left for that work: the fallback directory behaviour, the remaining mutating methods, `token_refreshed`, the tenant-switch flush, and making the rows inert without dimming them (which needs the existing `*_armed` styles so stranded results stay visible).

One further finding was left as a deliberate judgment call: the greyed-out-button flag is written out by hand at two call sites and no test pins it. Both are correct as written, and the manager-level refusal is the real safety net — the greying is defence in depth. Moving the flag onto `ViewData` would touch a struct shared by every screen, which is out of scope for a fix branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
