### PR TITLE
fix(refbox): explain why portal requests over http are refused

### DIFF
--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -509,7 +509,15 @@ fn portal_target(mode: Mode, require_https: bool) -> SiteTarget {
 /// refbox at a workable site later (a plain-http custom site, say) keeps
 /// working without a restart.
 fn https_policy_conflict(target: &SiteTarget) -> Option<String> {
-    (target.require_https && !target.base_url.starts_with("https://")).then(|| {
+    // Compared without case because a URL scheme is case-insensitive and
+    // `reqwest` lowercases it before its own check: `HTTPS://…` works fine, so
+    // matching it case-sensitively here would log "will all fail" over an
+    // address that in fact succeeds.
+    let is_https = target
+        .base_url
+        .get(..8)
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case("https://"));
+    (target.require_https && !is_https).then(|| {
         format!(
             "Portal requests to {} will all fail: the address is not https and this refbox \
              requires https. Restart with --allow-http to use a plain-http address.",
@@ -6742,6 +6750,15 @@ mod site_target_tests {
     fn an_address_that_will_work_is_not_explained() {
         assert!(https_policy_conflict(&target("https://api.uwhportal.com", true)).is_none());
         assert!(https_policy_conflict(&target("http://scoreboard.local:8099", false)).is_none());
+    }
+
+    /// A URL scheme is case-insensitive and `reqwest` lowercases it before
+    /// deciding, so `HTTPS://…` is sent normally. Announcing that every request
+    /// "will all fail" over an address that in fact works would be a worse
+    /// error than the opaque one this replaced.
+    #[test]
+    fn an_uppercase_scheme_that_will_work_is_not_explained() {
+        assert!(https_policy_conflict(&target("HTTPS://api.uwhportal.com", true)).is_none());
     }
 
     /// The portal keeps taking its TLS requirement from the launch flag, and

--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -493,6 +493,31 @@ fn portal_target(mode: Mode, require_https: bool) -> SiteTarget {
     }
 }
 
+/// The message to log when `target` names an address that `https_only` will
+/// refuse, or `None` when nothing will be refused.
+///
+/// `https_only` does not fail when the client is built — it rejects each
+/// request inside `reqwest`, which reports it as `builder error for url (...)`.
+/// That wording names neither the cause nor the remedy, and it reappears on
+/// every call: the periodic health check, the event-list fetch, every upload.
+/// Saying it once here, where the address is chosen, explains all of them —
+/// and this is the only place that knows both halves of the conflict, the
+/// address and the policy.
+///
+/// Deliberately only reports: the refusal itself is the intended behaviour of
+/// the `--allow-http` flag, and the client is still built so that pointing the
+/// refbox at a workable site later (a plain-http custom site, say) keeps
+/// working without a restart.
+fn https_policy_conflict(target: &SiteTarget) -> Option<String> {
+    (target.require_https && !target.base_url.starts_with("https://")).then(|| {
+        format!(
+            "Portal requests to {} will all fail: the address is not https and this refbox \
+             requires https. Restart with --allow-http to use a plain-http address.",
+            target.base_url
+        )
+    })
+}
+
 /// Build a client for `target`, using the credential that belongs to that site.
 ///
 /// `None` when the client cannot be built at all, which leaves the refbox in
@@ -504,6 +529,9 @@ fn build_site_client(target: &SiteTarget, config: &Config) -> Option<UwhPortalCl
         SiteKind::Custom => config.custom_site.token.as_str(),
     };
     let token = (!token.is_empty()).then_some(token);
+    if let Some(msg) = https_policy_conflict(target) {
+        error!("{msg}");
+    }
     match UwhPortalClient::new(
         &target.base_url,
         token,
@@ -6683,6 +6711,37 @@ mod site_target_tests {
             )
             .is_none()
         );
+    }
+
+    fn target(base_url: &str, require_https: bool) -> SiteTarget {
+        SiteTarget {
+            kind: SiteKind::Portal,
+            base_url: base_url.to_string(),
+            require_https,
+            address: base_url.to_string(),
+        }
+    }
+
+    /// `https_only` refuses a plain-http address inside `reqwest`, which reports
+    /// it as "builder error for url" — wording that names neither the cause nor
+    /// the remedy, and that repeats on every call. This is the one line that
+    /// says both, so both must be in it: the address that will be refused, and
+    /// the flag that would allow it.
+    #[test]
+    fn a_plain_http_address_under_the_https_rule_is_explained() {
+        let msg = https_policy_conflict(&target("http://127.0.0.1:9099", true))
+            .expect("a plain-http address under the https rule must be explained");
+        assert!(msg.contains("http://127.0.0.1:9099"), "{msg}");
+        assert!(msg.contains("--allow-http"), "{msg}");
+    }
+
+    /// Nothing to explain when nothing will be refused. An https address always
+    /// works, and a plain-http address is fine once the rule is off — which is
+    /// how every plain-http custom site already runs, with no flag.
+    #[test]
+    fn an_address_that_will_work_is_not_explained() {
+        assert!(https_policy_conflict(&target("https://api.uwhportal.com", true)).is_none());
+        assert!(https_policy_conflict(&target("http://scoreboard.local:8099", false)).is_none());
     }
 
     /// The portal keeps taking its TLS requirement from the launch flag, and

--- a/refbox/src/portal_manager/health.rs
+++ b/refbox/src/portal_manager/health.rs
@@ -113,6 +113,15 @@ pub enum PortalCallError {
     /// Produced by `classify_error` downcasting the underlying `reqwest`
     /// transport error.
     Unreachable(String),
+    /// The refbox refused to send the request itself: the address is not
+    /// https and this refbox requires https (no `--allow-http`). Nothing
+    /// left the machine, so this is neither a connectivity failure nor a
+    /// token problem — it is a configuration choice, and reporting it as
+    /// `Unreachable` sends the operator hunting a network fault that does
+    /// not exist. Handled exactly like `Unreachable` downstream (indicator
+    /// red, no re-login prompt); only the wording differs. Produced by
+    /// `classify_error` recognising `reqwest`'s `https_only` rejection.
+    Blocked(String),
 }
 
 impl std::fmt::Display for PortalCallError {
@@ -120,6 +129,9 @@ impl std::fmt::Display for PortalCallError {
         match self {
             Self::Failed(msg) => write!(f, "portal call failed: {msg}"),
             Self::Unreachable(msg) => write!(f, "portal unreachable: {msg}"),
+            Self::Blocked(msg) => {
+                write!(f, "portal request blocked by the https-only setting: {msg}")
+            }
         }
     }
 }
@@ -206,6 +218,19 @@ async fn run_task(
                             // outage ran — at the 15s degraded cadence that is
                             // roughly 30KB an hour against a rolling log.
                             log::warn!("portal health check could not reach the portal: {e}");
+                            current_health = HealthState::Red;
+                            let _ = event_tx.send(PortalEvent::TokenUnreachable).await;
+                        }
+                        Err(PortalCallError::Blocked(e)) => {
+                            // The refbox refused to send this itself, so no
+                            // request reached the network. Degrade exactly as
+                            // an outage does — red, and no token verdict, since
+                            // the token was never offered to anyone — but say
+                            // what actually happened instead of blaming the
+                            // network for a configuration choice. Logged on
+                            // every check for the same reason the unreachable
+                            // arm is: the red indicator cannot say why.
+                            log::warn!("portal health check was blocked before sending: {e}");
                             current_health = HealthState::Red;
                             let _ = event_tx.send(PortalEvent::TokenUnreachable).await;
                         }
@@ -334,6 +359,12 @@ mod tests {
                 .to_string()
                 .contains("dns failure"),
             "an unreachable portal must keep the transport detail"
+        );
+        assert!(
+            PortalCallError::Blocked("http://127.0.0.1:9099 is not an https address".to_string())
+                .to_string()
+                .contains("http://127.0.0.1:9099"),
+            "a blocked request must keep the address that was refused"
         );
     }
 
@@ -544,6 +575,48 @@ mod tests {
                 .iter()
                 .any(|ev| matches!(ev, PortalEvent::TokenStatus(_))),
             "unreachable verify must NOT emit TokenStatus, got {events:?}"
+        );
+        drop(handle);
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn blocked_verify_emits_token_unreachable_not_token_status() {
+        // A verify_token the refbox refused to send is not evidence the login
+        // expired — the token was never offered to anyone. It must degrade the
+        // indicator exactly like an outage does (TokenUnreachable) and must NOT
+        // emit TokenStatus(false), which the UI reads as "login expired" and
+        // uses to push a pointless re-login.
+        let io = FakeIo {
+            verify_results: Mutex::new(vec![Err(PortalCallError::Blocked(
+                "http://127.0.0.1:9099 is not an https address".into(),
+            ))]),
+            verify_count: Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            scores_results: Mutex::new(vec![]),
+            scores_count: Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            stats_results: Mutex::new(vec![]),
+            stats_count: Arc::new(std::sync::atomic::AtomicU32::new(0)),
+        };
+        let mut handle = spawn(io);
+
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_secs(3)).await;
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_millis(500)).await;
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+
+        let events = drain_events(&mut handle.event_rx);
+        assert!(
+            events
+                .iter()
+                .any(|ev| matches!(ev, PortalEvent::TokenUnreachable)),
+            "blocked verify must emit TokenUnreachable, got {events:?}"
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|ev| matches!(ev, PortalEvent::TokenStatus(_))),
+            "blocked verify must NOT emit TokenStatus, got {events:?}"
         );
         drop(handle);
     }

