### PR TITLE
fix(refbox): log it when the portal cannot be reached

### DIFF
--- a/refbox/src/portal_manager/health.rs
+++ b/refbox/src/portal_manager/health.rs
@@ -192,12 +192,20 @@ async fn run_task(
                             current_health = HealthState::Green;
                             let _ = event_tx.send(PortalEvent::TokenStatus(true)).await;
                         }
-                        Err(PortalCallError::Unreachable(_)) => {
+                        Err(PortalCallError::Unreachable(e)) => {
                             // Couldn't reach the portal (wifi blip / outage).
                             // Degrade the indicator, but do NOT report a token
                             // problem: the login may be fine, so the UI must
                             // not push the operator to re-login or grey out the
                             // schedule REFRESH button.
+                            //
+                            // Log it: the indicator turning red is the only
+                            // other signal, and it cannot say WHY or when it
+                            // started. Every failed check is logged rather than
+                            // just the first, so the log shows how long the
+                            // outage ran — at the 15s degraded cadence that is
+                            // roughly 30KB an hour against a rolling log.
+                            log::warn!("portal health check could not reach the portal: {e}");
                             current_health = HealthState::Red;
                             let _ = event_tx.send(PortalEvent::TokenUnreachable).await;
                         }


### PR DESCRIPTION
## What changed

When the refbox cannot reach the portal — a Wi-Fi blip, a portal outage, a bad network at the pool
— it now writes a line to the log saying so, including the underlying reason:

```
WARN portal health check could not reach the portal: <reason>
```

Nothing the operator sees on screen changes. The portal indicator still turns red, and the refbox
still deliberately does **not** report a token problem, because the login may be perfectly fine and
pushing the operator to re-login would be wrong.

Every failed check is logged, not just the first one, so the log shows how long an outage ran
rather than only when it started.

## Why

Today the red indicator is the only signal that the portal is unreachable, and it cannot say *why*
it went red or *when* it started. That makes an outage at a tournament very hard to reconstruct
afterwards — the person debugging it has a red light and nothing else. This is finding 6 from the
code-quality inventory.

The cost was weighed: at the 15-second degraded checking cadence, continuous logging is roughly
30KB an hour against a rolling log, which is acceptable for the diagnostic value.

## Scope

Changes are limited to `refbox/src/portal_manager/health.rs` — nine added lines, of which one is
the log statement and the rest are the comment explaining the reasoning.

No change to `uwh-common`, no change to what the operator sees, no new dependencies.

## How to verify

Start the refbox with the portal enabled and then break its network access — disconnect Wi-Fi, or
point it at an address that does not answer. Within about 15 seconds:

- The portal indicator turns red, exactly as it does today.
- The log now also carries `portal health check could not reach the portal: ...` with the reason.
- The refbox does **not** ask you to log in again, and the schedule REFRESH button is not greyed
  out — confirming the unchanged behaviour is genuinely unchanged.

Leave it disconnected for a minute and confirm the message repeats, so the log shows the duration
of the outage.

`just check` passes with zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
