### PR TITLE
docs(uwh-common): say why the last-2-min setting is discarded

### DIFF
--- a/uwh-common/src/uwhportal/schedule.rs
+++ b/uwh-common/src/uwhportal/schedule.rs
@@ -284,6 +284,18 @@ impl Into<GameConfig> for TimingRule {
             team_timeouts_counted_per_half,
             overtime_allowed,
             sudden_death_allowed,
+            // Discarded on purpose, and this is NOT a bug to fix by wiring it
+            // to the clock. The setting is carried for DISPLAY only: the
+            // game-info screen shows it so the operator can see the rule
+            // before a game, while the clock's actual stop-time behaviour
+            // lives in the tournament manager and is deliberately not coupled
+            // to this field. Weighed and accepted in
+            // `docs/decisions/022-referee-names-display.md`, because the
+            // operator confirmed the value is always Yes/No in practice and
+            // the display is useful for game preparation.
+            //
+            // Connecting it here would silently change stop-clock timing at a
+            // tournament and overturn that decision.
             last_2_min_stop_time: _,
             half_play_duration,
             half_time_duration,


### PR DESCRIPTION
## What changed

A comment only. **No behaviour changes at all** — not one line of running code was touched.

In the code that converts a portal timing rule into the refbox's game configuration, the
"stop the clock in the last 2 minutes" setting is deliberately thrown away. The code said so with a
bare `_` and no explanation, which reads like an oversight.

The comment now records that this is intentional, why, and what would break if someone "fixed" it.

## Why

This is finding 7 from the code-quality inventory. A discarded setting with no explanation is an
invitation for a future contributor — human or AI — to helpfully wire it up to the game clock. Doing
that would silently change stop-clock timing at a tournament, which is exactly the kind of change
that must never happen by accident.

The setting is carried for **display only**: the game-info screen shows it so the operator can see
the rule before a game. The clock's actual stop-time behaviour lives in the tournament manager and
is deliberately not coupled to this field. That was weighed and accepted in
`docs/decisions/022-referee-names-display.md` (§3, "Stop-clock display"), which records both the
display-only design and the reason it was kept — the operator confirmed the value is always Yes/No
in practice and the display is useful for game preparation.

## Scope

Changes are limited to `uwh-common/src/uwhportal/schedule.rs` — twelve added lines, all of them
comment.

This touches `uwh-common`, which is the highest-blast-radius crate, so it is worth stating plainly:
the change adds no type, no field, no serialization, and no logic. Every downstream crate
(`refbox`, `schedule-processor`, `overlay`, `led-panel-sim`, `matrix-drawing`) compiles unchanged
because nothing they consume was altered.

## How to verify

Read the comment and check it against the ADR it cites — `docs/decisions/022-referee-names-display.md`,
section 3 "Stop-clock display". The ADR should confirm three things the comment claims: the field is
read for display only, the clock's behaviour is governed in the tournament manager and not coupled
to it, and the behaviour was kept because the value is always Yes/No in practice.

There is no observable behaviour change to test, because there is no behaviour change. `just check`
passes with zero warnings, which confirms the comment does not disturb compilation anywhere in the
workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