--- a/refbox/src/portal_manager/health.rs
+++ b/refbox/src/portal_manager/health.rs
@@ -113,15 +113,22 @@ pub enum PortalCallError {
     /// Produced by `classify_error` downcasting the underlying `reqwest`
     /// transport error.
     Unreachable(String),
-    /// The refbox refused to send the request itself: the address is not
-    /// https and this refbox requires https (no `--allow-http`). Nothing
-    /// left the machine, so this is neither a connectivity failure nor a
-    /// token problem — it is a configuration choice, and reporting it as
-    /// `Unreachable` sends the operator hunting a network fault that does
-    /// not exist. Handled exactly like `Unreachable` downstream (indicator
-    /// red, no re-login prompt); only the wording differs. Produced by
-    /// `classify_error` recognising `reqwest`'s `https_only` rejection.
-    Blocked(String),
+    /// The request was rejected before any socket was opened, so nothing
+    /// ever left the machine. The case this exists for is `https_only`
+    /// refusing a plain-http address, but an address that cannot be used at
+    /// all (no host, or a scheme that is not http or https) lands here too.
+    ///
+    /// Deliberately classified by that shared fact — never sent — rather
+    /// than by cause: only the launch-time check knows whether https is
+    /// required, so naming a cause here would let the log tell an operator
+    /// who already passed `--allow-http` to go and pass `--allow-http`.
+    ///
+    /// This is neither a connectivity failure nor a token problem, and
+    /// reporting it as `Unreachable` sends the operator hunting a network
+    /// fault that does not exist. Handled exactly like `Unreachable`
+    /// downstream (indicator red, no re-login prompt); only the wording
+    /// differs. Produced by `classify_error`.
+    NotSent(String),
 }
 
 impl std::fmt::Display for PortalCallError {
@@ -129,9 +136,7 @@ impl std::fmt::Display for PortalCallError {
         match self {
             Self::Failed(msg) => write!(f, "portal call failed: {msg}"),
             Self::Unreachable(msg) => write!(f, "portal unreachable: {msg}"),
-            Self::Blocked(msg) => {
-                write!(f, "portal request blocked by the https-only setting: {msg}")
-            }
+            Self::NotSent(msg) => write!(f, "portal request was never sent: {msg}"),
         }
     }
 }
