### PR TITLE
refactor(refbox): a dead portal subsystem gets no write target

### DIFF
--- a/docs/backlog/re-ended-game-queue-entry/NOTE.md
+++ b/docs/backlog/re-ended-game-queue-entry/NOTE.md
@@ -1,0 +1,86 @@
+# Re-ending a game stacks a duplicate queue entry — and the one-line fix is unsafe
+
+**Found:** 2026-08-13, during the degraded-mode no-write-target redesign (PR #2367).
+**Status:** attempted, reverted, needs its own design. Do NOT re-apply the one-line version.
+
+## The original defect
+
+`PortalManager::enqueue_game_end` appends unconditionally, so ending the same game twice queues two
+entries for it. Two consequences:
+
+- A session that cannot send never drains its queue, so the copies accumulate unbounded.
+- `discard` and `on_item_resolved` remove by id with `retain(|it| it.id != id)`, which drops **every**
+  match at once — so resolving one copy silently discards the other, unsent.
+
+## Why the obvious fix was reverted
+
+The obvious fix — replace the existing entry instead of appending — was implemented, tested green,
+and reverted on review (commit `1239df99`, reverted by `4b0212e3`). It introduces three new failure
+modes, all in the **healthy** path that every tournament uses, where the original defect only bites
+the degraded path that has never been observed in the field. It also does not fix the loss it claims
+to fix.
+
+Any real design must answer all three.
+
+### 1. It does not fix the lossy removal — only changes which copy is lost
+
+The background task iterates its **own clone** of the queue (`health.rs:144`, `151`). So:
+
+1. Task begins posting G1 with score 5-4 from its snapshot.
+2. Operator re-ends G1 with a corrected 6-4; the entry is replaced in place.
+3. The 5-4 post succeeds; `ItemResolved(G1)` arrives.
+4. `on_item_resolved` runs `retain(|it| it.id != id)` (`mod.rs:1071`) and removes the **6-4** entry.
+5. A green RecentSuccess row appears for G1.
+
+The corrected score is discarded and the operator is shown a success. Resolution is keyed on id
+alone, so it cannot tell which payload was actually sent. A fix likely needs the resolve to carry
+what it sent (a generation counter, or the scores) so it only clears the entry it posted.
+
+### 2. Replacement resets `score_sent`, so an already-accepted score is re-posted
+
+`score_sent = true` records that the portal already accepted the game's **score** and only the stats
+upload is outstanding. It gates three things: the auto-retry loop (`health.rs:153`), stuck/red
+classification (`mod.rs:380`), and `is_stats_pending` (`mod.rs:776`).
+
+Replacing the whole entry sets it back to `false`. So re-ending a stats-pending game re-enters the
+auto-retry loop and re-posts a score the portal already holds. That is a conflict, and per ADR 011 a
+conflict is indistinguishable from any other failure — so the row goes stuck/red permanently and
+needs a manual Force. Meanwhile `is_stats_pending` now returns false, so the outstanding stats
+upload stops being offered a retry and is untracked.
+
+Note the old duplicate-stacking behaviour was *less* harmful here: `find`/`find_mut` return the first
+match, so the stats-pending entry survived.
+
+### 3. A re-ended game that already succeeded can never leave the queue
+
+`on_item_resolved` opens with an idempotence guard (`mod.rs:1052`):
+
+```rust
+if self.recent_successes.iter().any(|rs| rs.id == id) {
+    return;
+}
+```
+
+Once G1 has succeeded, its id sits in the recent-successes ring (cap 5). Re-ending G1 queues it
+again, but every subsequent resolve for it returns early before the `retain`. The item stays queued,
+is re-posted every retry interval, crosses the 30-minute stuck threshold and paints the indicator
+red, and only clears once five other games push G1 out of the ring — or at the 120-hour expiry.
+
+This guard exists for a real reason (duplicate delivery would otherwise paint two green rows), so it
+cannot simply be removed.
+
+## Also worth folding in
+
+- `self.queue.items.iter_mut().find(|it| it.id == item.id)` re-implements the existing `find_mut`
+  helper (`mod.rs:617`). Use the helper.
+- Whatever the design, it needs a test for re-ending a **stats-pending** game and one for re-ending
+  an **already-resolved** game. Note that the naive "nothing is left behind after a discard" test
+  passes on the *unfixed* code — `retain` removes both copies — so it proves nothing.
+
+## Related
+
+- Spec: `docs/superpowers/specs/2026-08-13-degraded-no-write-target-design.md` (records the dedupe as
+  in scope; that judgement was reversed on review)
+- Plan Deviations: `docs/superpowers/plans/2026-08-13-degraded-no-write-target.md`
+- `docs/backlog/untried-result-labelled-as-send-error/NOTE.md` — also about `is_item_stuck` keying on
+  age alone

--- a/docs/backlog/unwritable-config-dir-looks-healthy/NOTE.md
+++ b/docs/backlog/unwritable-config-dir-looks-healthy/NOTE.md
@@ -1,0 +1,60 @@
+# An unwritable config dir yields a green portal indicator and memory-only results
+
+**Found:** 2026-08-13, reviewing PR #2367 (degraded mode no write target).
+**Status:** pre-existing on master, NOT introduced by that PR, and not fixed by it.
+**Reachability:** plausible on the field Pi, which runs a read-only overlayfs.
+
+## What happens
+
+`RefBoxApp::new` creates the config dir best-effort and discards the result:
+
+```rust
+std::fs::create_dir_all(&config_dir).ok();   // app/mod.rs, ~2392
+```
+
+Then `PortalManager::new` → `QueueStore::open(config_dir)` → `queue::load_or_empty(dir)`, which
+returns **success without touching the disk** when the queue file does not exist yet:
+
+```rust
+if !path.exists() {
+    return Ok(QueueFile::empty());          // queue.rs:88
+}
+```
+
+So on a first run in a directory that cannot be written:
+
+1. `open` succeeds and hands back a write target.
+2. `PortalManager::new` returns `Ok`, so `RefBoxApp::new` never tries its second-choice directory
+   (`std::env::temp_dir()`) and never reaches degraded mode.
+3. `startup_problem` stays `false`, so the portal indicator is **green** and every control is live.
+4. Every `enqueue_game_end` then fails inside `write_atomic` at `fs::File::create(tmp)`, logging one
+   `error!` line and leaving the result in memory only.
+
+Result: a whole tournament's results are memory-only and lost on restart, with no visible signal —
+the operator sees a healthy green portal the entire time.
+
+## Why PR #2367 does not fix it
+
+That PR's guarantee is narrow and exact: *never write where a read failed*. Holding a `QueueStore`
+proves the directory was read, not that it can be written. When there is no queue file there is
+nothing to read, so nothing is proven at all. The doc comment on `QueueStore::open` says so
+explicitly rather than overstating it.
+
+## Possible fixes, none chosen
+
+- Have `open` verify writability — e.g. write and remove a probe file, or attempt the tmp-file
+  create that `write_atomic` uses. Turns this into an `Err`, so `RefBoxApp::new` falls back to the
+  temp dir exactly as it does for an unreadable queue. Cost: an extra file create per launch, and it
+  must not itself destroy anything.
+- Stop discarding `create_dir_all`'s result at `app/mod.rs:2392` and treat failure as a reason to
+  use the second-choice directory.
+- Surface a repeated write failure in the indicator instead of a single `error!` line, so the
+  operator is not shown green while nothing is being saved.
+
+The first two are the honest fixes; the third is worth having regardless, since a write that starts
+failing mid-tournament has the same invisible outcome.
+
+## Related
+
+- `docs/superpowers/specs/2026-08-13-degraded-no-write-target-design.md`
+- `reference_pi_deployment_launch` in memory — the field Pi's read-only overlayfs

--- a/docs/superpowers/plans/2026-08-13-degraded-no-write-target.md
+++ b/docs/superpowers/plans/2026-08-13-degraded-no-write-target.md
@@ -813,6 +813,20 @@ Record anything that diverged from this plan here rather than in separate commit
   tenant-switch flush is exactly `self.persist()`, so Task 3 uses the funnel instead of a second
   write method. Its test became `store_writes_where_it_read`. Task 3 below is amended accordingly —
   ignore its `store.flush()` step and use `self.persist()?`.
+- **Task 4 was REVERTED after review** (`1239df99`, reverted by `4b0212e3`). The one-line "replace
+  instead of append" introduces three failure modes in the HEALTHY path — an in-flight upload's
+  success deletes the corrected result by id; resetting `score_sent` re-posts a score the portal
+  already accepted, stranding the row red forever; and a re-ended game that already succeeded can
+  never leave the queue because of the idempotence guard in `on_item_resolved`. It also does not fix
+  the lossy removal it claimed to fix. Full analysis and design constraints:
+  `docs/backlog/re-ended-game-queue-entry/NOTE.md`. The spec still lists the dedupe as in scope;
+  that judgement was reversed on review, and it needs its own spec under the heavy process.
+- **Task 5's sealing was tightened beyond `pub(super)`.** As first implemented, the read/write
+  functions were `pub(super)`, which leaves them reachable from `portal_manager/mod.rs` — where all
+  four previous regressions were born. Now `save` and `append_to_archive` are private to `queue.rs`
+  so a store is the only route to a write, with a `#[cfg(test)] seed_for_test` bypass for tests that
+  arrange on-disk state. Reads (`load_or_empty`, `load_archive_or_empty`) stay `pub(super)`: a read
+  cannot destroy anything, so sealing them would be churn without safety.
 - **Mutation-proofed both layers of the safety test.** Reintroducing the temp-dir fallback in
   `new_degraded` fails `a_session_that_could_not_read_its_queue_writes_nothing_anywhere` on the
   `store.is_none()` assertion; with that assertion temporarily removed it then fails on "the shared

--- a/docs/superpowers/plans/2026-08-13-degraded-no-write-target.md
+++ b/docs/superpowers/plans/2026-08-13-degraded-no-write-target.md
@@ -1,0 +1,802 @@
+# Degraded portal mode: no write target — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make it structurally impossible for a refbox session that could not read its portal queue
+to write one, by replacing `config_dir: PathBuf` with `store: Option<QueueStore>` whose only
+constructor requires a successful read.
+
+**Architecture:** `QueueStore::open(dir)` returns the store *together with* the `QueueFile` it
+loaded, so a write target cannot exist for a directory nobody read. `PortalManager` holds
+`Option<QueueStore>`; the temp-directory fallback and `queue_dir()` are deleted. Three existing
+guards survive because they are about *not being able to send*, which is a different fact from
+*having nowhere to write*.
+
+**Tech Stack:** Rust 2024, MSRV 1.85, `tokio` for the async tests, `tempfile` for test dirs,
+`serde_json` for the on-disk format. No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-08-13-degraded-no-write-target-design.md` — read it first;
+this plan argues from it.
+
+## Global Constraints
+
+- `refbox` crate only. Do not touch `uwh-common`, `overlay`, `wireless-remote`, or any file under
+  `refbox/src/app/view_builders/`, and change no translation file.
+- No new dependencies, no new on-disk file format, no UI changes. The inert detail rows keep
+  exactly the appearance they have on master.
+- Rust edition 2024, MSRV 1.85. `cargo clippy --workspace --all-targets --all-features -- -D
+  warnings` must stay clean.
+- No `unwrap()` / `expect()` in non-test code without a comment justifying it.
+- **Tests must never write to the shared system temp directory.** `std::env::temp_dir()` is the
+  healthy path's second-choice queue directory (`app/mod.rs:2424`), so a file planted there can be
+  adopted and uploaded by a real session. Every test uses `tempfile::TempDir`.
+- Heavy process applies (persistence of tournament results): every task ends with its own test run
+  and commit; run `just check` before the final commit.
+- Keep these three guards. Deleting any of them reintroduces the #2349 regression, because in the
+  no-client route the disk works and the store exists:
+  - `retry_all`'s `if self.startup_problem { … return Ok(()) }`
+  - the `!self.startup_problem` gate around `sweep_expired` in `ui_tick`
+  - the `has_startup_problem()` early return in `Message::PortalRowTapped` (`app/mod.rs:3492`)
+
+---
+
+## File Structure
+
+| File | Responsibility after this work |
+|---|---|
+| `refbox/src/portal_manager/queue.rs` | The on-disk format **and** `QueueStore` — the only thing that can write it. Free read/write functions become `pub(super)`. |
+| `refbox/src/portal_manager/mod.rs` | `PortalManager` holds `store: Option<QueueStore>`; all ten write sites go through one `persist()` funnel; owns the tenant-switch flush. |
+| `refbox/src/app/mod.rs` | Constructs the manager; calls the flush by name instead of reaching for a directory. |
+
+No files are created. No file is split — `queue.rs` is ~230 lines and gains ~40.
+
+---
+
+## Task 1: `QueueStore` — a write target you can only get by reading
+
+**Files:**
+- Modify: `refbox/src/portal_manager/queue.rs` (add after `append_to_archive`, ~line 183)
+- Test: `refbox/src/portal_manager/queue.rs` (the existing `#[cfg(test)] mod tests`, ~line 185)
+
+**Interfaces:**
+- Consumes: existing private `queue_path`, `tmp_path`, `write_atomic`, `load_or_empty`,
+  `append_to_archive`, `save` in this file.
+- Produces: `pub(super) struct QueueStore` with
+  `open(dir: &Path) -> std::io::Result<(Self, QueueFile)>`,
+  `save(&self, q: &QueueFile) -> std::io::Result<()>`,
+  `append_to_archive(&self, items: &[QueuedItem]) -> std::io::Result<()>`,
+  `flush(&self) -> std::io::Result<()>`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the existing nested `mod load_save_tests` in `queue.rs` (~line 224) — it already has
+`use super::*;` and `use tempfile::TempDir;`. Add this helper at the top of that module, since the
+existing tests write the literal out longhand three times:
+
+```rust
+        fn one_item_queue(game: &str, black: u8, white: u8) -> QueueFile {
+            QueueFile {
+                version: 1,
+                items: vec![QueuedItem {
+                    id: ItemId {
+                        event_id: "event".into(),
+                        game_number: game.into(),
+                    },
+                    black_score: black,
+                    white_score: white,
+                    stats: "{}".into(),
+                    queued_at: datetime!(2026-08-13 10:00 UTC),
+                    attempts: 0,
+                    last_attempt_at: None,
+                    force: false,
+                    score_sent: false,
+                }],
+            }
+        }
+```
+
+Then the tests:
+
+```rust
+        #[test]
+        fn store_open_hands_back_the_queue_it_loaded() {
+            let tmp = TempDir::new().unwrap();
+            let q = one_item_queue("G1", 3, 2);
+            save(tmp.path(), &q).unwrap();
+
+            let (_store, loaded) = QueueStore::open(tmp.path()).unwrap();
+            assert_eq!(loaded, q, "open must return the queue it read, not an empty one");
+        }
+
+        #[test]
+        fn store_open_on_a_missing_file_is_an_empty_queue() {
+            let tmp = TempDir::new().unwrap();
+            let (_store, loaded) = QueueStore::open(tmp.path()).unwrap();
+            assert!(loaded.items.is_empty());
+        }
+
+        #[test]
+        fn store_round_trips_and_flushes() {
+            let tmp = TempDir::new().unwrap();
+            let (store, _) = QueueStore::open(tmp.path()).unwrap();
+            let q = one_item_queue("G2", 1, 0);
+
+            store.save(&q).unwrap();
+            assert_eq!(load_or_empty(tmp.path()).unwrap(), q);
+
+            store.flush().unwrap();
+            assert!(
+                load_or_empty(tmp.path()).unwrap().items.is_empty(),
+                "flush must leave an empty queue on disk"
+            );
+        }
+```
+
+And the one that pins the safety property (note `datetime!` is already imported by the parent
+`mod tests`, which `use super::*` re-exports into this module):
+
+```rust
+    #[cfg(unix)]
+    #[test]
+    fn no_store_exists_for_a_queue_that_cannot_be_read() {
+        // THE safety property: a directory whose queue file we cannot read
+        // yields no write target at all, so nothing can overwrite it.
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = tempfile::TempDir::new().unwrap();
+        save(tmp.path(), &QueueFile::empty()).unwrap();
+        let path = queue_path(tmp.path());
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        let result = QueueStore::open(tmp.path());
+
+        // Restore before asserting so a failure cannot leave an unreadable
+        // file behind for the rest of the suite.
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        assert!(
+            result.is_err(),
+            "an unreadable queue file must not produce a write target"
+        );
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p refbox --bins queue::tests::store 2>&1 | tail -20`
+Expected: FAIL — `cannot find struct QueueStore in this scope`.
+
+- [ ] **Step 3: Implement `QueueStore`**
+
+Add to `queue.rs` after `append_to_archive`:
+
+```rust
+/// A directory this session successfully read the portal queue from, and is
+/// therefore allowed to write back to.
+///
+/// `open` is the only constructor, and it returns the loaded queue along with
+/// the store — so a `QueueStore` cannot exist for a directory we could not
+/// read. That is the entire safety property: a session with no readable queue
+/// holds no store, and a store is the only route to a queue write, so it
+/// cannot destroy a file it never saw. `queue::save` renames over the target,
+/// and a rename needs write permission on the *directory*, not the file, so an
+/// unreadable-but-replaceable queue is exactly the case this prevents.
+///
+/// See `docs/superpowers/specs/2026-08-13-degraded-no-write-target-design.md`.
+#[derive(Debug)]
+pub(super) struct QueueStore {
+    dir: PathBuf,
+}
+
+impl QueueStore {
+    /// Read `dir`'s queue and, on success, return the write target for it.
+    /// A missing file is a successful read of an empty queue (a first run);
+    /// a corrupt one is rotated aside by `load_or_empty` and also succeeds.
+    /// Only an I/O or permission failure yields `Err` — and therefore no
+    /// write target.
+    pub(super) fn open(dir: &Path) -> std::io::Result<(Self, QueueFile)> {
+        let queue = load_or_empty(dir)?;
+        Ok((
+            Self {
+                dir: dir.to_path_buf(),
+            },
+            queue,
+        ))
+    }
+
+    pub(super) fn save(&self, q: &QueueFile) -> std::io::Result<()> {
+        save(&self.dir, q)
+    }
+
+    pub(super) fn append_to_archive(&self, items: &[QueuedItem]) -> std::io::Result<()> {
+        append_to_archive(&self.dir, items)
+    }
+
+    /// Clear the on-disk queue. Used by the portal-tenant switch, where items
+    /// queued for the old tenant cannot be delivered to the new one.
+    pub(super) fn flush(&self) -> std::io::Result<()> {
+        self.save(&QueueFile::empty())
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo test -p refbox --bins queue:: 2>&1 | tail -10`
+Expected: PASS, all queue tests green (the four new ones plus the existing round-trip tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add refbox/src/portal_manager/queue.rs
+git commit -m "refactor(refbox): add a queue write target you can only get by reading"
+```
+
+---
+
+## Task 2: `PortalManager` holds `Option<QueueStore>`; the temp-dir fallback goes
+
+This is the task that changes behaviour. It must be atomic — the field cannot be half-migrated.
+
+**Files:**
+- Modify: `refbox/src/portal_manager/mod.rs` — field at ~425, `new_for_test` ~438, `sweep_expired`
+  ~524, `new` ~610, `new_degraded` ~658, and the ten write sites at 536, 539, 796, 814, 869, 894,
+  905, 947, 967, 1042
+- Modify: `refbox/src/app/mod.rs:1955` and `:5887` — keep compiling via `queue_dir()`'s new
+  `Option` return; Task 3 replaces them properly
+- Test: `refbox/src/portal_manager/mod.rs` (`mod tests`)
+
+**Interfaces:**
+- Consumes: `QueueStore::{open, save, append_to_archive}` from Task 1.
+- Produces: private `fn persist(&self) -> std::io::Result<()>` on `PortalManager`; field
+  `store: Option<QueueStore>`; `fn queue_dir(&self) -> Option<&std::path::Path>` (temporary —
+  deleted in Task 3).
+
+- [ ] **Step 1: Write the failing tests**
+
+Replace the whole body of the existing `degraded_never_overwrites_a_queue_it_could_not_read`
+(~line 1694) with this, and rename it:
+
+```rust
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_session_that_could_not_read_its_queue_writes_nothing_anywhere() {
+        // The write target is the directory we read from, or there is none.
+        // This session cannot read, so it must leave the file byte-identical,
+        // create nothing beside it, and touch no other directory either.
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        {
+            let (mut healthy, _rx) = PortalManager::new(tmp.path(), NullIo).unwrap();
+            healthy
+                .enqueue_game_end("event".into(), "G1".into(), 1, 0, "{}".into())
+                .unwrap();
+            healthy
+                .enqueue_game_end("event".into(), "G2".into(), 2, 0, "{}".into())
+                .unwrap();
+        }
+        let path = tmp.path().join("portal_queue.json");
+        let before = std::fs::read(&path).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        // The shared temp dir is the healthy path's SECOND-choice queue dir,
+        // so prove we do not fall back to it. `None` vs `Some` also covers
+        // "there was no file and there still isn't".
+        let shared = std::env::temp_dir().join("portal_queue.json");
+        let shared_before = std::fs::read(&shared).ok();
+
+        {
+            let (mut degraded, _rx) = PortalManager::new_degraded(tmp.path());
+            assert!(
+                degraded.store.is_none(),
+                "a queue we could not read must leave this session with no write target"
+            );
+            let _ = degraded.enqueue_game_end("event".into(), "G3".into(), 3, 0, "{}".into());
+            assert_eq!(
+                degraded.queue.items.len(),
+                1,
+                "the result is still held in memory for the operator to read off the screen"
+            );
+        }
+
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        assert_eq!(
+            std::fs::read(&path).unwrap(),
+            before,
+            "the unreadable queue file must be left byte-identical"
+        );
+        assert_eq!(
+            std::fs::read(&shared).ok(),
+            shared_before,
+            "the shared system temp dir must not be used as a fallback"
+        );
+        let mut names: Vec<_> = std::fs::read_dir(tmp.path())
+            .unwrap()
+            .map(|e| e.unwrap().file_name())
+            .collect();
+        names.sort();
+        assert_eq!(
+            names.len(),
+            1,
+            "no new file may appear beside the queue we could not read, got {names:?}"
+        );
+    }
+```
+
+Then add, to pin the other half of the rule:
+
+```rust
+    #[tokio::test]
+    async fn a_session_that_cannot_send_still_saves_when_the_disk_is_fine() {
+        // The no-client route: nothing can be uploaded, but the disk is
+        // perfect, so results MUST still be recorded where a later healthy
+        // start finds them. "Cannot send" is not "cannot save".
+        let tmp = tempfile::TempDir::new().unwrap();
+        {
+            let (mut degraded, _rx) = PortalManager::new_degraded(tmp.path());
+            assert!(
+                degraded.store.is_some(),
+                "a readable queue must still give this session a write target"
+            );
+            degraded
+                .enqueue_game_end("event".into(), "G7".into(), 5, 4, "{}".into())
+                .unwrap();
+        }
+
+        let (later, _rx) = PortalManager::new(tmp.path(), NullIo).unwrap();
+        assert_eq!(later.queue.items.len(), 1, "a later healthy start must find it");
+        assert_eq!(later.queue.items[0].id.game_number, "G7");
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p refbox --bins a_session_that 2>&1 | tail -20`
+Expected: FAIL — `no field 'store' on type 'PortalManager'`.
+
+- [ ] **Step 3: Migrate the field and all ten write sites**
+
+In `refbox/src/portal_manager/mod.rs`:
+
+1. Replace the field (~425):
+
+```rust
+    /// Where this session may write the queue — or `None` when it may not.
+    ///
+    /// A `QueueStore` can only be obtained by successfully reading a
+    /// directory (`QueueStore::open`), so `None` means "we could not read the
+    /// queue file, therefore we must never write over it". This absence is
+    /// the safety property; it replaces six years of per-method guards. See
+    /// the 2026-08-13 spec.
+    store: Option<queue::QueueStore>,
+```
+
+Delete the `config_dir: PathBuf` field.
+
+2. Add the funnel, next to `has_startup_problem`:
+
+```rust
+    /// Write the queue back, if this session has anywhere to write it.
+    ///
+    /// NOT a guard: a session without a store holds no directory at all, so
+    /// there is nothing to guard against. This is only the shared funnel for
+    /// the ten call sites — the safety comes from `Option<QueueStore>`,
+    /// because the sole way to obtain a store is a successful read. A future
+    /// mutator cannot bypass this the way it could bypass a boolean check:
+    /// there is no path to write without a store in hand.
+    fn persist(&self) -> std::io::Result<()> {
+        match &self.store {
+            Some(store) => store.save(&self.queue),
+            None => Ok(()),
+        }
+    }
+```
+
+3. Replace every `queue::save(&self.config_dir, &self.queue)?` with `self.persist()?`, and each
+   `if let Err(e) = queue::save(&self.config_dir, &self.queue) {` with
+   `if let Err(e) = self.persist() {`. That is the sites at 796, 814, 869, 894, 905, 947, 967, 1042.
+
+4. `sweep_expired` (~524) needs the store for the archive too. Replace its body's write section:
+
+```rust
+        // Archive BEFORE removing so a failed write never loses a score. With
+        // no write target there is nothing to archive to and nothing on disk
+        // to shrink, so leave the queue alone entirely: dropping items from
+        // memory would lose them with no on-disk copy anywhere.
+        let Some(store) = &self.store else {
+            return Ok(());
+        };
+        store.append_to_archive(&expired)?;
+        let n = expired.len();
+        self.queue.items = kept;
+        store.save(&self.queue)?;
+```
+
+5. `new` (~614): replace `let queue = queue::load_or_empty(config_dir)?;` with
+
+```rust
+        let (store, queue) = queue::QueueStore::open(config_dir)?;
+```
+
+and set `store: Some(store),` in the struct literal.
+
+6. `new_degraded`: delete `new_degraded_with_fallback` entirely and make `new_degraded` the only
+   constructor again, with this in place of the old load-and-fallback block:
+
+```rust
+        // Adopt whatever is already queued, and take a write target only if
+        // that read succeeded. A failed read leaves this session with none:
+        // `queue::save` renames over the file and a rename needs permission
+        // on the directory rather than the file, so an unreadable-but-
+        // replaceable queue would otherwise be destroyed by the first
+        // enqueue. There is deliberately no second-choice directory — the
+        // temp dir is the healthy path's own fallback, and writing a
+        // fabricated queue there is how a real session ends up adopting one.
+        let (queue, store) = match queue::QueueStore::open(config_dir) {
+            Ok((store, queue)) => (queue, Some(store)),
+            Err(e) => {
+                log::warn!(
+                    "could not read the portal queue ({e}); this session has no write target, so \
+                     the existing file is left untouched and any result recorded now is held in \
+                     memory only"
+                );
+                (QueueFile::empty(), None)
+            }
+        };
+```
+
+7. `new_for_test` (~438): replace the `config_dir` line with `store: None,` and this comment:
+
+```rust
+            // No write target: these managers are for indicator and row-
+            // ordering assertions, none of which persists. A test that needs a
+            // save must build its own via `QueueStore::open` over a `TempDir`
+            // — never a path in the shared system temp dir, which is the
+            // healthy path's second-choice queue directory.
+            store: None,
+```
+
+8. `queue_dir` (~474) becomes temporary and honest until Task 3:
+
+```rust
+    pub fn queue_dir(&self) -> Option<&std::path::Path> {
+        self.store.as_ref().map(|s| s.dir())
+    }
+```
+
+Add to `QueueStore` in `queue.rs`:
+
+```rust
+    pub(super) fn dir(&self) -> &Path {
+        &self.dir
+    }
+```
+
+9. In `app/mod.rs`, wrap both flush sites (1954 and 5886) so they compile against the `Option`:
+
+```rust
+                if old_source == GameSource::Portal {
+                    if let Some(dir) = self.portal_manager.queue_dir() {
+                        if let Err(e) = crate::portal_manager::queue::save(
+                            dir,
+                            &crate::portal_manager::queue::QueueFile::empty(),
+                        ) {
+                            error!("Failed to flush portal queue before restart: {e}");
+                        }
+                    }
+                }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo test -p refbox --bins 2>&1 | tail -5`
+Expected: PASS — all tests green, including the untouched `degraded_retry_all_is_inert_and_does_not_rewrite_ageing`, `degraded_ui_tick_does_not_archive_expired_items`, `degraded_construction_neither_invents_nor_replaces_a_queue`, `degraded_enqueue_does_not_clobber_results_already_queued` and `degraded_queue_is_found_by_a_later_healthy_start`. If any of those five fail, STOP: the redesign has changed a behaviour it was supposed to preserve.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add refbox/src/portal_manager/mod.rs refbox/src/portal_manager/queue.rs refbox/src/app/mod.rs
+git commit -m "refactor(refbox): a session with no readable queue gets no write target"
+```
+
+---
+
+## Task 3: the tenant-switch flush becomes a method; `queue_dir()` is deleted
+
+**Files:**
+- Modify: `refbox/src/portal_manager/mod.rs` — delete `queue_dir`, add
+  `flush_queue_for_tenant_switch`
+- Modify: `refbox/src/app/mod.rs:1954` and `:5886`
+- Test: `refbox/src/portal_manager/mod.rs` (`mod tests`)
+
+**Interfaces:**
+- Consumes: `QueueStore::flush` (Task 1), `store` field (Task 2).
+- Produces: `pub fn flush_queue_for_tenant_switch(&mut self) -> std::io::Result<()>`. `queue_dir`
+  and `QueueStore::dir` no longer exist.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+    #[tokio::test]
+    async fn tenant_switch_flush_clears_a_queue_this_session_owns() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (mut m, _rx) = PortalManager::new(tmp.path(), NullIo).unwrap();
+        m.enqueue_game_end("old-tenant".into(), "G1".into(), 1, 0, "{}".into())
+            .unwrap();
+
+        m.flush_queue_for_tenant_switch().unwrap();
+
+        assert!(m.queue.items.is_empty(), "in memory too, not just on disk");
+        let (_store, on_disk) = queue::QueueStore::open(tmp.path()).unwrap();
+        assert!(on_disk.items.is_empty(), "the on-disk queue must be cleared");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn tenant_switch_flush_writes_nothing_without_a_write_target() {
+        // The old code flushed through `queue_dir()`, bypassing every guard —
+        // in the fallback state it wrote to the shared temp dir, clearing a
+        // queue belonging to a different session and a different tenant.
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        {
+            let (mut healthy, _rx) = PortalManager::new(tmp.path(), NullIo).unwrap();
+            healthy
+                .enqueue_game_end("event".into(), "G1".into(), 1, 0, "{}".into())
+                .unwrap();
+        }
+        let path = tmp.path().join("portal_queue.json");
+        let before = std::fs::read(&path).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o000)).unwrap();
+        let shared = std::env::temp_dir().join("portal_queue.json");
+        let shared_before = std::fs::read(&shared).ok();
+
+        {
+            let (mut degraded, _rx) = PortalManager::new_degraded(tmp.path());
+            degraded.flush_queue_for_tenant_switch().unwrap();
+        }
+
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        assert_eq!(
+            std::fs::read(&path).unwrap(),
+            before,
+            "a session with no write target must not clear a queue it never owned"
+        );
+        assert_eq!(std::fs::read(&shared).ok(), shared_before);
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p refbox --bins tenant_switch_flush 2>&1 | tail -20`
+Expected: FAIL — `no method named 'flush_queue_for_tenant_switch'`.
+
+- [ ] **Step 3: Implement the method and delete `queue_dir`**
+
+In `mod.rs`, delete `queue_dir` and add:
+
+```rust
+    /// Clear the retry queue for a portal-tenant switch: results queued under
+    /// the old tenant cannot be delivered to the new one, so the restarted app
+    /// must not carry them over. Only ever called for the built-in portal —
+    /// a custom site is one address the operator typed, and results queued for
+    /// it stay deliverable to exactly that site after a restart.
+    ///
+    /// A session with no write target does nothing: it never owned a queue
+    /// file, so there is nothing of its own to clear and clearing someone
+    /// else's would destroy real results.
+    pub fn flush_queue_for_tenant_switch(&mut self) -> std::io::Result<()> {
+        self.queue.items.clear();
+        if let Some(store) = &self.store {
+            store.flush()?;
+        }
+        self.recompute_indicator();
+        Ok(())
+    }
+```
+
+Delete `QueueStore::dir` from `queue.rs` — nothing needs it now.
+
+In `app/mod.rs`, replace both flush blocks (the one added in Task 2 at ~1954, and ~5886) with:
+
+```rust
+                if old_source == GameSource::Portal {
+                    if let Err(e) = self.portal_manager.flush_queue_for_tenant_switch() {
+                        error!("Failed to flush portal queue before restart: {e}");
+                        // Continue with restart — the operator pressed Restart and we
+                        // must not block. The queue will be treated as stale items for
+                        // the new tenant, which the retry logic will eventually discard.
+                    }
+                }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo test -p refbox --bins 2>&1 | tail -5`
+Expected: PASS, whole suite green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add refbox/src/portal_manager/mod.rs refbox/src/portal_manager/queue.rs refbox/src/app/mod.rs
+git commit -m "refactor(refbox): flush the queue through the manager, not a borrowed path"
+```
+
+---
+
+## Task 4: re-ending a game replaces its queued result
+
+**Files:**
+- Modify: `refbox/src/portal_manager/mod.rs` — `enqueue_game_end` (~773, the `push` at ~795)
+- Test: `refbox/src/portal_manager/mod.rs` (`mod tests`)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: no signature change — `enqueue_game_end` keeps
+  `(&mut self, String, String, u8, u8, String) -> std::io::Result<()>`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+    #[tokio::test]
+    async fn re_ending_a_game_replaces_its_queued_result() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (mut m, _rx) = PortalManager::new(tmp.path(), NullIo).unwrap();
+        m.enqueue_game_end("event".into(), "G1".into(), 1, 0, "{}".into())
+            .unwrap();
+        m.enqueue_game_end("event".into(), "G1".into(), 2, 1, "{}".into())
+            .unwrap();
+
+        assert_eq!(
+            m.queue.items.len(),
+            1,
+            "a re-ended game must replace its entry, not stack a second one"
+        );
+        assert_eq!(
+            (m.queue.items[0].black_score, m.queue.items[0].white_score),
+            (2, 1),
+            "the later result wins — it is the corrected score"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolving_a_re_ended_game_leaves_nothing_behind() {
+        // `discard`/`on_item_resolved` remove by id with `retain`, which drops
+        // EVERY match — so with duplicates queued, resolving one silently
+        // discarded the other, unsent.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (mut m, _rx) = PortalManager::new(tmp.path(), NullIo).unwrap();
+        m.enqueue_game_end("event".into(), "G1".into(), 1, 0, "{}".into())
+            .unwrap();
+        m.enqueue_game_end("event".into(), "G1".into(), 2, 1, "{}".into())
+            .unwrap();
+
+        let id = m.queue.items[0].id.clone();
+        m.discard(&id).unwrap();
+
+        assert!(
+            m.queue.items.is_empty(),
+            "no orphaned duplicate may survive the removal"
+        );
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p refbox --bins re_ending_a_game 2>&1 | tail -20`
+Expected: FAIL — `assertion failed: left: 2, right: 1` (two entries queued).
+
+- [ ] **Step 3: Replace instead of push**
+
+In `enqueue_game_end`, replace `self.queue.items.push(item);` with:
+
+```rust
+        // A game can legitimately be re-ended: a corrected score, or an
+        // operator re-running the same game number. Replace the existing entry
+        // rather than stacking a second one. Two reasons this matters: a
+        // session that cannot send never drains its queue, so duplicates
+        // accumulate unbounded; and `discard`/`on_item_resolved` remove by id
+        // with `retain`, which drops every match at once — so resolving one
+        // copy silently discarded the other, unsent. The later result wins.
+        if let Some(existing) = self.queue.items.iter_mut().find(|it| it.id == item.id) {
+            *existing = item;
+        } else {
+            self.queue.items.push(item);
+        }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo test -p refbox --bins 2>&1 | tail -5`
+Expected: PASS, whole suite green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add refbox/src/portal_manager/mod.rs
+git commit -m "fix(refbox): re-ending a game replaces its queued result"
+```
+
+---
+
+## Task 5: seal the module and prove the shared temp dir stays clean
+
+**Files:**
+- Modify: `refbox/src/portal_manager/mod.rs:9` (`pub mod queue;`)
+- Modify: `refbox/src/portal_manager/queue.rs` — visibility of `load_or_empty`, `save`,
+  `append_to_archive`, `load_archive_or_empty`
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: nothing new. `queue` is no longer reachable from `app`.
+
+- [ ] **Step 1: Seal it**
+
+`app/mod.rs` no longer references `crate::portal_manager::queue` at all after Task 3 — verify
+first, then narrow the visibility so it cannot come back:
+
+```bash
+grep -rn "portal_manager::queue" refbox/src/ --include=*.rs | grep -v "^refbox/src/portal_manager/"
+```
+
+Expected: no output. Then in `mod.rs:9` change `pub mod queue;` to `mod queue;`, and in `queue.rs`
+change `pub fn load_or_empty`, `pub fn save`, `pub fn append_to_archive` and
+`pub fn load_archive_or_empty` to `pub(super) fn …`. Leave `QueueFile`, `QueuedItem` and their
+fields `pub` — the background task and the snapshot channel use them inside this module tree.
+
+- [ ] **Step 2: Verify it compiles and the suite is green**
+
+Run: `cargo test -p refbox --bins 2>&1 | tail -5`
+Expected: PASS. A compile error here means something outside `portal_manager` still reaches for the
+queue — find it rather than widening the visibility back.
+
+- [ ] **Step 3: Prove no test writes to the shared temp directory**
+
+Both directions, exactly as #2349 established — a delete-guard is not an overwrite-guard, so check
+content, not existence:
+
+```bash
+printf '{"sentinel":1}' > /tmp/portal_queue.json
+md5sum /tmp/portal_queue.json
+cargo test -p refbox --bins 2>&1 | tail -3
+md5sum /tmp/portal_queue.json
+rm -f /tmp/portal_queue.json
+cargo test -p refbox --bins 2>&1 | tail -3
+ls -la /tmp/portal_queue.json /tmp/portal_queue.json.tmp /tmp/portal_queue.expired.json
+```
+
+Expected: the two md5sums identical, and the final `ls` reports all three as missing.
+
+- [ ] **Step 4: Full gate**
+
+Run: `just check`
+Expected: exit 0. Fix any clippy finding rather than allowing it.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add refbox/src/portal_manager/mod.rs refbox/src/portal_manager/queue.rs
+git commit -m "refactor(refbox): seal the queue module inside portal_manager"
+```
+
+---
+
+## Acceptance criteria check (from the spec)
+
+Map each spec criterion to where it is proven, and confirm before opening the PR:
+
+| # | Criterion | Proven by |
+|---|---|---|
+| 1 | Unreadable-queue session creates no file anywhere | `a_session_that_could_not_read_its_queue_writes_nothing_anywhere` + Task 5 Step 3 |
+| 2 | No-client session still saves; later healthy start finds it | `a_session_that_cannot_send_still_saves_when_the_disk_is_fine`, plus the preserved `degraded_queue_is_found_by_a_later_healthy_start` |
+| 3 | The unreadable file is byte-identical | same test, `assert_eq!(read(&path), before)` |
+| 4 | Tenant switch writes nothing without a target; still clears normally | `tenant_switch_flush_writes_nothing_without_a_write_target`, `tenant_switch_flush_clears_a_queue_this_session_owns` |
+| 5 | Re-ending leaves one entry; removal leaves nothing | `re_ending_a_game_replaces_its_queued_result`, `resolving_a_re_ended_game_leaves_nothing_behind` |
+| 6 | The three send-ability guards still hold | existing `degraded_retry_all_is_inert_and_does_not_rewrite_ageing`, `degraded_ui_tick_does_not_archive_expired_items`, unchanged `PortalRowTapped` gate |
+| 7 | `just check` exit 0 | Task 5 Step 4 |
+| 8 | No view_builder or translation file touched | `git diff --stat origin/master` before the PR |
+
+## Deviations
+
+Record anything that diverged from this plan here rather than in separate commits, per
+`.claude/rules/plan-execution.md`.

--- a/docs/superpowers/plans/2026-08-13-degraded-no-write-target.md
+++ b/docs/superpowers/plans/2026-08-13-degraded-no-write-target.md
@@ -813,11 +813,6 @@ Record anything that diverged from this plan here rather than in separate commit
   tenant-switch flush is exactly `self.persist()`, so Task 3 uses the funnel instead of a second
   write method. Its test became `store_writes_where_it_read`. Task 3 below is amended accordingly —
   ignore its `store.flush()` step and use `self.persist()?`.
-- **Task 4's second test was dropped, not written.** `resolving_a_re_ended_game_leaves_nothing_behind`
-  passed on the UNFIXED code: `retain` removes every id match, so "nothing behind" was already true
-  with duplicates queued. A test that passes before and after proves nothing. Replaced with on-disk
-  assertions on the dedupe test — the persisted queue holds one entry and it carries the corrected
-  score, which does discriminate (the old code persisted two).
 - **Mutation-proofed both layers of the safety test.** Reintroducing the temp-dir fallback in
   `new_degraded` fails `a_session_that_could_not_read_its_queue_writes_nothing_anywhere` on the
   `store.is_none()` assertion; with that assertion temporarily removed it then fails on "the shared

--- a/docs/superpowers/plans/2026-08-13-degraded-no-write-target.md
+++ b/docs/superpowers/plans/2026-08-13-degraded-no-write-target.md
@@ -813,6 +813,11 @@ Record anything that diverged from this plan here rather than in separate commit
   tenant-switch flush is exactly `self.persist()`, so Task 3 uses the funnel instead of a second
   write method. Its test became `store_writes_where_it_read`. Task 3 below is amended accordingly —
   ignore its `store.flush()` step and use `self.persist()?`.
+- **Task 4's second test was dropped, not written.** `resolving_a_re_ended_game_leaves_nothing_behind`
+  passed on the UNFIXED code: `retain` removes every id match, so "nothing behind" was already true
+  with duplicates queued. A test that passes before and after proves nothing. Replaced with on-disk
+  assertions on the dedupe test — the persisted queue holds one entry and it carries the corrected
+  score, which does discriminate (the old code persisted two).
 - **Mutation-proofed both layers of the safety test.** Reintroducing the temp-dir fallback in
   `new_degraded` fails `a_session_that_could_not_read_its_queue_writes_nothing_anywhere` on the
   `store.is_none()` assertion; with that assertion temporarily removed it then fails on "the shared

--- a/docs/superpowers/plans/2026-08-13-degraded-no-write-target.md
+++ b/docs/superpowers/plans/2026-08-13-degraded-no-write-target.md
@@ -800,3 +800,21 @@ Map each spec criterion to where it is proven, and confirm before opening the PR
 
 Record anything that diverged from this plan here rather than in separate commits, per
 `.claude/rules/plan-execution.md`.
+
+- **Tasks 1 and 2 share one commit.** Task 1 as written cannot be committed on its own: nothing in
+  the non-test build constructs `QueueStore`, so `cargo clippy -p refbox --bins` reports
+  `struct QueueStore is never constructed` and `associated items open, save, append_to_archive and
+  flush are never used`. With `-D warnings` in CI that is a red commit, and silencing it with
+  `#[allow(dead_code)]` needs explicit discussion under `.claude/rules/rust.md`. Folding the two
+  tasks into one commit was the only option that violates neither. Task 1's tests and Task 2's
+  tests both ran and were seen to fail before their implementations landed.
+- **`QueueStore::flush` was dropped.** It hit the same dead-code wall (no production caller until
+  Task 3), which was the signal that it should not exist: after `self.queue.items.clear()` the
+  tenant-switch flush is exactly `self.persist()`, so Task 3 uses the funnel instead of a second
+  write method. Its test became `store_writes_where_it_read`. Task 3 below is amended accordingly —
+  ignore its `store.flush()` step and use `self.persist()?`.
+- **Mutation-proofed both layers of the safety test.** Reintroducing the temp-dir fallback in
+  `new_degraded` fails `a_session_that_could_not_read_its_queue_writes_nothing_anywhere` on the
+  `store.is_none()` assertion; with that assertion temporarily removed it then fails on "the shared
+  system temp dir must not be used as a fallback". So the test catches the regression both
+  structurally and by observed effect.

--- a/docs/superpowers/specs/2026-08-13-degraded-no-write-target-design.md
+++ b/docs/superpowers/specs/2026-08-13-degraded-no-write-target-design.md
@@ -1,0 +1,191 @@
+# Degraded portal mode: no write target by construction
+
+**Date:** 2026-08-13
+**Crate:** `refbox` only
+**Status:** approved design, not yet implemented
+**Follows:** PR #2319 (startup message), #2336 (degraded queue persistence), #2348 (closed
+unmerged — redesign chosen over a seventh guard), #2349 (RETRY ALL false-success regression)
+
+---
+
+## Why this exists
+
+Four review rounds in this area have each found the same class of defect in the previous round's
+own fix: a session whose portal subsystem failed to start could write — and destroy — queue data.
+Each round added another per-method guard. Four guards now exist in four different shapes across
+two layers — `if !self.startup_problem { … }` wrapping the body in `ui_tick`, an early
+`return Ok(())` in `retry_all`, an early return in the app's `PortalRowTapped` handler, and a
+bool passed into the view — while ten write sites and several mutators have none. The fourth
+round found a hole inside the third round's own fix.
+
+The decision recorded here is to stop guarding methods and remove the capability instead: a
+session that could not read a queue file has **nowhere to write**, enforced by the type system
+rather than by a check each new method must remember to repeat.
+
+## What was wrong with "degraded mode" as a concept
+
+The existing code treats one flag, `startup_problem`, as meaning both "cannot send" and "cannot
+save". They are different failures with different correct behaviours, and conflating them is the
+root of the bug class.
+
+| Route into degraded mode | What actually broke | Disk usable? |
+|---|---|---|
+| No portal client (`app/mod.rs:2404`) | `UwhPortalClient::new` failed — realistically a TLS/certificate-store problem | **Yes, fully** |
+| Both directories failed (`app/mod.rs:2433`) | Queue unreadable in the config dir *and* the temp dir | No |
+| Queue load failed inside `new_degraded` | The file we would be replacing could not be read | Not safely |
+
+Two consequences of reading this properly:
+
+- In the no-client route the disk is perfect. That session should persist results exactly as a
+  healthy one does; only the uploading is missing. This is what #2336 established and it stays.
+- An unreadable config-dir queue **with** a working client does not reach degraded mode at all: it
+  falls to the temp dir, where there is normally no queue file, so it starts *healthy* pointed at
+  the temp dir. Reaching degraded mode with a failed load therefore requires two independent
+  faults at once.
+
+## Reachability, recorded so nobody over-invests
+
+Degraded mode has never been observed in the field. Corruption — the plausible cause — is already
+handled elsewhere: `queue::load_or_empty` renames a corrupt or wrong-version file to
+`portal_queue.corrupt.<ts>.json` and returns an empty queue as **success**. So the "unreadable"
+path needs a permission or hardware I/O error on the refbox's own config directory, coinciding
+with a failure that reaches degraded mode in the first place.
+
+This work is insurance against silently losing tournament results, not a response to an incident.
+Keep it proportionate: no new UI, no new on-disk format, no new dependencies.
+
+---
+
+## The design
+
+### The invariant as a type
+
+```rust
+pub(crate) struct QueueStore { dir: PathBuf }
+
+impl QueueStore {
+    /// The ONLY constructor. Returns the store together with the queue it
+    /// loaded, so a store cannot exist unless this directory was read.
+    pub(crate) fn open(dir: &Path) -> std::io::Result<(Self, QueueFile)>;
+
+    pub(crate) fn save(&self, q: &QueueFile) -> std::io::Result<()>;
+    pub(crate) fn append_to_archive(&self, items: &[QueuedItem]) -> std::io::Result<()>;
+    /// Writes an empty queue. For the portal-tenant switch.
+    pub(crate) fn flush(&self) -> std::io::Result<()>;
+}
+```
+
+`PortalManager` holds `store: Option<QueueStore>` in place of `config_dir: PathBuf`. Because
+`open` is the only constructor and it hands back the loaded queue, "only ever write to the
+directory you successfully read from" is true of the program's structure, not of its discipline.
+
+`queue.rs`'s free functions `save`, `load_or_empty`, `append_to_archive` and
+`load_archive_or_empty` become private to the `portal_manager` module. `QueueFile`, `QueuedItem`
+and `ItemId` stay public — the background task and the app snapshot them.
+
+### What this removes
+
+- **The temp-directory fallback, entirely.** With it goes `new_degraded_with_fallback`, the
+  `new_for_test` non-existent-path guard, and the possibility of any session or test writing to
+  the shared temp dir at all.
+- **`queue_dir()`**, and with it the tenant-switch flush's ability to bypass the manager
+  (`app/mod.rs:1955` and `:5887`). The flush becomes `store.flush()`, so a store-less session
+  writes nothing and no session can flush a directory it does not own.
+- **The need for a guard on every mutator that never got one.** `token_refreshed` was identified
+  in review round 3 as an ungated mutator reachable in the client-present route, and the two
+  background-task callbacks (`on_score_sent_stats_pending`, `on_item_resolved`) write unguarded as
+  well. None of them needs a guard after this: with no store they cannot write, and with no
+  background task the callbacks never fire. This is the hole the next review round would have
+  found.
+
+### What this deliberately keeps
+
+Three guards survive, all justified by the *same* single reason — nothing can be sent — rather
+than six ad-hoc ones:
+
+| Guard | Why it is not about writing |
+|---|---|
+| `retry_all` | Flips red rows to yellow "attempt 0" and rewrites every result's age, reporting a success no background task can deliver |
+| the expiry sweep in `ui_tick` | Archives results into a file the UI never shows, when the session was never able to send them |
+| `Message::PortalRowTapped` | Offers a Retry that cannot run and a Discard that deletes permanently |
+
+These matter *most* in the no-client route, where the store exists and writes succeed. Deleting
+them would reintroduce #2349 exactly.
+
+### The duplicate-game defect
+
+`enqueue_game_end` appends unconditionally. In a session that never drains its queue, re-ending
+the same game stacks duplicate entries; `discard` and `on_item_resolved` then use
+`retain(|it| it.id != id)`, which removes **every** copy — so resolving one silently drops the
+other, unsent.
+
+Fix: enqueueing a game that is already queued replaces the existing entry. The later result wins,
+which is correct for a game re-ended with a corrected score.
+
+### Accepted behaviour change
+
+Today an unreadable-queue session writes to the temp directory, where a later healthy start might
+adopt the results because the temp dir is its second choice. After this change that session writes
+nothing, and that recovery path is gone.
+
+Accepted deliberately: #2349 established the same write can destroy a *different* session's real
+queue, and adopting a stranger's temp-dir queue is itself a hazard. A theoretical recovery is
+traded for a real destruction risk. Approved by Eric 2026-08-13.
+
+---
+
+## Acceptance criteria
+
+Observable or runnable, not internal:
+
+1. A session that cannot read its queue file creates **no file anywhere** — not in the config
+   directory, not in the system temp directory. Verifiable by planting a sentinel at
+   `$TMPDIR/portal_queue.json` and confirming it is untouched, and by listing the config dir.
+2. A no-client session with a working disk still records finished games to the real queue file,
+   and a subsequent healthy start finds and uploads them. (Unchanged from #2336 — this must not
+   regress.)
+3. The unreadable queue file is left byte-identical.
+4. A portal-tenant switch in a store-less session writes nothing; in a normal session it still
+   clears the queue as it does today.
+5. Re-ending the same game leaves one entry holding the later score; removing that game leaves
+   nothing behind.
+6. RETRY ALL, the expiry sweep, and row taps remain inert whenever nothing can be sent — the
+   #2349 guarantees, still proven by their existing tests.
+7. `just check` exit 0, all existing tests green.
+8. No file under `refbox/src/app/view_builders/` is modified, and no translation file changes.
+
+## Out of scope
+
+- Any UI change, including the inert rows' appearance. They keep exactly the styling they have on
+  master. If that is revisited it gets its own decision — the `red_button_armed` /
+  `yellow_button_armed` option is recorded in `docs/backlog/` and in memory, not here.
+- `uwh-common`, the wire format, the LED panel, the overlay, the wireless remote.
+- The healthy path's directory selection (config dir, then temp dir). Only the *degraded*
+  fallback is removed.
+- `is_item_stuck` keying purely on age without asking whether an item was ever attempted —
+  already backlogged at `docs/backlog/untried-result-labelled-as-send-error/NOTE.md`.
+- Concurrent refbox processes sharing a config dir. One-refbox-at-a-time remains the standing
+  rule.
+
+## Testing approach
+
+The type-level facts cannot be unit-tested — being compile errors is the point. Tests cover the
+behavioural consequences, one per acceptance criterion above, plus:
+
+- A test that a store-less manager's mutators leave the config directory empty, driven through
+  `enqueue_game_end` (the one mutator genuinely reachable in that state).
+- Tests must never write to the shared system temp directory. `QueueStore::open` over a
+  `TempDir` is the only pattern; `new_for_test` gets `store: None` or a `TempDir`-backed store,
+  never a path in the shared temp dir. A full `cargo test` must leave a planted sentinel at
+  `$TMPDIR/portal_queue.json` byte-identical, and create nothing when none is present.
+
+## Files expected to change
+
+| File | Change |
+|---|---|
+| `refbox/src/portal_manager/queue.rs` | Add `QueueStore`; make the free read/write functions module-private |
+| `refbox/src/portal_manager/mod.rs` | `config_dir: PathBuf` → `store: Option<QueueStore>`; route all ten write sites through it; delete the temp-dir fallback, `new_degraded_with_fallback`, `queue_dir()`; dedupe `enqueue_game_end` |
+| `refbox/src/app/mod.rs` | Construction at ~2397–2439; the two flush sites at ~1955 and ~5887 |
+
+No other files. `refbox` is a binary crate, so all of this is internal — nothing outside it can
+observe the type change.

--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -1951,16 +1951,11 @@ impl RefBoxApp {
                 // deliverable to exactly that site after the restart; flushing
                 // them would destroy real game results.
                 if old_source == GameSource::Portal {
-                    if let Some(dir) = self.portal_manager.queue_dir() {
-                        if let Err(e) = crate::portal_manager::queue::save(
-                            dir,
-                            &crate::portal_manager::queue::QueueFile::empty(),
-                        ) {
-                            error!("Failed to flush portal queue before restart: {e}");
-                            // Continue with restart — the operator pressed Restart and we
-                            // must not block. The queue will be treated as stale items for
-                            // the new tenant, which the retry logic will eventually discard.
-                        }
+                    if let Err(e) = self.portal_manager.flush_queue_for_tenant_switch() {
+                        error!("Failed to flush portal queue before restart: {e}");
+                        // Continue with restart — the operator pressed Restart and we
+                        // must not block. The queue will be treated as stale items for
+                        // the new tenant, which the retry logic will eventually discard.
                     }
                 }
 
@@ -5885,13 +5880,8 @@ impl RefBoxApp {
                     // arm: a custom site is the same address either side of a
                     // mode change, so its queued results stay deliverable.
                     if self.source == GameSource::Portal {
-                        if let Some(dir) = self.portal_manager.queue_dir() {
-                            if let Err(e) = crate::portal_manager::queue::save(
-                                dir,
-                                &crate::portal_manager::queue::QueueFile::empty(),
-                            ) {
-                                error!("Failed to flush portal queue before restart: {e}");
-                            }
+                        if let Err(e) = self.portal_manager.flush_queue_for_tenant_switch() {
+                            error!("Failed to flush portal queue before restart: {e}");
                         }
                     }
                     if let Err(e) = confy::store(APP_NAME, None, &self.config) {

--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -1951,14 +1951,16 @@ impl RefBoxApp {
                 // deliverable to exactly that site after the restart; flushing
                 // them would destroy real game results.
                 if old_source == GameSource::Portal {
-                    if let Err(e) = crate::portal_manager::queue::save(
-                        self.portal_manager.queue_dir(),
-                        &crate::portal_manager::queue::QueueFile::empty(),
-                    ) {
-                        error!("Failed to flush portal queue before restart: {e}");
-                        // Continue with restart — the operator pressed Restart and we
-                        // must not block. The queue will be treated as stale items for
-                        // the new tenant, which the retry logic will eventually discard.
+                    if let Some(dir) = self.portal_manager.queue_dir() {
+                        if let Err(e) = crate::portal_manager::queue::save(
+                            dir,
+                            &crate::portal_manager::queue::QueueFile::empty(),
+                        ) {
+                            error!("Failed to flush portal queue before restart: {e}");
+                            // Continue with restart — the operator pressed Restart and we
+                            // must not block. The queue will be treated as stale items for
+                            // the new tenant, which the retry logic will eventually discard.
+                        }
                     }
                 }
 
@@ -5883,11 +5885,13 @@ impl RefBoxApp {
                     // arm: a custom site is the same address either side of a
                     // mode change, so its queued results stay deliverable.
                     if self.source == GameSource::Portal {
-                        if let Err(e) = crate::portal_manager::queue::save(
-                            self.portal_manager.queue_dir(),
-                            &crate::portal_manager::queue::QueueFile::empty(),
-                        ) {
-                            error!("Failed to flush portal queue before restart: {e}");
+                        if let Some(dir) = self.portal_manager.queue_dir() {
+                            if let Err(e) = crate::portal_manager::queue::save(
+                                dir,
+                                &crate::portal_manager::queue::QueueFile::empty(),
+                            ) {
+                                error!("Failed to flush portal queue before restart: {e}");
+                            }
                         }
                     }
                     if let Err(e) = confy::store(APP_NAME, None, &self.config) {

--- a/refbox/src/portal_manager/mod.rs
+++ b/refbox/src/portal_manager/mod.rs
@@ -425,11 +425,19 @@ pub struct PortalManager {
     startup_problem: bool,
     indicator_state: PortalIndicatorState,
     command_tx: mpsc::Sender<health::PortalCommand>,
-    config_dir: std::path::PathBuf,
     /// In-memory ring of the most recent successful submissions,
     /// newest at the front, capped at `RECENT_SUCCESS_CAP`. Used only
     /// for the detail-page strip; not persisted across restarts.
     recent_successes: VecDeque<RecentSuccess>,
+    /// Where this session may write the queue — or `None` when it may not.
+    ///
+    /// A `QueueStore` can only be obtained by successfully reading a directory
+    /// (`QueueStore::open`), so `None` means "we could not read the queue file,
+    /// therefore we must never write over it". That absence is the safety
+    /// property, and it replaces guarding each mutating method one at a time.
+    /// There is deliberately no second-choice directory: see
+    /// `docs/superpowers/specs/2026-08-13-degraded-no-write-target-design.md`.
+    store: Option<queue::QueueStore>,
 }
 
 impl PortalManager {
@@ -449,16 +457,14 @@ impl PortalManager {
             startup_problem: false,
             indicator_state: PortalIndicatorState::default(),
             command_tx: tx,
-            // Deliberately a path that does not exist. `queue::save` creates no
-            // directories, so any mutator called on a manager built here fails
-            // its write loudly instead of quietly landing a fabricated result in
-            // the shared system temp dir — which is the healthy path's second
-            // choice of queue directory (see `RefBoxApp::new`), so a real
-            // session would adopt it and try to upload it. A test that needs a
-            // save to succeed should build the manager over its own `TempDir`
-            // (see `enqueue_game_end_appends_item_and_turns_yellow`).
-            config_dir: std::env::temp_dir().join("uwh-refbox-new-for-test-must-not-write"),
             recent_successes: VecDeque::new(),
+            // No write target: these managers exist for indicator and
+            // row-ordering assertions, none of which persists. A test that
+            // needs a save to succeed builds the manager over its own
+            // `TempDir` (see `enqueue_game_end_appends_item_and_turns_yellow`)
+            // — never a path in the shared system temp dir, which is the
+            // healthy path's second-choice queue directory.
+            store: None,
         };
         m.recompute_indicator();
         m
@@ -468,11 +474,27 @@ impl PortalManager {
         self.indicator_state
     }
 
-    /// Return the directory used for the on-disk queue file.
-    /// Used by the portal-tenant-switch restart handler to flush the queue
-    /// (items queued for the old tenant cannot be delivered to the new one).
-    pub fn queue_dir(&self) -> &std::path::Path {
-        &self.config_dir
+    /// Return the directory used for the on-disk queue file, or `None` when
+    /// this session has no write target. Used by the portal-tenant-switch
+    /// restart handler to flush the queue (items queued for the old tenant
+    /// cannot be delivered to the new one).
+    pub fn queue_dir(&self) -> Option<&std::path::Path> {
+        self.store.as_ref().map(|s| s.dir())
+    }
+
+    /// Write the queue back, if this session has anywhere to write it.
+    ///
+    /// NOT a guard: a session without a store holds no directory at all, so
+    /// there is nothing to guard against. This is only the shared funnel for
+    /// the mutating methods — the safety comes from `Option<QueueStore>`,
+    /// because the sole way to obtain a store is a successful read. A future
+    /// mutator cannot bypass this the way it could bypass a boolean check:
+    /// without a store in hand there is no path to a write at all.
+    fn persist(&self) -> std::io::Result<()> {
+        match &self.store {
+            Some(store) => store.save(&self.queue),
+            None => Ok(()),
+        }
     }
 
     /// True while any game result is still waiting to reach the site it was
@@ -532,11 +554,17 @@ impl PortalManager {
         if expired.is_empty() {
             return Ok(());
         }
-        // Archive BEFORE removing so a failed write never loses a score.
-        queue::append_to_archive(&self.config_dir, &expired)?;
+        // Archive BEFORE removing so a failed write never loses a score. With
+        // no write target there is nothing to archive to and nothing on disk to
+        // shrink, so leave the queue alone entirely: dropping items from memory
+        // would lose them with no on-disk copy anywhere.
+        let Some(store) = &self.store else {
+            return Ok(());
+        };
+        store.append_to_archive(&expired)?;
         let n = expired.len();
         self.queue.items = kept;
-        queue::save(&self.config_dir, &self.queue)?;
+        store.save(&self.queue)?;
         self.recompute_indicator();
         self.push_queue_snapshot();
         log::info!(
@@ -611,7 +639,10 @@ impl PortalManager {
         config_dir: &std::path::Path,
         io: impl health::PortalTaskIo + Send + Sync + 'static,
     ) -> std::io::Result<(Self, mpsc::Receiver<PortalEvent>)> {
-        let queue = queue::load_or_empty(config_dir)?;
+        // Reading and gaining the right to write are the same step: a healthy
+        // session owns the directory it just read, and a read failure
+        // propagates so `RefBoxApp::new` can try its second-choice directory.
+        let (store, queue) = queue::QueueStore::open(config_dir)?;
         let handle = health::spawn(io);
         let command_tx = handle.command_tx.clone();
 
@@ -623,8 +654,8 @@ impl PortalManager {
             startup_problem: false,
             indicator_state: PortalIndicatorState::default(),
             command_tx,
-            config_dir: config_dir.to_path_buf(),
             recent_successes: VecDeque::new(),
+            store: Some(store),
         };
         // Clear any items that already exceeded the expiry limit before this
         // launch (e.g. leftovers carried across a portal switch or reboot).
@@ -651,28 +682,12 @@ impl PortalManager {
     /// Results are still queued in this mode — `enqueue_game_end` runs
     /// whenever an event is linked — so they have to land where the next
     /// healthy launch will look for them, or they are silently abandoned.
-    /// Writing them elsewhere is what this constructor used to do, from when
-    /// its only caller was the both-directories-failed case.
+    /// "Cannot send" is not "cannot save": in the no-client route the disk is
+    /// perfectly fine and this session persists exactly as a healthy one does.
     ///
     /// The returned receiver is a dummy that never emits events.
     pub(crate) fn new_degraded(
         config_dir: &std::path::Path,
-    ) -> (Self, mpsc::Receiver<PortalEvent>) {
-        Self::new_degraded_with_fallback(config_dir, &std::env::temp_dir())
-    }
-
-    /// `new_degraded` with the failed-load fallback directory injected.
-    ///
-    /// Production always passes `std::env::temp_dir()` (via `new_degraded`).
-    /// Tests pass a directory of their own: the fallback is the *shared*
-    /// system temp dir, which is also the healthy path's second choice of
-    /// queue directory (see `RefBoxApp::new`), so a test that let an enqueue
-    /// land there would overwrite a real queue file on the machine running it
-    /// — and leave a fabricated result for a real fallback session to adopt
-    /// and try to upload.
-    fn new_degraded_with_fallback(
-        config_dir: &std::path::Path,
-        fallback_dir: &std::path::Path,
     ) -> (Self, mpsc::Receiver<PortalEvent>) {
         // Build (sender, receiver) pairs where the senders go nowhere:
         // the event-channel sender is discarded so the returned receiver
@@ -682,28 +697,27 @@ impl PortalManager {
         let (_, rx) = mpsc::channel(1);
         let (command_tx, _command_rx) = mpsc::channel(1);
 
-        // Adopt whatever is already queued, best-effort. This must never fail
-        // the construction: one trigger for degraded mode IS an unreadable
-        // queue file, and the game has to keep running regardless.
+        // Adopt whatever is already queued, and take a write target only if
+        // that read succeeded. This must never fail the construction: one
+        // trigger for degraded mode IS an unreadable queue file, and the game
+        // has to keep running regardless.
         //
-        // Skipping this load would NOT be the safe option: `queue::save`
-        // rewrites the whole file, so an empty starting queue means the first
-        // enqueue overwrites — and destroys — results already waiting.
-        // Adopt whatever is already queued, and only write where we could
-        // read. If the load fails we must NOT keep `config_dir` as the write
-        // target: `queue::save` renames over the file, and a rename needs
-        // write permission on the *directory*, not on the file — so an
-        // unreadable-but-replaceable queue would be silently destroyed by the
-        // first enqueue. That is the exact failure this fallback exists for,
-        // and the healthy path already handles it by moving to the temp dir.
-        let (queue, queue_dir) = match queue::load_or_empty(config_dir) {
-            Ok(q) => (q, config_dir.to_path_buf()),
+        // A failed read leaves this session with no write target at all.
+        // `save` renames over the file and a rename needs write permission on
+        // the *directory* rather than the file, so an unreadable-but-
+        // replaceable queue would otherwise be destroyed by the first enqueue.
+        // There is deliberately no second-choice directory: the system temp dir
+        // is the healthy path's own fallback, so writing a fabricated queue
+        // there is how a real session ends up adopting one.
+        let (queue, store) = match queue::QueueStore::open(config_dir) {
+            Ok((store, queue)) => (queue, Some(store)),
             Err(e) => {
                 log::warn!(
-                    "could not read the portal queue ({e}); this session will not write to it, \
-                     so the existing file is left intact"
+                    "could not read the portal queue ({e}); this session has no write target, so \
+                     the existing file is left untouched and any result recorded now is held in \
+                     memory only"
                 );
-                (QueueFile::empty(), fallback_dir.to_path_buf())
+                (QueueFile::empty(), None)
             }
         };
 
@@ -718,8 +732,8 @@ impl PortalManager {
             startup_problem: true,
             indicator_state: PortalIndicatorState::default(),
             command_tx,
-            config_dir: queue_dir,
             recent_successes: VecDeque::new(),
+            store,
         };
         m.recompute_indicator();
         (m, rx)
@@ -793,7 +807,7 @@ impl PortalManager {
             score_sent: false,
         };
         self.queue.items.push(item);
-        queue::save(&self.config_dir, &self.queue)?;
+        self.persist()?;
         self.recompute_indicator();
         self.push_queue_snapshot();
         Ok(())
@@ -811,7 +825,7 @@ impl PortalManager {
             item.attempts = 0;
             item.last_attempt_at = None;
             item.queued_at = OffsetDateTime::now_utc();
-            queue::save(&self.config_dir, &self.queue)?;
+            self.persist()?;
         }
         self.recompute_indicator();
         self.push_queue_snapshot();
@@ -866,7 +880,7 @@ impl PortalManager {
             item.last_attempt_at = None;
             item.queued_at = now;
         }
-        queue::save(&self.config_dir, &self.queue)?;
+        self.persist()?;
         self.recompute_indicator();
         self.push_queue_snapshot();
         // Stats-pending games are not on the auto-retry cadence; give
@@ -891,7 +905,7 @@ impl PortalManager {
     pub fn force_immediate_retry(&mut self, id: &ItemId) -> std::io::Result<()> {
         if let Some(item) = self.find_mut(id) {
             item.last_attempt_at = None;
-            queue::save(&self.config_dir, &self.queue)?;
+            self.persist()?;
             self.push_queue_snapshot();
         }
         Ok(())
@@ -902,7 +916,7 @@ impl PortalManager {
     /// portal currently has for that game stands.
     pub fn discard(&mut self, id: &ItemId) -> std::io::Result<()> {
         self.queue.items.retain(|it| it.id != *id);
-        queue::save(&self.config_dir, &self.queue)?;
+        self.persist()?;
         self.recompute_indicator();
         self.push_queue_snapshot();
         Ok(())
@@ -944,7 +958,7 @@ impl PortalManager {
             item.attempts = 0;
             item.last_attempt_at = None;
         }
-        queue::save(&self.config_dir, &self.queue)?;
+        self.persist()?;
         self.recompute_indicator();
         self.push_queue_snapshot();
         Ok(())
@@ -964,7 +978,7 @@ impl PortalManager {
             return; // Already stats-pending; nothing to do.
         }
         item.score_sent = true;
-        if let Err(e) = queue::save(&self.config_dir, &self.queue) {
+        if let Err(e) = self.persist() {
             log::warn!("portal queue save after score-sent/stats-pending failed: {e}");
         }
         self.recompute_indicator();
@@ -1039,7 +1053,7 @@ impl PortalManager {
             self.recent_successes.pop_back();
         }
 
-        if let Err(e) = queue::save(&self.config_dir, &self.queue) {
+        if let Err(e) = self.persist() {
             log::warn!("portal queue save after item resolution failed: {e}");
         }
         self.recompute_indicator();
@@ -1564,7 +1578,7 @@ mod tests {
         // replace one that is already there.
         let empty_dir = tempfile::TempDir::new().unwrap();
         let (manager, _rx) = PortalManager::new_degraded(empty_dir.path());
-        assert_eq!(manager.config_dir.as_path(), empty_dir.path());
+        assert_eq!(manager.queue_dir(), Some(empty_dir.path()));
         assert!(
             !empty_dir.path().join("portal_queue.json").exists(),
             "degraded construction must not create a queue file"
@@ -1691,11 +1705,10 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn degraded_never_overwrites_a_queue_it_could_not_read() {
-        // A queue file we cannot READ can still be REPLACED: `queue::save`
-        // renames over it, and rename needs permission on the directory, not
-        // on the file. So if the load fails, this session must not write here
-        // at all — otherwise the first enqueue destroys real results.
+    async fn a_session_that_could_not_read_its_queue_writes_nothing_anywhere() {
+        // The write target is the directory we read from, or there is none.
+        // This session cannot read, so it must leave the file byte-identical,
+        // create nothing beside it, and touch no other directory either.
         use std::os::unix::fs::PermissionsExt;
 
         let tmp = tempfile::TempDir::new().unwrap();
@@ -1712,40 +1725,73 @@ mod tests {
         let before = std::fs::read(&path).unwrap();
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o000)).unwrap();
 
-        // This test drives the failed-load fallback, whose production write
-        // target is the shared system temp dir — which is also the healthy
-        // path's SECOND choice of queue directory (see `RefBoxApp::new`).
-        // Letting the enqueue below land there would overwrite a real queue
-        // file on the machine running the test suite, and leave a fabricated
-        // result for a real fallback session to adopt and try to upload. So
-        // inject a fallback of our own: the test never touches the shared path.
-        let fallback = tempfile::TempDir::new().unwrap();
+        // The shared temp dir is the healthy path's SECOND-choice queue dir,
+        // so prove we do not fall back to it. Comparing `Option` covers both
+        // "a file was there and is unchanged" and "none was there and none is".
+        let shared = std::env::temp_dir().join("portal_queue.json");
+        let shared_before = std::fs::read(&shared).ok();
 
-        // Degraded session cannot read it, then records a game of its own.
         {
-            let (mut degraded, _rx) =
-                PortalManager::new_degraded_with_fallback(tmp.path(), fallback.path());
-            assert_ne!(
-                degraded.config_dir.as_path(),
-                tmp.path(),
-                "a queue that could not be read must not stay the write target"
+            let (mut degraded, _rx) = PortalManager::new_degraded(tmp.path());
+            assert!(
+                degraded.store.is_none(),
+                "a queue we could not read must leave this session with no write target"
             );
             let _ = degraded.enqueue_game_end("event".into(), "G3".into(), 3, 0, "{}".into());
+            assert_eq!(
+                degraded.queue.items.len(),
+                1,
+                "the result is still held in memory for the operator to read off the screen"
+            );
         }
 
-        // The result went to the fallback, so it is not silently dropped.
-        assert!(
-            fallback.path().join("portal_queue.json").exists(),
-            "the degraded session's own result must land in the fallback dir"
-        );
-
-        // Restore access and prove the original results are untouched.
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
         assert_eq!(
             std::fs::read(&path).unwrap(),
             before,
             "the unreadable queue file must be left byte-identical"
         );
+        assert_eq!(
+            std::fs::read(&shared).ok(),
+            shared_before,
+            "the shared system temp dir must not be used as a fallback"
+        );
+        let mut names: Vec<_> = std::fs::read_dir(tmp.path())
+            .unwrap()
+            .map(|e| e.unwrap().file_name())
+            .collect();
+        names.sort();
+        assert_eq!(
+            names.len(),
+            1,
+            "no new file may appear beside the queue we could not read, got {names:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_session_that_cannot_send_still_saves_when_the_disk_is_fine() {
+        // The no-client route: nothing can be uploaded, but the disk is
+        // perfect, so results MUST still be recorded where a later healthy
+        // start finds them. "Cannot send" is not "cannot save".
+        let tmp = tempfile::TempDir::new().unwrap();
+        {
+            let (mut degraded, _rx) = PortalManager::new_degraded(tmp.path());
+            assert!(
+                degraded.store.is_some(),
+                "a readable queue must still give this session a write target"
+            );
+            degraded
+                .enqueue_game_end("event".into(), "G7".into(), 5, 4, "{}".into())
+                .unwrap();
+        }
+
+        let (later, _rx) = PortalManager::new(tmp.path(), NullIo).unwrap();
+        assert_eq!(
+            later.queue.items.len(),
+            1,
+            "a later healthy start must find it"
+        );
+        assert_eq!(later.queue.items[0].id.game_number, "G7");
     }
 
     #[tokio::test]

--- a/refbox/src/portal_manager/mod.rs
+++ b/refbox/src/portal_manager/mod.rs
@@ -474,12 +474,21 @@ impl PortalManager {
         self.indicator_state
     }
 
-    /// Return the directory used for the on-disk queue file, or `None` when
-    /// this session has no write target. Used by the portal-tenant-switch
-    /// restart handler to flush the queue (items queued for the old tenant
-    /// cannot be delivered to the new one).
-    pub fn queue_dir(&self) -> Option<&std::path::Path> {
-        self.store.as_ref().map(|s| s.dir())
+    /// Clear the retry queue for a portal-tenant switch: results queued under
+    /// the old tenant cannot be delivered to the new one, so the restarted app
+    /// must not carry them over. Only ever called for the built-in portal — a
+    /// custom site is one address the operator typed, and results queued for it
+    /// stay deliverable to exactly that site after a restart.
+    ///
+    /// A session with no write target does nothing on disk: it never owned a
+    /// queue file, so it has nothing of its own to clear, and clearing someone
+    /// else's would destroy real results. The caller used to reach for the
+    /// directory and write it directly, which bypassed the manager entirely.
+    pub fn flush_queue_for_tenant_switch(&mut self) -> std::io::Result<()> {
+        self.queue.items.clear();
+        self.persist()?;
+        self.recompute_indicator();
+        Ok(())
     }
 
     /// Write the queue back, if this session has anywhere to write it.
@@ -1578,7 +1587,10 @@ mod tests {
         // replace one that is already there.
         let empty_dir = tempfile::TempDir::new().unwrap();
         let (manager, _rx) = PortalManager::new_degraded(empty_dir.path());
-        assert_eq!(manager.queue_dir(), Some(empty_dir.path()));
+        assert!(
+            manager.store.is_some(),
+            "a readable (here: absent) queue means this session owns the directory it read"
+        );
         assert!(
             !empty_dir.path().join("portal_queue.json").exists(),
             "degraded construction must not create a queue file"
@@ -1792,6 +1804,63 @@ mod tests {
             "a later healthy start must find it"
         );
         assert_eq!(later.queue.items[0].id.game_number, "G7");
+    }
+
+    #[tokio::test]
+    async fn tenant_switch_flush_clears_a_queue_this_session_owns() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (mut m, _rx) = PortalManager::new(tmp.path(), NullIo).unwrap();
+        m.enqueue_game_end("old-tenant".into(), "G1".into(), 1, 0, "{}".into())
+            .unwrap();
+
+        m.flush_queue_for_tenant_switch().unwrap();
+
+        assert!(m.queue.items.is_empty(), "in memory too, not just on disk");
+        let (_store, on_disk) = queue::QueueStore::open(tmp.path()).unwrap();
+        assert!(
+            on_disk.items.is_empty(),
+            "the on-disk queue must be cleared"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn tenant_switch_flush_writes_nothing_without_a_write_target() {
+        // The old code flushed through `queue_dir()`, bypassing the manager
+        // entirely — in the fallback state that wrote to the shared temp dir,
+        // clearing a queue belonging to a different session and a different
+        // tenant.
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        {
+            let (mut healthy, _rx) = PortalManager::new(tmp.path(), NullIo).unwrap();
+            healthy
+                .enqueue_game_end("event".into(), "G1".into(), 1, 0, "{}".into())
+                .unwrap();
+        }
+        let path = tmp.path().join("portal_queue.json");
+        let before = std::fs::read(&path).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o000)).unwrap();
+        let shared = std::env::temp_dir().join("portal_queue.json");
+        let shared_before = std::fs::read(&shared).ok();
+
+        {
+            let (mut degraded, _rx) = PortalManager::new_degraded(tmp.path());
+            degraded.flush_queue_for_tenant_switch().unwrap();
+        }
+
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        assert_eq!(
+            std::fs::read(&path).unwrap(),
+            before,
+            "a session with no write target must not clear a queue it never owned"
+        );
+        assert_eq!(
+            std::fs::read(&shared).ok(),
+            shared_before,
+            "and must not clear one in the shared temp dir either"
+        );
     }
 
     #[tokio::test]

--- a/refbox/src/portal_manager/mod.rs
+++ b/refbox/src/portal_manager/mod.rs
@@ -488,6 +488,14 @@ impl PortalManager {
         self.queue.items.clear();
         self.persist()?;
         self.recompute_indicator();
+        // Tell the background task too. It works from its own clone of the
+        // queue (see `health::spawn`), so without this it would keep the old
+        // tenant's items and could still post them — while `has_queued_items()`
+        // reports an empty queue, which is what unblocks the source and
+        // site-address controls. Both current callers restart the process
+        // immediately afterwards, so the window is short today, but this method
+        // is public and its name carries no restart precondition.
+        self.push_queue_snapshot();
         Ok(())
     }
 
@@ -502,7 +510,19 @@ impl PortalManager {
     fn persist(&self) -> std::io::Result<()> {
         match &self.store {
             Some(store) => store.save(&self.queue),
-            None => Ok(()),
+            None => {
+                // Logged, not silent. `Ok` is honest about this call — nothing
+                // failed — but the caller cannot tell a completed write from a
+                // skipped one, and callers only report `Err`. Without this line
+                // a result recorded in a session with no write target leaves no
+                // trace at all, which is the false-success class #2349 fixed for
+                // RETRY ALL.
+                log::warn!(
+                    "portal queue not persisted: this session has no write target (its queue \
+                     file could not be read), so results are held in memory only"
+                );
+                Ok(())
+            }
         }
     }
 
@@ -688,11 +708,16 @@ impl PortalManager {
     /// succeed and clear the red state, hiding the problem.
     ///
     /// `config_dir` must be the real config directory, not a scratch path.
-    /// Results are still queued in this mode — `enqueue_game_end` runs
-    /// whenever an event is linked — so they have to land where the next
-    /// healthy launch will look for them, or they are silently abandoned.
-    /// "Cannot send" is not "cannot save": in the no-client route the disk is
-    /// perfectly fine and this session persists exactly as a healthy one does.
+    /// Results are still queued in this mode — `enqueue_game_end` runs whenever
+    /// an event is linked — so where they land matters.
+    ///
+    /// "Cannot send" is not "cannot save". If the queue reads cleanly (the
+    /// no-client route, where the disk is perfectly fine) this session persists
+    /// exactly as a healthy one does, and the next healthy launch finds the
+    /// results. If the read FAILED there is no write target and no second
+    /// choice, so results recorded this session are held in memory only and are
+    /// lost when the process exits — the deliberate trade for never overwriting
+    /// a queue we could not read. See the 2026-08-13 spec.
     ///
     /// The returned receiver is a dummy that never emits events.
     pub(crate) fn new_degraded(
@@ -787,12 +812,17 @@ impl PortalManager {
     }
 
     /// Enqueue a game-end submission and trigger an immediate attempt.
-    /// Persistence is best-effort: the in-memory queue is updated
-    /// before disk write, so an I/O failure leaves the score queued in
-    /// memory for the rest of the session but not on disk. The corrupt-
-    /// or-missing-file rotation in `queue::load` is the recovery path
-    /// across restarts; subsequent successful mutations will re-persist
-    /// the queue including this item.
+    ///
+    /// Persistence is best-effort: the in-memory queue is updated before the
+    /// disk write, so an I/O failure leaves the score queued in memory for the
+    /// rest of the session but not on disk, and a later successful mutation
+    /// re-persists it including this item. The corrupt-or-unknown-version
+    /// rotation in `queue::load_or_empty` is the recovery path across restarts.
+    ///
+    /// A session with **no write target** is different: no mutation can ever
+    /// persist, so results recorded here live only as long as the process. They
+    /// still appear on the portal detail page, which is all the operator has to
+    /// go on. `persist` logs each skipped write.
     pub fn enqueue_game_end(
         &mut self,
         event_id: String,
@@ -1454,7 +1484,7 @@ mod tests {
         // Pre-populate a queue file with an item older than 120h.
         let mut old = mk_young_item();
         old.queued_at = OffsetDateTime::now_utc() - TimeDuration::hours(200);
-        crate::portal_manager::queue::save(
+        crate::portal_manager::queue::seed_for_test(
             tmp.path(),
             &QueueFile {
                 version: 1,
@@ -1597,7 +1627,7 @@ mod tests {
         );
 
         let seeded_dir = tempfile::TempDir::new().unwrap();
-        queue::save(
+        queue::seed_for_test(
             seeded_dir.path(),
             &QueueFile {
                 version: 1,
@@ -1634,7 +1664,7 @@ mod tests {
         // the "(attempt N)" counter the next healthy session shows.
         item.attempts = 4;
         item.last_attempt_at = Some(OffsetDateTime::now_utc() - TimeDuration::hours(1));
-        queue::save(
+        queue::seed_for_test(
             tmp.path(),
             &QueueFile {
                 version: 1,
@@ -1687,7 +1717,7 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         let mut expired = mk_stuck_item();
         expired.queued_at = OffsetDateTime::now_utc() - TimeDuration::hours(200);
-        queue::save(
+        queue::seed_for_test(
             tmp.path(),
             &QueueFile {
                 version: 1,
@@ -1737,11 +1767,13 @@ mod tests {
         let before = std::fs::read(&path).unwrap();
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o000)).unwrap();
 
-        // The shared temp dir is the healthy path's SECOND-choice queue dir,
-        // so prove we do not fall back to it. Comparing `Option` covers both
-        // "a file was there and is unchanged" and "none was there and none is".
+        // The shared temp dir is the healthy path's SECOND-choice queue dir, so
+        // prove we do not fall back to it. Assert on OUR OWN game number rather
+        // than comparing the whole file before and after: a real refbox on this
+        // machine may legitimately be using that dir as its second choice while
+        // the suite runs, and a byte comparison would fail on its writes, which
+        // have nothing to do with this test.
         let shared = std::env::temp_dir().join("portal_queue.json");
-        let shared_before = std::fs::read(&shared).ok();
 
         {
             let (mut degraded, _rx) = PortalManager::new_degraded(tmp.path());
@@ -1763,10 +1795,11 @@ mod tests {
             before,
             "the unreadable queue file must be left byte-identical"
         );
-        assert_eq!(
-            std::fs::read(&shared).ok(),
-            shared_before,
-            "the shared system temp dir must not be used as a fallback"
+        let shared_text = std::fs::read_to_string(&shared).unwrap_or_default();
+        assert!(
+            !shared_text.contains("G3"),
+            "the shared system temp dir must not be used as a fallback, but it now holds \
+             this test's game: {shared_text}"
         );
         let mut names: Vec<_> = std::fs::read_dir(tmp.path())
             .unwrap()
@@ -1842,24 +1875,28 @@ mod tests {
         let path = tmp.path().join("portal_queue.json");
         let before = std::fs::read(&path).unwrap();
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o000)).unwrap();
-        let shared = std::env::temp_dir().join("portal_queue.json");
-        let shared_before = std::fs::read(&shared).ok();
 
+        let degraded_had_no_store;
         {
             let (mut degraded, _rx) = PortalManager::new_degraded(tmp.path());
+            degraded_had_no_store = degraded.store.is_none();
             degraded.flush_queue_for_tenant_switch().unwrap();
         }
 
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        assert!(
+            degraded_had_no_store,
+            "precondition: this session must have no write target"
+        );
+        // A flush writes an EMPTY queue, so there is no content marker that
+        // could identify it in the shared temp dir the way the fallback test
+        // does. Asserting the shared file is unchanged would be flaky — a real
+        // refbox may be using that dir as its legitimate second choice while the
+        // suite runs — so rely on the structural check above plus this one.
         assert_eq!(
             std::fs::read(&path).unwrap(),
             before,
             "a session with no write target must not clear a queue it never owned"
-        );
-        assert_eq!(
-            std::fs::read(&shared).ok(),
-            shared_before,
-            "and must not clear one in the shared temp dir either"
         );
     }
 

--- a/refbox/src/portal_manager/mod.rs
+++ b/refbox/src/portal_manager/mod.rs
@@ -815,7 +815,24 @@ impl PortalManager {
             force: false,
             score_sent: false,
         };
-        self.queue.items.push(item);
+        // A game can legitimately be re-ended: a corrected score, or an
+        // operator re-running the same game number. Replace the existing entry
+        // rather than stacking a second one. Two reasons this matters: a
+        // session that cannot send never drains its queue, so duplicates
+        // accumulate unbounded; and `discard`/`on_item_resolved` remove by id
+        // with `retain`, which drops every match at once — so resolving one
+        // copy silently discarded the other, unsent. The later result wins,
+        // which is correct for a game re-ended with a corrected score.
+        //
+        // Replacing resets the whole entry, including `attempts`, `force` and
+        // `score_sent` — right for a genuinely new result: it has not been
+        // attempted, and an operator who had armed FORCE for the superseded
+        // score should decide again for the new one.
+        if let Some(existing) = self.queue.items.iter_mut().find(|it| it.id == item.id) {
+            *existing = item;
+        } else {
+            self.queue.items.push(item);
+        }
         self.persist()?;
         self.recompute_indicator();
         self.push_queue_snapshot();
@@ -1804,6 +1821,44 @@ mod tests {
             "a later healthy start must find it"
         );
         assert_eq!(later.queue.items[0].id.game_number, "G7");
+    }
+
+    #[tokio::test]
+    async fn re_ending_a_game_replaces_its_queued_result() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (mut m, _rx) = PortalManager::new(tmp.path(), NullIo).unwrap();
+        m.enqueue_game_end("event".into(), "G1".into(), 1, 0, "{}".into())
+            .unwrap();
+        m.enqueue_game_end("event".into(), "G1".into(), 2, 1, "{}".into())
+            .unwrap();
+
+        assert_eq!(
+            m.queue.items.len(),
+            1,
+            "a re-ended game must replace its entry, not stack a second one"
+        );
+        assert_eq!(
+            (m.queue.items[0].black_score, m.queue.items[0].white_score),
+            (2, 1),
+            "the later result wins — it is the corrected score"
+        );
+
+        // On disk too: a duplicate pair here is what made removal lossy.
+        // `discard`/`on_item_resolved` remove by id with `retain`, which drops
+        // EVERY match, so resolving one copy silently discarded the other,
+        // unsent — and a session that cannot send never drains the queue, so
+        // the copies accumulated unbounded.
+        let (_store, on_disk) = queue::QueueStore::open(tmp.path()).unwrap();
+        assert_eq!(
+            on_disk.items.len(),
+            1,
+            "the persisted queue must hold one entry for the game, not two"
+        );
+        assert_eq!(
+            (on_disk.items[0].black_score, on_disk.items[0].white_score),
+            (2, 1),
+            "and it must be the corrected score that survives a restart"
+        );
     }
 
     #[tokio::test]

--- a/refbox/src/portal_manager/mod.rs
+++ b/refbox/src/portal_manager/mod.rs
@@ -815,24 +815,7 @@ impl PortalManager {
             force: false,
             score_sent: false,
         };
-        // A game can legitimately be re-ended: a corrected score, or an
-        // operator re-running the same game number. Replace the existing entry
-        // rather than stacking a second one. Two reasons this matters: a
-        // session that cannot send never drains its queue, so duplicates
-        // accumulate unbounded; and `discard`/`on_item_resolved` remove by id
-        // with `retain`, which drops every match at once — so resolving one
-        // copy silently discarded the other, unsent. The later result wins,
-        // which is correct for a game re-ended with a corrected score.
-        //
-        // Replacing resets the whole entry, including `attempts`, `force` and
-        // `score_sent` — right for a genuinely new result: it has not been
-        // attempted, and an operator who had armed FORCE for the superseded
-        // score should decide again for the new one.
-        if let Some(existing) = self.queue.items.iter_mut().find(|it| it.id == item.id) {
-            *existing = item;
-        } else {
-            self.queue.items.push(item);
-        }
+        self.queue.items.push(item);
         self.persist()?;
         self.recompute_indicator();
         self.push_queue_snapshot();
@@ -1821,44 +1804,6 @@ mod tests {
             "a later healthy start must find it"
         );
         assert_eq!(later.queue.items[0].id.game_number, "G7");
-    }
-
-    #[tokio::test]
-    async fn re_ending_a_game_replaces_its_queued_result() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        let (mut m, _rx) = PortalManager::new(tmp.path(), NullIo).unwrap();
-        m.enqueue_game_end("event".into(), "G1".into(), 1, 0, "{}".into())
-            .unwrap();
-        m.enqueue_game_end("event".into(), "G1".into(), 2, 1, "{}".into())
-            .unwrap();
-
-        assert_eq!(
-            m.queue.items.len(),
-            1,
-            "a re-ended game must replace its entry, not stack a second one"
-        );
-        assert_eq!(
-            (m.queue.items[0].black_score, m.queue.items[0].white_score),
-            (2, 1),
-            "the later result wins — it is the corrected score"
-        );
-
-        // On disk too: a duplicate pair here is what made removal lossy.
-        // `discard`/`on_item_resolved` remove by id with `retain`, which drops
-        // EVERY match, so resolving one copy silently discarded the other,
-        // unsent — and a session that cannot send never drains the queue, so
-        // the copies accumulated unbounded.
-        let (_store, on_disk) = queue::QueueStore::open(tmp.path()).unwrap();
-        assert_eq!(
-            on_disk.items.len(),
-            1,
-            "the persisted queue must hold one entry for the game, not two"
-        );
-        assert_eq!(
-            (on_disk.items[0].black_score, on_disk.items[0].white_score),
-            (2, 1),
-            "and it must be the corrected score that survives a restart"
-        );
     }
 
     #[tokio::test]

--- a/refbox/src/portal_manager/mod.rs
+++ b/refbox/src/portal_manager/mod.rs
@@ -6,7 +6,7 @@
 
 pub mod health;
 pub mod link_session;
-pub mod queue;
+mod queue;
 
 use serde::{Deserialize, Serialize};
 use std::collections::VecDeque;

--- a/refbox/src/portal_manager/queue.rs
+++ b/refbox/src/portal_manager/queue.rs
@@ -132,8 +132,25 @@ fn write_atomic(target: &Path, tmp: &Path, q: &QueueFile) -> std::io::Result<()>
 }
 
 /// Atomically write the queue file to `dir/portal_queue.json`.
-pub(super) fn save(dir: &Path, q: &QueueFile) -> std::io::Result<()> {
+///
+/// Private to this file on purpose: `QueueStore` is the only way to reach it,
+/// and a store can only be obtained by reading the directory first. Reads stay
+/// visible to the rest of `portal_manager` — a read cannot destroy anything —
+/// but every write must come through a store. All four previous regressions in
+/// this area were introduced in `mod.rs`, so `pub(super)` here would leave the
+/// door open in exactly the place it has always been walked through.
+fn save(dir: &Path, q: &QueueFile) -> std::io::Result<()> {
     write_atomic(&queue_path(dir), &tmp_path(dir), q)
+}
+
+/// Seed a queue file directly, for tests that need to arrange on-disk state.
+///
+/// The one deliberate bypass of the rule above, and it is `#[cfg(test)]` so it
+/// cannot exist in a shipped binary. Production code has no route to a write
+/// except `QueueStore`.
+#[cfg(test)]
+pub(super) fn seed_for_test(dir: &Path, q: &QueueFile) -> std::io::Result<()> {
+    save(dir, q)
 }
 
 // --- Expired-item archive (Bug 2: portal_queue.expired.json) ---
@@ -173,7 +190,7 @@ pub(super) fn load_archive_or_empty(dir: &Path) -> std::io::Result<QueueFile> {
 
 /// Append expired items to the archive, atomically. No-op on empty input.
 /// Additive: items archived by earlier sweeps are preserved.
-pub(super) fn append_to_archive(dir: &Path, items: &[QueuedItem]) -> std::io::Result<()> {
+fn append_to_archive(dir: &Path, items: &[QueuedItem]) -> std::io::Result<()> {
     if items.is_empty() {
         return Ok(());
     }
@@ -192,6 +209,13 @@ pub(super) fn append_to_archive(dir: &Path, items: &[QueuedItem]) -> std::io::Re
 /// cannot destroy a file it never saw. `save` renames over the target, and a
 /// rename needs write permission on the *directory* rather than the file, so
 /// an unreadable-but-replaceable queue is exactly the case this prevents.
+///
+/// What holding a store does NOT prove is that writing will succeed. When the
+/// queue file is absent, `load_or_empty` returns success without touching the
+/// disk, so an unwritable directory still yields a store and its first write
+/// fails at `write_atomic`. That hole predates this type — see
+/// `docs/backlog/unwritable-config-dir-looks-healthy/NOTE.md`. The guarantee
+/// here is narrow and exact: we never write where a read *failed*.
 ///
 /// See `docs/superpowers/specs/2026-08-13-degraded-no-write-target-design.md`.
 #[derive(Debug)]

--- a/refbox/src/portal_manager/queue.rs
+++ b/refbox/src/portal_manager/queue.rs
@@ -215,10 +215,6 @@ impl QueueStore {
         ))
     }
 
-    pub(super) fn dir(&self) -> &Path {
-        &self.dir
-    }
-
     pub(super) fn save(&self, q: &QueueFile) -> std::io::Result<()> {
         save(&self.dir, q)
     }

--- a/refbox/src/portal_manager/queue.rs
+++ b/refbox/src/portal_manager/queue.rs
@@ -182,6 +182,52 @@ pub fn append_to_archive(dir: &Path, items: &[QueuedItem]) -> std::io::Result<()
     write_atomic(&archive_path(dir), &archive_tmp_path(dir), &archive)
 }
 
+/// A directory this session successfully read the portal queue from, and is
+/// therefore allowed to write back to.
+///
+/// `open` is the only constructor, and it returns the loaded queue along with
+/// the store — so a `QueueStore` cannot exist for a directory we could not
+/// read. That is the entire safety property: a session with no readable queue
+/// holds no store, and a store is the only route to a queue write, so it
+/// cannot destroy a file it never saw. `save` renames over the target, and a
+/// rename needs write permission on the *directory* rather than the file, so
+/// an unreadable-but-replaceable queue is exactly the case this prevents.
+///
+/// See `docs/superpowers/specs/2026-08-13-degraded-no-write-target-design.md`.
+#[derive(Debug)]
+pub(super) struct QueueStore {
+    dir: PathBuf,
+}
+
+impl QueueStore {
+    /// Read `dir`'s queue and, on success, return the write target for it.
+    /// A missing file is a successful read of an empty queue (a first run),
+    /// and a corrupt one is rotated aside by `load_or_empty` and also
+    /// succeeds. Only an I/O or permission failure yields `Err` — and
+    /// therefore no write target at all.
+    pub(super) fn open(dir: &Path) -> std::io::Result<(Self, QueueFile)> {
+        let queue = load_or_empty(dir)?;
+        Ok((
+            Self {
+                dir: dir.to_path_buf(),
+            },
+            queue,
+        ))
+    }
+
+    pub(super) fn dir(&self) -> &Path {
+        &self.dir
+    }
+
+    pub(super) fn save(&self, q: &QueueFile) -> std::io::Result<()> {
+        save(&self.dir, q)
+    }
+
+    pub(super) fn append_to_archive(&self, items: &[QueuedItem]) -> std::io::Result<()> {
+        append_to_archive(&self.dir, items)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -225,6 +271,82 @@ mod tests {
     mod load_save_tests {
         use super::*;
         use tempfile::TempDir;
+
+        fn one_item_queue(game: &str, black: u8, white: u8) -> QueueFile {
+            QueueFile {
+                version: 1,
+                items: vec![QueuedItem {
+                    id: ItemId {
+                        event_id: "event".into(),
+                        game_number: game.into(),
+                    },
+                    black_score: black,
+                    white_score: white,
+                    stats: "{}".into(),
+                    queued_at: datetime!(2026-08-13 10:00 UTC),
+                    attempts: 0,
+                    last_attempt_at: None,
+                    force: false,
+                    score_sent: false,
+                }],
+            }
+        }
+
+        #[test]
+        fn store_open_hands_back_the_queue_it_loaded() {
+            let tmp = TempDir::new().unwrap();
+            let q = one_item_queue("G1", 3, 2);
+            save(tmp.path(), &q).unwrap();
+
+            let (_store, loaded) = QueueStore::open(tmp.path()).unwrap();
+            assert_eq!(
+                loaded, q,
+                "open must return the queue it read, not an empty one"
+            );
+        }
+
+        #[test]
+        fn store_open_on_a_missing_file_is_an_empty_queue() {
+            let tmp = TempDir::new().unwrap();
+            let (_store, loaded) = QueueStore::open(tmp.path()).unwrap();
+            assert!(loaded.items.is_empty());
+        }
+
+        #[test]
+        fn store_writes_where_it_read() {
+            let tmp = TempDir::new().unwrap();
+            let (store, _) = QueueStore::open(tmp.path()).unwrap();
+            let q = one_item_queue("G2", 1, 0);
+
+            store.save(&q).unwrap();
+            assert_eq!(
+                load_or_empty(tmp.path()).unwrap(),
+                q,
+                "a store must write back to the directory it was opened on"
+            );
+        }
+
+        #[cfg(unix)]
+        #[test]
+        fn no_store_exists_for_a_queue_that_cannot_be_read() {
+            // THE safety property: a directory whose queue file we cannot read
+            // yields no write target at all, so nothing can overwrite it.
+            use std::os::unix::fs::PermissionsExt;
+            let tmp = TempDir::new().unwrap();
+            save(tmp.path(), &QueueFile::empty()).unwrap();
+            let path = queue_path(tmp.path());
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+            let result = QueueStore::open(tmp.path());
+
+            // Restore before asserting so a failure cannot leave an unreadable
+            // file behind for the rest of the suite.
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+            assert!(
+                result.is_err(),
+                "an unreadable queue file must not produce a write target"
+            );
+        }
 
         #[test]
         fn loads_empty_when_file_missing() {

--- a/refbox/src/portal_manager/queue.rs
+++ b/refbox/src/portal_manager/queue.rs
@@ -83,7 +83,7 @@ fn tmp_path(dir: &Path) -> PathBuf {
 /// Load the queue file from `dir`. If missing, return an empty queue. If
 /// present but unparseable, rename to `portal_queue.corrupt.<ts>.json`,
 /// log an error, and return an empty queue.
-pub fn load_or_empty(dir: &Path) -> std::io::Result<QueueFile> {
+pub(super) fn load_or_empty(dir: &Path) -> std::io::Result<QueueFile> {
     let path = queue_path(dir);
     if !path.exists() {
         return Ok(QueueFile::empty());
@@ -132,7 +132,7 @@ fn write_atomic(target: &Path, tmp: &Path, q: &QueueFile) -> std::io::Result<()>
 }
 
 /// Atomically write the queue file to `dir/portal_queue.json`.
-pub fn save(dir: &Path, q: &QueueFile) -> std::io::Result<()> {
+pub(super) fn save(dir: &Path, q: &QueueFile) -> std::io::Result<()> {
     write_atomic(&queue_path(dir), &tmp_path(dir), q)
 }
 
@@ -156,7 +156,7 @@ fn archive_tmp_path(dir: &Path) -> PathBuf {
 /// Load the archive of expired queue items. Missing → empty. Unparseable or
 /// unknown-version → logged and treated as empty (the archive is a
 /// best-effort safety net, so a corrupt archive must never block a sweep).
-pub fn load_archive_or_empty(dir: &Path) -> std::io::Result<QueueFile> {
+pub(super) fn load_archive_or_empty(dir: &Path) -> std::io::Result<QueueFile> {
     let path = archive_path(dir);
     if !path.exists() {
         return Ok(QueueFile::empty());
@@ -173,7 +173,7 @@ pub fn load_archive_or_empty(dir: &Path) -> std::io::Result<QueueFile> {
 
 /// Append expired items to the archive, atomically. No-op on empty input.
 /// Additive: items archived by earlier sweeps are preserved.
-pub fn append_to_archive(dir: &Path, items: &[QueuedItem]) -> std::io::Result<()> {
+pub(super) fn append_to_archive(dir: &Path, items: &[QueuedItem]) -> std::io::Result<()> {
     if items.is_empty() {
         return Ok(());
     }


### PR DESCRIPTION
> Reviewed before going ready. That pass found 14 issues; the significant ones are addressed below and two became backlog notes. This is the fifth round of work in this area, and each previous round found a defect of the same class inside the previous round's own fix.

## What changed

The refbox can no longer write a queue file into a folder it did not successfully read.

That used to be a rule the code had to remember, enforced by a check inside each method that writes. Four review rounds each found another method that had forgotten it — most recently one inside the previous round's own fix. This replaces the rule with a structure: the only way to obtain permission to write is to read the folder, and both happen in the same step. A session that could not read holds no permission, so there is nothing for it to write with.

Everything that made this recur goes with it:

- **The system-temp-folder fallback is deleted.** That folder is the healthy path's own *second choice* of queue folder, so a fabricated queue left there could be adopted and uploaded by a real session.
- **The tournament-site switch no longer borrows a folder path** and writes behind the manager's back. In the old fallback state it could clear a queue belonging to a different session and a different site.
- **The write functions are sealed** inside the file that owns the on-disk format, so obtaining a write target is the *only* route to a write — from anywhere, including the portal manager itself, which is where all four previous regressions were introduced. Reads stay open, since a read cannot destroy anything. This is what stops the class returning rather than merely fixing today's instance.

## Why

Two different failures were being treated as one. "Cannot send" and "cannot save" are not the same thing, and conflating them is the root of the bug class:

| Route | What actually broke | Disk usable? |
|---|---|---|
| No portal client | The network client would not construct | **Yes, fully** |
| Both folders failed | Disk I/O is broken | No |
| Queue file unreadable | We could not read the file we would be replacing | Not safely |

The first row must keep saving results exactly as a healthy session does — its disk is perfect and only the uploading is missing. Only the third row must write nothing. The old single "degraded" flag could not express that difference, so guards accumulated instead.

## Scope

`refbox` only, three source files: `portal_manager/queue.rs`, `portal_manager/mod.rs`, and three call sites in `app/mod.rs`. No screen, no translation file, no shared crate, no new dependency, no new on-disk format.

One commit on this branch is a revert of its own Task 4 (the re-ended-game dedupe) — see "What was tried and pulled back out" below.

The design and plan are committed alongside: `docs/superpowers/specs/2026-08-13-degraded-no-write-target-design.md` and `docs/superpowers/plans/2026-08-13-degraded-no-write-target.md`, the latter carrying a Deviations section for the three places execution diverged.

## How to verify

`just check` exit 0, 563 tests (up from 556).

The central claim is mutation-proven two ways. Reintroducing the temp-folder fallback fails `a_session_that_could_not_read_its_queue_writes_nothing_anywhere` on the structural assertion; with that assertion temporarily removed it fails again on the observed effect — a file appearing in the shared temp folder. So the test catches this regression both by construction and by consequence.

The shared temp folder stays clean in both directions:

```
printf '{"sentinel":1}' > /tmp/portal_queue.json
cargo test -p refbox --bins      # comes back byte-identical
rm /tmp/portal_queue.json
cargo test -p refbox --bins      # nothing is created
```

Three guards are deliberately **kept**, all for the same single reason — nothing can be sent:

- `retry_all` still refuses (removing it reintroduces the false success fixed in #2349)
- the expiry sweep still skips, so results nobody could send are not archived out of sight
- row taps still do nothing, since Retry cannot run and Discard would delete permanently

They matter most in the no-client route, where the store exists and writes succeed.

## One accepted behaviour reduction

A session that cannot read its queue no longer writes results to the system temp folder, so the theoretical recovery through that folder is gone. Results are held in memory and shown on the existing portal page for the operator to read off the screen.

Accepted deliberately: #2349 established that the same write can destroy a *different* session's real queue, and adopting a stranger's temp-folder queue is itself a hazard. A theoretical recovery is traded for a real destruction risk.

Stated plainly, because the review pushed back on how this was first written: **nothing on screen marks those rows as unsaved.** They render as ordinary pending/stuck rows, identical to results safely on disk, under the existing "portal failed to start" banner. Marking them would be new UI, which is explicitly out of scope for this branch. Every skipped write is logged, so the log does show it.

## What was tried and pulled back out

The spec also called for fixing a second defect: ending the same game twice queues two entries for it, and removing the game then deletes every copy at once. I implemented the obvious fix — replace the entry instead of appending — and reverted it on review. It introduces three failure modes in the **healthy** path that every tournament uses, while the defect it fixes only bites the degraded path that has never been observed:

- The uploader works from its own copy of the queue. If it is mid-upload with the old score when the operator re-ends the game, the success arrives afterwards and removes the entry by game number, deleting the corrected score and showing a green "sent" row. So replacement does not fix the loss it claims to — it only changes which copy is lost.
- Replacing resets the flag recording that the portal already accepted the score, so a re-ended stats-pending game re-posts a score the portal holds. That is a conflict, indistinguishable from any other failure here, so the row stays red until someone Forces it — and the outstanding stats upload stops being tracked.
- An existing guard ignores a success for a game already in the recent-successes list, so a re-ended game that already succeeded can never leave the queue: it is re-posted every retry interval and goes red at thirty minutes.

All three, with the design constraints a real fix has to satisfy, are written up in `docs/backlog/re-ended-game-queue-entry/NOTE.md`. It needs its own spec.

## Reachability, so this is not over-read

Degraded mode has never been observed in the field. Corruption — the plausible cause — is already handled elsewhere: a corrupt queue file is renamed aside and treated as empty, successfully. The unreadable path therefore needs a permission or hardware fault coinciding with a second, separate fault. This is insurance against silently losing tournament results, not a response to an incident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