@@ -153,6 +158,10 @@ async fn run_task(
     // `last_success` never advances.
     let mut last_check_at: Option<TokioInstant> = None;
     let mut current_health = HealthState::Green;
+    // Whether the "never sent" warning has already been logged for the run of
+    // checks we are in. Cleared by any check that produces a different
+    // outcome, so the warning returns if the condition returns.
+    let mut not_sent_logged = false;
     let mut queue_snapshot = QueueFile::empty();
 
     loop {
@@ -202,6 +211,7 @@ async fn run_task(
                         Ok(()) => {
                             last_success = Some(TokioInstant::now());
                             current_health = HealthState::Green;
+                            not_sent_logged = false;
                             let _ = event_tx.send(PortalEvent::TokenStatus(true)).await;
                         }
                         Err(PortalCallError::Unreachable(e)) => {
@@ -219,18 +229,28 @@ async fn run_task(
                             // roughly 30KB an hour against a rolling log.
                             log::warn!("portal health check could not reach the portal: {e}");
                             current_health = HealthState::Red;
+                            not_sent_logged = false;
                             let _ = event_tx.send(PortalEvent::TokenUnreachable).await;
                         }
-                        Err(PortalCallError::Blocked(e)) => {
-                            // The refbox refused to send this itself, so no
-                            // request reached the network. Degrade exactly as
-                            // an outage does — red, and no token verdict, since
-                            // the token was never offered to anyone — but say
-                            // what actually happened instead of blaming the
-                            // network for a configuration choice. Logged on
-                            // every check for the same reason the unreachable
-                            // arm is: the red indicator cannot say why.
-                            log::warn!("portal health check was blocked before sending: {e}");
+                        Err(PortalCallError::NotSent(e)) => {
+                            // Nothing reached the network, so degrade exactly
+                            // as an outage does — red, and no token verdict,
+                            // since the token was never offered to anyone —
+                            // but say what happened instead of blaming the
+                            // network for a configuration choice.
+                            //
+                            // Logged once, unlike the unreachable arm above.
+                            // That arm repeats deliberately, because how long
+                            // an outage ran is worth knowing; here the address
+                            // is fixed at launch and cannot start working
+                            // mid-session, so repeating would add ~240
+                            // identical lines an hour and say nothing new. The
+                            // flag clears on any other outcome, so a later
+                            // recurrence is logged again.
+                            if !not_sent_logged {
+                                log::warn!("portal health check was never sent: {e}");
+                                not_sent_logged = true;
+                            }
                             current_health = HealthState::Red;
                             let _ = event_tx.send(PortalEvent::TokenUnreachable).await;
                         }
@@ -239,6 +259,7 @@ async fn run_task(
                             // returned a server error). Treat as a token
                             // problem so the operator is prompted to re-login.
                             current_health = HealthState::Red;
+                            not_sent_logged = false;
                             let _ = event_tx.send(PortalEvent::TokenStatus(false)).await;
                         }
                     }
@@ -361,7 +382,7 @@ mod tests {
             "an unreachable portal must keep the transport detail"
         );
         assert!(
-            PortalCallError::Blocked("http://127.0.0.1:9099 is not an https address".to_string())
+            PortalCallError::NotSent("http://127.0.0.1:9099 is not an https address".to_string())
                 .to_string()
                 .contains("http://127.0.0.1:9099"),
             "a blocked request must keep the address that was refused"
@@ -580,14 +601,14 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]
-    async fn blocked_verify_emits_token_unreachable_not_token_status() {
+    async fn unsent_verify_emits_token_unreachable_not_token_status() {
         // A verify_token the refbox refused to send is not evidence the login
         // expired — the token was never offered to anyone. It must degrade the
         // indicator exactly like an outage does (TokenUnreachable) and must NOT
         // emit TokenStatus(false), which the UI reads as "login expired" and
         // uses to push a pointless re-login.
         let io = FakeIo {
-            verify_results: Mutex::new(vec![Err(PortalCallError::Blocked(
+            verify_results: Mutex::new(vec![Err(PortalCallError::NotSent(
                 "http://127.0.0.1:9099 is not an https address".into(),
             ))]),
             verify_count: Arc::new(std::sync::atomic::AtomicU32::new(0)),
@@ -610,13 +631,13 @@ mod tests {
             events
                 .iter()
                 .any(|ev| matches!(ev, PortalEvent::TokenUnreachable)),
-            "blocked verify must emit TokenUnreachable, got {events:?}"
+            "unsent verify must emit TokenUnreachable, got {events:?}"
         );
         assert!(
             !events
                 .iter()
                 .any(|ev| matches!(ev, PortalEvent::TokenStatus(_))),
-            "blocked verify must NOT emit TokenStatus, got {events:?}"
+            "unsent verify must NOT emit TokenStatus, got {events:?}"
         );
         drop(handle);
     }

--- a/refbox/src/portal_manager/mod.rs
+++ b/refbox/src/portal_manager/mod.rs
@@ -119,8 +119,8 @@ impl UwhPortalIo {
 /// amendment (2026-04-21).
 fn classify_error(e: Box<dyn std::error::Error>) -> health::PortalCallError {
     if let Some(req_err) = e.downcast_ref::<reqwest::Error>() {
-        if let Some(url) = refused_scheme(req_err) {
-            return health::PortalCallError::Blocked(format!("{url} is not an https address"));
+        if let Some(detail) = never_sent(req_err) {
+            return health::PortalCallError::NotSent(detail);
         }
         health::PortalCallError::Unreachable(e.to_string())
     } else {
@@ -128,17 +128,32 @@ fn classify_error(e: Box<dyn std::error::Error>) -> health::PortalCallError {
     }
 }
 
-/// The URL `https_only` refused, or `None` when this is some other error.
+/// Why the request never left the machine, or `None` if it did leave.
 ///
-/// `reqwest` rejects a non-https URL inside `Client::execute`, before any
-/// socket is opened, and reports it as a builder-kind error carrying that URL.
-/// Nothing in its public API names that case, so it is recognised by its two
-/// observable marks: builder kind, plus a URL whose scheme is not https. A
-/// builder error on an https URL is something else entirely and is left alone,
-/// so this cannot swallow a genuine transport failure.
-fn refused_scheme(e: &reqwest::Error) -> Option<&reqwest::Url> {
-    let url = e.url()?;
-    (e.is_builder() && url.scheme() != "https").then_some(url)
+/// A builder-kind `reqwest` error is raised inside `Client::execute` before
+/// any socket is opened. `https_only` refusing a plain-http address is the
+/// case this exists for, but the same kind covers an address with no host and
+/// a scheme that is not http or https. They are treated together on purpose:
+/// what matters downstream is that nothing reached the network, which is what
+/// separates all of them from a real transport failure.
+///
+/// The detail deliberately states what is true of the address rather than
+/// naming a cause. Whether https is required is not knowable here — the client
+/// may since have been repointed at another site — and claiming it would let
+/// the log tell an operator who already passed `--allow-http` to pass
+/// `--allow-http`. The launch-time check owns that advice.
+fn never_sent(e: &reqwest::Error) -> Option<String> {
+    if !e.is_builder() {
+        return None;
+    }
+    // An address malformed enough to fail parsing carries no URL to quote, so
+    // that case falls back to the error's own text. Keying off the kind alone
+    // is what keeps the class intact: the request did not go out either way.
+    Some(match e.url() {
+        Some(url) if url.scheme() != "https" => format!("{url} is not an https address"),
+        Some(url) => format!("{url} could not be sent as written"),
+        None => format!("the address could not be used ({e})"),
+    })
 }
 
 /// Parse an `event_id` string (from a `QueuedItem`) into an `EventId`.
@@ -1188,12 +1203,30 @@ mod tests {
     use crate::portal_manager::queue::{QueueFile, QueuedItem};
     use time::{Duration as TimeDuration, OffsetDateTime};
 
+    /// A client for one test to use. Deliberately built per test rather than
+    /// shared: a `reqwest` client carries timers belonging to the runtime that
+    /// built it, and each `#[tokio::test]` gets its own runtime, so a shared
+    /// client's timeout silently fails to fire and the tests get slower, not
+    /// faster.
+    ///
+    /// The timeout bounds the one test that opens a real socket: a closed
+    /// loopback port is refused at once on some hosts but silently dropped on
+    /// others (WSL among them), where without it the test would hang rather
+    /// than fail. A timeout is still the connectivity failure that test
+    /// asserts, so the assertion is not weakened.
+    fn test_client(require_https: bool) -> reqwest::Client {
+        reqwest::Client::builder()
+            .https_only(require_https)
+            .timeout(std::time::Duration::from_millis(500))
+            .build()
+            .unwrap()
+    }
+
     /// Produce the exact error `reqwest` raises when `https_only` refuses a
     /// plain-http URL. It is raised inside `execute`, before any socket is
     /// opened, so this reaches no network at all.
     async fn https_only_refusal(url: &str) -> Box<dyn std::error::Error> {
-        let client = reqwest::Client::builder().https_only(true).build().unwrap();
-        Box::new(client.get(url).send().await.unwrap_err())
+        Box::new(test_client(true).get(url).send().await.unwrap_err())
     }
 
     /// The refbox refusing to send is a configuration choice, not a broken
@@ -1204,21 +1237,49 @@ mod tests {
     async fn a_refusal_to_send_is_not_reported_as_a_connectivity_failure() {
         let err = https_only_refusal("http://127.0.0.1:9099/api/events").await;
         match classify_error(err) {
-            health::PortalCallError::Blocked(msg) => {
+            health::PortalCallError::NotSent(msg) => {
                 assert!(msg.contains("http://127.0.0.1:9099"), "{msg}");
             }
             other => panic!("an https-only refusal must not be classified as {other:?}"),
         }
     }
 
+    /// `https_only` is not the only reason a request never leaves. A scheme
+    /// that is not http or https, an address with no host, and one that cannot
+    /// be parsed at all are all rejected the same way — and here with
+    /// `https_only` switched OFF, which is the case that would expose a
+    /// detection keyed to the https rule. All three are realistic overrides:
+    /// the wrong scheme, and a host:port with the scheme forgotten.
+    ///
+    /// What they share is what matters — nothing reached the network — so they
+    /// must classify together. Sorting them by cause instead would let the log
+    /// tell an operator who already passed `--allow-http` to pass
+    /// `--allow-http`.
+    #[tokio::test]
+    async fn an_unusable_address_is_also_not_a_connectivity_failure() {
+        for url in ["ftp://example.test/api", "localhost:9099", "127.0.0.1:9099"] {
+            let err: Box<dyn std::error::Error> =
+                Box::new(test_client(false).get(url).send().await.unwrap_err());
+            let classified = classify_error(err);
+            assert!(
+                matches!(classified, health::PortalCallError::NotSent(_)),
+                "{url} never reaches the network, got {classified:?}"
+            );
+        }
+    }
+
     /// Guards the detection against over-reach: a genuine transport failure
-    /// must keep its existing meaning. Loopback port 1 is never bound, so the
-    /// connection is refused at once without leaving the machine.
+    /// must keep its existing meaning. Loopback port 1 is never bound, so this
+    /// fails without leaving the machine.
     #[tokio::test]
     async fn a_genuine_transport_failure_is_still_a_connectivity_failure() {
-        let client = reqwest::Client::builder().build().unwrap();
-        let err: Box<dyn std::error::Error> =
-            Box::new(client.get("http://127.0.0.1:1/").send().await.unwrap_err());
+        let err: Box<dyn std::error::Error> = Box::new(
+            test_client(false)
+                .get("http://127.0.0.1:1/")
+                .send()
+                .await
+                .unwrap_err(),
+        );
         assert!(matches!(
             classify_error(err),
             health::PortalCallError::Unreachable(_)

--- a/refbox/src/portal_manager/mod.rs
+++ b/refbox/src/portal_manager/mod.rs
@@ -118,11 +118,27 @@ impl UwhPortalIo {
 /// `verify_token` token-status path acts on the distinction. See ADR 011
 /// amendment (2026-04-21).
 fn classify_error(e: Box<dyn std::error::Error>) -> health::PortalCallError {
-    if e.downcast_ref::<reqwest::Error>().is_some() {
+    if let Some(req_err) = e.downcast_ref::<reqwest::Error>() {
+        if let Some(url) = refused_scheme(req_err) {
+            return health::PortalCallError::Blocked(format!("{url} is not an https address"));
+        }
         health::PortalCallError::Unreachable(e.to_string())
     } else {
         health::PortalCallError::Failed(e.to_string())
     }
+}
+
+/// The URL `https_only` refused, or `None` when this is some other error.
+///
+/// `reqwest` rejects a non-https URL inside `Client::execute`, before any
+/// socket is opened, and reports it as a builder-kind error carrying that URL.
+/// Nothing in its public API names that case, so it is recognised by its two
+/// observable marks: builder kind, plus a URL whose scheme is not https. A
+/// builder error on an https URL is something else entirely and is left alone,
+/// so this cannot swallow a genuine transport failure.
+fn refused_scheme(e: &reqwest::Error) -> Option<&reqwest::Url> {
+    let url = e.url()?;
+    (e.is_builder() && url.scheme() != "https").then_some(url)
 }
 
 /// Parse an `event_id` string (from a `QueuedItem`) into an `EventId`.
@@ -1171,6 +1187,43 @@ mod tests {
     use super::*;
     use crate::portal_manager::queue::{QueueFile, QueuedItem};
     use time::{Duration as TimeDuration, OffsetDateTime};
+
+    /// Produce the exact error `reqwest` raises when `https_only` refuses a
+    /// plain-http URL. It is raised inside `execute`, before any socket is
+    /// opened, so this reaches no network at all.
+    async fn https_only_refusal(url: &str) -> Box<dyn std::error::Error> {
+        let client = reqwest::Client::builder().https_only(true).build().unwrap();
+        Box::new(client.get(url).send().await.unwrap_err())
+    }
+
+    /// The refbox refusing to send is a configuration choice, not a broken
+    /// network. Classifying it as `Unreachable` makes the log say "could not
+    /// reach the portal", which sends the operator hunting a wifi fault that
+    /// does not exist.
+    #[tokio::test]
+    async fn a_refusal_to_send_is_not_reported_as_a_connectivity_failure() {
+        let err = https_only_refusal("http://127.0.0.1:9099/api/events").await;
+        match classify_error(err) {
+            health::PortalCallError::Blocked(msg) => {
+                assert!(msg.contains("http://127.0.0.1:9099"), "{msg}");
+            }
+            other => panic!("an https-only refusal must not be classified as {other:?}"),
+        }
+    }
+
+    /// Guards the detection against over-reach: a genuine transport failure
+    /// must keep its existing meaning. Loopback port 1 is never bound, so the
+    /// connection is refused at once without leaving the machine.
+    #[tokio::test]
+    async fn a_genuine_transport_failure_is_still_a_connectivity_failure() {
+        let client = reqwest::Client::builder().build().unwrap();
+        let err: Box<dyn std::error::Error> =
+            Box::new(client.get("http://127.0.0.1:1/").send().await.unwrap_err());
+        assert!(matches!(
+            classify_error(err),
+            health::PortalCallError::Unreachable(_)
+        ));
+    }
 
     fn mk_young_item() -> QueuedItem {
         QueuedItem {


### PR DESCRIPTION
## What changed

When the refbox is pointed at an insecure (`http://`) portal address without the
`--allow-http` launch flag, it refuses to send anything. That refusal is correct and
is unchanged. What changed is how it explains itself.

**Before**, every portal call failed with `builder error for url (...)` — the
networking library's own internal wording, naming neither the cause nor the remedy.
The 15-second health check then repeated it as *"could not reach the portal"*, which
reads as a wifi failure. It isn't: nothing was ever sent, so this is a setting, not a
network fault, and blaming the network sends the operator looking for a problem that
does not exist.

**Now**, at launch, once:

```
ERROR refbox::app] Portal requests to http://127.0.0.1:9099 will all fail: the address
                   is not https and this refbox requires https. Restart with
                   --allow-http to use a plain-http address.
```

and the repeating health-check line says the request *was never sent* rather than that
the portal could not be reached. It is logged once, not every 15 seconds: a fixed
address cannot start working mid-session, so repetition would add nothing.

Nothing about what the refbox permits changed — the https-only default, the
`--allow-http` flag, the custom-site scheme derivation, the red indicator, retry
timing, and every word on screen are all exactly as before.

## Why

The https requirement was deliberately kept, not relaxed. Two grounded reasons:
every portal request carries the event access key in an `Authorization` header, so over
an insecure connection on shared venue wifi that key is readable by anyone on the
network; and `https_only` is also applied to the redirect policy, so it blocks a
redirect that downgrades from a secure to an insecure address — a protection that
applies to the normal production address, not just to developer overrides.

So the requirement is right and the defect is purely the explanation.

One design point worth flagging for review: the classification deliberately keys off
the fact that **the request never left the machine**, not off "the https rule refused
it". The same underlying failure also covers an address with an unusable scheme or one
that will not parse, both reachable with `--allow-http` already passed — where naming
the https rule as the cause would tell an operator to pass a flag they had passed.
Only the launch-time check knows whether https is required, so it owns that advice.

## Scope

Changes are limited to `refbox`: `src/app/mod.rs`, `src/portal_manager/mod.rs`, and
`src/portal_manager/health.rs`. No changes to `uwh-common`, no wire-format changes, no
new dependencies, no new translation keys (these messages are log-only — the remedy is
a command-line flag, so the reader who can act on it is the one reading the log).

## How to verify

Three runs, each ~30 seconds. The first is the reported failure:

1. **Insecure address, no flag** — `UWH_PORTAL_URL_OVERRIDE=http://127.0.0.1:9099 refbox`
   Expect the clear ERROR above near the top of the log, and the health-check line to
   say "was never sent", appearing **once** even over a minute or more.
2. **Same address with the flag** — add `--allow-http`
   Expect no warning at all and normal portal behaviour. To see requests actually
   leaving, run `python3 -m http.server 9099` first: its log shows the API requests
   arriving (they 404, which is fine — the point is they were sent).
3. **Secure address, dead machine** — `UWH_PORTAL_URL_OVERRIDE=https://127.0.0.1:9099 refbox`
   Expect the unchanged `could not reach the portal: error sending request` — still
   repeating every 15 seconds, which is correct for a genuine outage.

All three were run against a built refbox and behave as described. `just check` passes
clean; 570 tests green, including five new ones covering the launch message, the
classification, the guard against misclassifying a real transport failure, and an
uppercase `HTTPS://` address that works and must not be warned about.

## Known limitation, left deliberately

The event-list fetch still logs the raw `builder error for url (...)`. It appears a few
lines below the clear explanation, so it is explained rather than fixed at each
individual failure site. Happy to address it separately if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
