### PR TITLE
fix(uwh-common): refuse an access key that cannot be sent

### DIFF
--- a/docs/superpowers/plans/2026-08-14-access-key-header-panic.md
+++ b/docs/superpowers/plans/2026-08-14-access-key-header-panic.md
@@ -1,0 +1,794 @@
+# Access Key Header Panic — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A refbox holding an access key that an HTTP header cannot carry reports the problem and keeps running, instead of panicking on the next portal call.
+
+**Architecture:** The key is checked once, where it arrives, and the client stores a finished `HeaderValue` instead of raw text. After that, `authenticated_request` performs no conversion at all, so none of the 10 authenticated calls can hit this fault again. The character rule lives in `uwh-common` and `schedule-processor` delegates to it.
+
+**Correction to the brief:** there are **10** authenticated call sites, not 11 — `get_event_list` sends no authorization header at all. Verified with `grep -c "authenticated_request(&self.client"`. This matters for the live run: the refbox's startup event-list request is unauthenticated, so it does **not** trigger the crash (see Task 5).
+
+**Tech Stack:** Rust 2024, MSRV 1.85, `reqwest` (client), `iced` 0.13 (refbox UI), Fluent `.ftl` (translations).
+
+**Spec:** `docs/superpowers/specs/2026-08-14-access-key-header-panic-design.md`
+
+## Global Constraints
+
+- Work from the worktree `/home/estraily/projects/uwh-refbox-rs/.worktrees/access-key-header-panic`. Run every cargo/just command from there.
+- **Heavy process** (`.claude/rules/plan-execution.md`): `uwh-common` is the highest-blast-radius crate. Verify per task; do not batch tasks.
+- **Approval gate:** ask the human before every commit. Never push or open a PR without asking.
+- Clippy is `-D warnings`. `cargo fmt --all` before every commit.
+- No `unwrap()`/`expect()` in production code without a comment stating why it cannot panic.
+- No new dependencies.
+- `uwh-common::uwhportal` is already `#[cfg(feature = "std")]`, so no_std is not expected to change — it is still checked in Task 5.
+- Rejected outright, at every layer: dropping the authorization header when it cannot be built. That sends the request unauthenticated and turns a loud crash into a silent wrong answer.
+- The character rule, used everywhere: **printable ASCII only** — `matches!(c, ' '..='~')`.
+
+---
+
+### Task 1: The shared rule in `uwh-common`
+
+**Files:**
+- Modify: `uwh-common/src/uwhportal/mod.rs` (add public check + error type near the bottom, before the `#[cfg(test)]` modules at line 884)
+- Test: `uwh-common/src/uwhportal/mod.rs` (new `#[cfg(test)] mod access_key_tests`)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `pub struct UnsendableAccessKey { pub character: char }` (implements `Debug`, `Clone`, `Copy`, `PartialEq`, `Eq`, `Display`, `std::error::Error`) and `pub fn check_access_key(key: &str) -> Result<(), UnsendableAccessKey>`. Task 2, 3 and 4 all use these exact names.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add at the end of `uwh-common/src/uwhportal/mod.rs`:
+
+```rust
+#[cfg(test)]
+mod access_key_tests {
+    use super::*;
+
+    #[test]
+    fn a_curly_quote_is_refused_and_named() {
+        // The case this exists for: a key copied through a chat app or a word
+        // processor, where a straight quote has been turned into a curly one.
+        let err = check_access_key("abc\u{2019}123").unwrap_err();
+        assert_eq!(err.character, '\u{2019}');
+    }
+
+    #[test]
+    fn a_newline_or_tab_is_refused() {
+        assert_eq!(check_access_key("abc\n123").unwrap_err().character, '\n');
+        assert_eq!(check_access_key("abc\t123").unwrap_err().character, '\t');
+    }
+
+    #[test]
+    fn a_normal_key_is_accepted() {
+        // Letters, digits, and the punctuation base64 and JWTs use.
+        let key = "eyJhbGciOiJI.UzI1NiIs-InR5cCI6_IkpXVCJ9~abc+/=";
+        assert_eq!(check_access_key(key), Ok(()));
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p uwh-common access_key_tests`
+Expected: FAIL to compile — `cannot find function 'check_access_key' in this scope`.
+
+- [ ] **Step 3: Write the implementation**
+
+Add immediately above the `#[cfg(test)] mod coin_flip_tests` block:
+
+```rust
+/// A character an access key must not contain, because an HTTP header cannot
+/// carry it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UnsendableAccessKey {
+    /// The first character in the key that cannot be sent.
+    pub character: char,
+}
+
+impl std::fmt::Display for UnsendableAccessKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "the access key contains a character that cannot be sent to the site ({:?})",
+            self.character
+        )
+    }
+}
+
+impl Error for UnsendableAccessKey {}
+
+/// Check that `key` can be carried in an `Authorization` header.
+///
+/// Printable ASCII only. Everything a real access key contains — letters,
+/// digits, and the punctuation used by base64 and JWTs — is in this range, and
+/// everything outside it is what a header cannot carry: a newline, a tab, a
+/// curly quote left by a chat app or a word processor.
+///
+/// Whitespace around the key is *not* trimmed here; callers that accept a
+/// pasted key trim first, so that this reports only characters that are
+/// genuinely part of the key.
+pub fn check_access_key(key: &str) -> Result<(), UnsendableAccessKey> {
+    match key.chars().find(|c| !matches!(c, ' '..='~')) {
+        Some(character) => Err(UnsendableAccessKey { character }),
+        None => Ok(()),
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo test -p uwh-common access_key_tests`
+Expected: 3 passed.
+
+- [ ] **Step 5: Format, lint, and ask before committing**
+
+```bash
+cargo fmt --all
+cargo clippy -p uwh-common --all-targets --all-features -- -D warnings
+```
+
+Then ask the human for permission to commit. On approval:
+
+```bash
+git add uwh-common/src/uwhportal/mod.rs
+git commit -m "feat(uwh-common): add the access-key character check"
+```
+
+---
+
+### Task 2: The client stores a finished header
+
+This is the task that removes the panic. Everything else is plumbing.
+
+**Files:**
+- Modify: `uwh-common/src/uwhportal/mod.rs` — struct field (line ~160), `new` (~166), `set_token` (~187), `has_token` (~195), `authenticated_request` (~842), and the 10 call sites listed below
+- Test: `uwh-common/src/uwhportal/mod.rs` (`mod access_key_tests`, extended)
+
+**Interfaces:**
+- Consumes: `check_access_key`, `UnsendableAccessKey` from Task 1.
+- Produces: `UwhPortalClient::set_token(&mut self, token: &str) -> Result<(), UnsendableAccessKey>` — **signature change, callers in Task 3 and Task 4**. `UwhPortalClient::new` keeps its existing signature and its `Result<Self, Box<dyn Error>>`, gaining a failure case. Private field renamed `access_token: Option<String>` → `auth_header: Option<HeaderValue>`. `has_token` and `clear_token` keep their signatures and meaning.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these to `mod access_key_tests` (the module from Task 1):
+
+`Duration`, `Error`, `Method`, `AUTHORIZATION` and `HeaderValue` all arrive
+through the module's existing `use super::*` — do not re-import them, clippy
+runs with `-D warnings`.
+
+```rust
+    fn test_client(key: Option<&str>) -> Result<UwhPortalClient, Box<dyn Error>> {
+        UwhPortalClient::new("https://example.test", key, true, Duration::from_secs(5))
+    }
+
+    #[test]
+    fn a_good_key_becomes_exactly_one_bearer_header() {
+        let client = test_client(Some("good-key")).unwrap();
+        let request = authenticated_request(
+            &client.client,
+            Method::GET,
+            "https://example.test/thing",
+            &client.auth_header,
+        )
+        .build()
+        .unwrap();
+        assert_eq!(
+            request.headers().get(AUTHORIZATION).unwrap(),
+            "Bearer good-key"
+        );
+    }
+
+    #[test]
+    fn a_client_cannot_be_built_with_a_key_that_cannot_be_sent() {
+        // On master this succeeded, and the panic waited until the first call.
+        assert!(test_client(Some("abc\u{2019}123")).is_err());
+    }
+
+    #[test]
+    fn a_refused_key_leaves_the_previous_key_in_place() {
+        // A half-updated client would be worse than a refused one: it would
+        // start sending calls with no credential at all.
+        let mut client = test_client(Some("good-key")).unwrap();
+        assert!(client.set_token("abc\u{2019}123").is_err());
+        assert_eq!(
+            client.auth_header,
+            Some(HeaderValue::from_static("Bearer good-key"))
+        );
+        assert!(client.has_token());
+    }
+
+    #[test]
+    fn a_key_copied_with_a_trailing_newline_is_trimmed_not_refused() {
+        // Copying a key out of a web page is how the newline gets there.
+        let mut client = test_client(None).unwrap();
+        assert_eq!(client.set_token("  good-key \r\n"), Ok(()));
+        assert_eq!(
+            client.auth_header,
+            Some(HeaderValue::from_static("Bearer good-key"))
+        );
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p uwh-common access_key_tests`
+Expected: FAIL to compile — `no field 'auth_header' on type 'UwhPortalClient'`.
+
+- [ ] **Step 3: Change the client to hold a header**
+
+In `uwh-common/src/uwhportal/mod.rs`, replace the field:
+
+```rust
+pub struct UwhPortalClient {
+    base_url: String,
+    // The finished header, not the raw key. Building it here, once, is what
+    // keeps a key that cannot be sent out of the 11 calls that use it.
+    auth_header: Option<HeaderValue>,
+    client: Client,
+    id: OnceCell<u32>,
+}
+```
+
+In `new`, replace `access_token: access_token.map(|s| s.to_string()),` with a checked conversion. The `?` runs before `Self` is built, so a client that exists always holds a usable key:
+
+```rust
+        let auth_header = match access_token {
+            Some(token) => Some(build_auth_header(token)?),
+            None => None,
+        };
+
+        Ok(Self {
+            base_url,
+            auth_header,
+            client,
+            id: OnceCell::new(),
+        })
+```
+
+Replace `set_token` and `has_token`:
+
+```rust
+    /// Replace the access key.
+    ///
+    /// The key is checked and converted before it is stored, so a key that
+    /// cannot be sent is refused here — the previous key is kept and the
+    /// client is never left half-updated.
+    pub fn set_token(&mut self, token: &str) -> Result<(), UnsendableAccessKey> {
+        self.auth_header = Some(build_auth_header(token)?);
+        Ok(())
+    }
+
+    pub fn clear_token(&mut self) {
+        self.auth_header = None;
+    }
+
+    pub fn has_token(&self) -> bool {
+        self.auth_header.is_some()
+    }
+```
+
+Add the private helper next to `authenticated_request`:
+
+```rust
+/// Turn an access key into the `Authorization` header value, or say which
+/// character stops it.
+///
+/// Surrounding whitespace is dropped first: a key copied out of a web page
+/// arrives with a trailing newline, and that is worth accepting rather than
+/// refusing.
+fn build_auth_header(token: &str) -> Result<HeaderValue, UnsendableAccessKey> {
+    let token = token.trim();
+    check_access_key(token)?;
+    // why this cannot panic: `check_access_key` has just proved every
+    // character is in `' '..='~'` (0x20..=0x7E), which is exactly the range
+    // `from_str` accepts, and "Bearer " is itself in that range.
+    Ok(HeaderValue::from_str(&format!("Bearer {token}"))
+        .expect("a printable-ASCII key always makes a valid header value"))
+}
+```
+
+Replace `authenticated_request` — this is the line that panicked:
+
+```rust
+fn authenticated_request(
+    client: &Client,
+    method: Method,
+    url: &str,
+    auth_header: &Option<HeaderValue>,
+) -> RequestBuilder {
+    let mut request = client.request(method, url);
+    if let Some(value) = auth_header {
+        request = request.header(AUTHORIZATION, value.clone());
+    }
+    request
+}
+```
+
+- [ ] **Step 4: Update the 10 call sites**
+
+Each is a single-word change, `&self.access_token` → `&self.auth_header`:
+
+| Line | Method |
+|---|---|
+| 309 | `verify_token` |
+| 333 | `post_game_stats` |
+| 366 | `post_game_scores` |
+| 410 | `get_event_schedule_privileged` |
+| 589 | `push_event_schedule` |
+| 624 | `push_team_map` |
+| 703 | `get_coin_flips` |
+| 737 | `get_event_referee_name_map` |
+| 781 | `get_game_referee_name_map` |
+| 826 | `set_coin_flip_result` |
+
+`get_event_list` is *not* in this list — it sends no authorization header. Let the compiler confirm the set:
+
+Run: `cargo build -p uwh-common 2>&1 | grep -c "no field"`
+Expected: 0 once every call site is updated.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cargo test -p uwh-common access_key_tests`
+Expected: 7 passed (3 from Task 1, 4 from this task).
+
+- [ ] **Step 6: The mutation check — prove the tests are load-bearing**
+
+Do not skip this. Delete the line `check_access_key(token)?;` from `build_auth_header`, then:
+
+Run: `cargo test -p uwh-common access_key_tests`
+Expected: RED. `a_client_cannot_be_built_with_a_key_that_cannot_be_sent` and `a_refused_key_leaves_the_previous_key_in_place` both fail, and the panic re-appears in the test output from the `expect` — which is the original crash, now caught by a test instead of an operator.
+
+Then restore the line and re-run:
+
+Run: `cargo test -p uwh-common access_key_tests`
+Expected: 7 passed.
+
+Record in the plan's Deviations section that the mutation check was run and what went red.
+
+- [ ] **Step 7: Format, lint, and ask before committing**
+
+```bash
+cargo fmt --all
+cargo clippy -p uwh-common --all-targets --all-features -- -D warnings
+```
+
+Ask the human. On approval:
+
+```bash
+git add uwh-common/src/uwhportal/mod.rs
+git commit -m "fix(uwh-common): check the access key before it reaches the header"
+```
+
+---
+
+### Task 3: `schedule-processor` delegates to the shared rule
+
+**Files:**
+- Modify: `schedule-processor/src/site.rs:65-90` (`validate_access_key` — the doc comment and the character check)
+- Modify: `schedule-processor/src/main.rs` — the 5 `set_token` calls at lines 573, 615, 770, 1080, 1130
+- Test: `schedule-processor/src/site.rs` (existing tests at lines 171-212 must keep passing **unchanged** — they are the proof the delegation preserved behaviour)
+
+**Interfaces:**
+- Consumes: `uwh_common::uwhportal::check_access_key` (Task 1), `set_token -> Result` (Task 2).
+- Produces: nothing new. `validate_access_key(raw: &str) -> Result<Option<String>, String>` keeps its exact signature, wording, trimming and `Ok(None)` behaviour.
+
+- [ ] **Step 1: Run the existing tests first, so the baseline is known**
+
+Run: `cargo test -p schedule-processor site::`
+Expected: PASS. These are the tests that must still pass at the end.
+
+- [ ] **Step 2: Delegate the character question**
+
+In `schedule-processor/src/site.rs`, replace the doc comment paragraph and the character check inside `validate_access_key`. The comment currently says the panic is unfixed — this branch fixes it, so the sentence becomes false and must go.
+
+```rust
+/// Clean up and check an access key the operator pasted.
+///
+/// `Ok(None)` means no key was given, which is allowed — an open site can be
+/// read without one, and anything that later needs a key asks for it then.
+///
+/// The character rule lives in `uwh-common`, which owns the header this key
+/// ends up in, so the two cannot drift apart. `uwh-common` refuses a bad key
+/// too; this check exists so the operator gets a sentence about their paste at
+/// the moment they paste it, rather than a failure later.
+pub fn validate_access_key(raw: &str) -> Result<Option<String>, String> {
+    let key = raw.trim();
+    if key.is_empty() {
+        return Ok(None);
+    }
+    if let Err(why) = uwh_common::uwhportal::check_access_key(key) {
+        return Err(format!(
+            "That access key contains a character that cannot be sent to the site \
+             ({:?}). Copy the key again, straight from where your site shows it.",
+            why.character
+        ));
+    }
+    Ok(Some(key.to_string()))
+}
+```
+
+- [ ] **Step 3: Run the existing tests to confirm nothing changed**
+
+Run: `cargo test -p schedule-processor site::`
+Expected: PASS, all of them, unmodified. If `a_pasted_key_with_a_smart_quote_is_refused` fails on its message assertion, the wording above drifted — fix the wording, not the test.
+
+- [ ] **Step 4: Handle the refusal at the 5 key-setting sites**
+
+`set_token` now returns a `Result`. Each site gets the treatment its neighbours already use.
+
+Line ~573 — the key came from `validate_access_key`, so a refusal here means the two rules disagree. Log it rather than ignore it:
+
+```rust
+                                Ok(Some(key)) => {
+                                    if let Err(why) = portal_client.set_token(&key) {
+                                        error!("{why}");
+                                        continue 'outer;
+                                    }
+                                }
+```
+
+Lines ~615, ~770, ~1130 — the key came from a login response. Same shape as the `Err` arm beside each one, which does `continue 'outer`:
+
+```rust
+                            if let Err(why) = portal_client.set_token(&token) {
+                                error!("The site returned an access key that cannot be used: {why}");
+                                continue 'outer;
+                            }
+```
+
+At line ~770 and ~1130 this replaces `Ok(token) => portal_client.set_token(&token),` inside a `match`, so it becomes:
+
+```rust
+                        Ok(token) => {
+                            if let Err(why) = portal_client.set_token(&token) {
+                                error!("The site returned an access key that cannot be used: {why}");
+                                continue 'outer;
+                            }
+                        }
+```
+
+Line ~1080 — its neighbouring `Err` arm says "Proceeding without login", so this one warns and carries on rather than restarting the loop:
+
+```rust
+                                    Ok(token) => {
+                                        if let Err(why) = portal_client.set_token(&token) {
+                                            error!(
+                                                "The site returned an access key that cannot be \
+                                                 used. Proceeding without login. Reason: {why}"
+                                            );
+                                        }
+                                    }
+```
+
+- [ ] **Step 5: Build and lint**
+
+Run: `cargo clippy -p schedule-processor --all-targets --all-features -- -D warnings`
+Expected: clean, no `unused_must_use`.
+
+Run: `cargo test -p schedule-processor`
+Expected: PASS.
+
+- [ ] **Step 6: Format and ask before committing**
+
+```bash
+cargo fmt --all
+```
+
+Ask the human. On approval:
+
+```bash
+git add schedule-processor/src/site.rs schedule-processor/src/main.rs
+git commit -m "refactor(schedule-processor): use the shared access-key check"
+```
+
+---
+
+### Task 4: The refbox refuses a bad key from the site and says so
+
+**Files:**
+- Modify: `refbox/src/app/mod.rs:43` (import), `:359` (new `ConfirmationKind` variant), `:1449` (debug-only key setter), `:4740-4744` (the comment listing which kinds reach that match), `:5102-5120` (`PortalTokenResponse::Success` arm)
+- Modify: `refbox/src/app/view_builders/confirmation.rs:24-40` (header text) and `:117-119` (buttons)
+- Modify: `refbox/translations/<15 locales>/refbox.ftl` — one new key each
+- Test: none automated (refbox is a bin crate and this path needs a live client); proven by Task 5's live run and by the `uwh-common` tests from Task 2
+
+**Interfaces:**
+- Consumes: `check_access_key`, `UnsendableAccessKey` (Task 1), `set_token -> Result` (Task 2).
+- Produces: `ConfirmationKind::UwhPortalKeyUnusable` (no payload) and the Fluent key `uwhportal-token-unusable-key`.
+
+- [ ] **Step 1: Add the translation key to all 15 locales**
+
+The dialog's two sibling reasons are both two-line, so this one matches. Add after `uwhportal-token-no-pending-link` in each file:
+
+`refbox/translations/en-US/refbox.ftl`:
+```
+uwhportal-token-unusable-key = The site sent an access key this refbox cannot use.
+    Ask the site for the key again.
+```
+
+`de-DE`:
+```
+uwhportal-token-unusable-key = Die Website hat einen Zugangsschlüssel gesendet, den diese Refbox nicht verwenden kann.
+    Fordern Sie den Schlüssel erneut bei der Website an.
+```
+
+`es`:
+```
+uwhportal-token-unusable-key = El sitio envió una clave de acceso que esta Refbox no puede usar.
+    Solicite la clave al sitio de nuevo.
+```
+
+`fr`:
+```
+uwhportal-token-unusable-key = Le site a envoyé une clé d'accès que cette Refbox ne peut pas utiliser.
+    Demandez à nouveau la clé au site.
+```
+
+`id-ID`:
+```
+uwhportal-token-unusable-key = Situs mengirim kunci akses yang tidak dapat digunakan Refbox ini.
+    Mintalah kunci itu lagi dari situs Anda.
+```
+
+`it-IT`:
+```
+uwhportal-token-unusable-key = Il sito ha inviato una chiave di accesso che questa Refbox non può usare.
+    Richiedi di nuovo la chiave al sito.
+```
+
+`ja-JP`:
+```
+uwhportal-token-unusable-key = サイトから送られたアクセスキーは、この Refbox では使用できません。
+    サイトにキーをもう一度要求してください。
+```
+
+`ko-KR`:
+```
+uwhportal-token-unusable-key = 사이트에서 보낸 액세스 키를 이 Refbox에서 사용할 수 없습니다.
+    사이트에 키를 다시 요청하세요.
+```
+
+`ms-MY`:
+```
+uwhportal-token-unusable-key = Tapak ini menghantar kunci akses yang tidak boleh digunakan oleh Refbox ini.
+    Minta kunci itu semula daripada tapak anda.
+```
+
+`nl-NL`:
+```
+uwhportal-token-unusable-key = De site heeft een toegangssleutel gestuurd die deze Refbox niet kan gebruiken.
+    Vraag de sleutel opnieuw op bij de site.
+```
+
+`pt-PT`:
+```
+uwhportal-token-unusable-key = O site enviou uma chave de acesso que esta Refbox não consegue usar.
+    Peça novamente a chave ao site.
+```
+
+`th-TH`:
+```
+uwhportal-token-unusable-key = เว็บไซต์ส่งคีย์การเข้าถึงที่ Refbox นี้ใช้ไม่ได้
+    โปรดขอคีย์จากเว็บไซต์อีกครั้ง
+```
+
+`tl-PH`:
+```
+uwhportal-token-unusable-key = Nagpadala ang site ng access key na hindi magagamit ng Refbox na ito.
+    Hilingin muli ang key sa site.
+```
+
+`tr-TR`:
+```
+uwhportal-token-unusable-key = Site, bu Refbox'ın kullanamayacağı bir erişim anahtarı gönderdi.
+    Anahtarı siteden tekrar isteyin.
+```
+
+`zh-CN`:
+```
+uwhportal-token-unusable-key = 站点发送的访问密钥无法在此 Refbox 上使用。
+    请再次向站点索取密钥。
+```
+
+- [ ] **Step 2: Add the confirmation variant**
+
+In `refbox/src/app/mod.rs`, beside `UwhPortalLinkFailed`:
+
+```rust
+    UwhPortalLinkFailed(PortalTokenResponse),
+    // Raised when the site's reply carried an access key this refbox cannot
+    // put in a header. Not a `PortalTokenResponse` variant: the server never
+    // says this, the refbox concludes it, and that type should keep meaning
+    // "what the server replied".
+    UwhPortalKeyUnusable,
+```
+
+Extend the import on line 43 with `check_access_key`.
+
+- [ ] **Step 3: Render it in the dialog**
+
+In `refbox/src/app/view_builders/confirmation.rs`, add to the `header_text` match after the `UwhPortalLinkFailed(PortalTokenResponse::Success(_))` arm:
+
+```rust
+        ConfirmationKind::UwhPortalKeyUnusable => fl!("uwhportal-token-unusable-key"),
+```
+
+and widen the buttons arm so it offers the same single OK:
+
+```rust
+        ConfirmationKind::UwhPortalLinkFailed(_) | ConfirmationKind::UwhPortalKeyUnusable => {
+            vec![(fl!("ok"), green_button, ConfirmationOption::GoBack)]
+        }
+```
+
+`ConfirmationOption::GoBack` returns the operator to the link-code keypad, which is where they can ask the site for a fresh key — the behaviour the other link failures already have.
+
+- [ ] **Step 4: Refuse the key before it is stored or saved**
+
+In `refbox/src/app/mod.rs`, the `PortalTokenResponse::Success(token)` arm. Check first, and wrap the existing body in the `else`:
+
+```rust
+                    PortalTokenResponse::Success(token) => {
+                        // The site's reply is not trusted text. A custom site is
+                        // somebody else's server, and a key carrying a character a
+                        // header cannot hold used to take the refbox down on the
+                        // next call. Refusing it here also keeps it out of the
+                        // config file, so it cannot come back at the next launch.
+                        let token = token.trim().to_string();
+                        if let Err(why) = check_access_key(&token) {
+                            warn!("The site returned an access key that cannot be sent: {why}");
+                            AppState::ConfirmationPage(ConfirmationKind::UwhPortalKeyUnusable)
+                        } else {
+                            info!("Portal token request succeeded");
+                            if let Some(client) = self.uwhportal_client.as_ref() {
+                                // why this cannot panic: the guard is held only for a
+                                // synchronous `set_token()` call and dropped immediately.
+                                if let Err(why) = client.lock().unwrap().set_token(&token) {
+                                    // Cannot happen: the key was just checked with the
+                                    // same rule `set_token` applies. Logged rather than
+                                    // ignored so a future divergence is not silent.
+                                    error!("Client refused a key that passed the check: {why}");
+                                }
+                            }
+
+                            // ... the rest of the existing arm, unchanged, from
+                            // `match self.current_site.kind {` through to
+                            // `AppState::EditGameConfig(ConfigPage::Game)` ...
+                        }
+                    }
+```
+
+Keep the whole existing body — the config save, `uwhportal_token_valid`, `portal_manager.token_refreshed()`, the schedule request, and the final `AppState::EditGameConfig(ConfigPage::Game)` — inside the `else`, untouched apart from indentation.
+
+- [ ] **Step 5: Update the stale comment about which kinds reach the final match**
+
+Around line 4740 the comment says only `Error` and `UwhPortalLinkFailed` reach that match. Add the new variant:
+
+```rust
+                // After ADR 009 Task 13 retired the global apply path, only
+                // `ConfirmationKind::Error` (which offers DiscardChanges) and
+                // `ConfirmationKind::UwhPortalLinkFailed` /
+                // `ConfirmationKind::UwhPortalKeyUnusable` (which offer GoBack)
+                // reach this match. The Game-related and PortalTenantSwitch
+                // confirmations are dispatched to apply_game_confirmation above.
+```
+
+- [ ] **Step 6: Fix the debug-only key setter**
+
+At line ~1449, `set_token` now returns a `Result`:
+
+```rust
+                // A literal printable-ASCII key, so the check cannot refuse it;
+                // this is the debug scramble path, not an operator's key.
+                let _ = guard.set_token("invalid-debug-token");
+```
+
+- [ ] **Step 7: Build, lint, and check the translations**
+
+Run: `cargo clippy -p refbox --all-targets --all-features -- -D warnings`
+Expected: clean, and no non-exhaustive-match errors left from the new variant.
+
+Run: `cargo test -p refbox`
+Expected: PASS, including the translation-consistency test — it fails if any of the 15 locales is missing the new key.
+
+- [ ] **Step 8: Format and ask before committing**
+
+```bash
+cargo fmt --all
+```
+
+Ask the human. On approval:
+
+```bash
+git add refbox/src refbox/translations
+git commit -m "fix(refbox): refuse an access key the site cannot be sent"
+```
+
+---
+
+### Task 5: Whole-workspace verification and the live run
+
+**Files:** none modified (unless a check fails).
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-4.
+- Produces: the evidence for the PR's "how to verify" section.
+
+- [ ] **Step 1: The downstream compile list**
+
+`uwh-common` is the highest-blast-radius crate, so every dependent is checked (`uwh-common/CLAUDE.md`):
+
+```bash
+cargo check -p refbox
+cargo check -p schedule-processor
+cargo check -p overlay
+cargo check -p led-panel-sim
+cargo build -p uwh-common --no-default-features
+```
+
+Expected: all clean. The last one proves the no_std build is unaffected — `uwhportal` is `std`-gated, so this is confirmation, not a risk.
+
+- [ ] **Step 2: The full gate**
+
+Run: `just check`
+Expected: fmt, lint, tests and audit all clean.
+
+Note: `just lint` is not `--all-targets`. The stricter form fails on a pre-existing `player_grid.rs` error that does not fail CI — if that appears, it is not from this branch.
+
+- [ ] **Step 3: Build the real binary for the live run**
+
+`just check` builds a *test* binary, which is not what gets launched:
+
+```bash
+cargo build -p refbox
+```
+
+- [ ] **Step 4: Prove the crash on master first**
+
+Ask the human before launching — they drive the refbox UI. Two things matter about how this is launched:
+
+- The config directory is **shared**: only one refbox at a time, and back up `~/.config/refbox/config.toml` before editing it.
+- **Never launch bare.** Without the override the refbox talks to the *production* portal and rewrites `portal_link.json`. Always:
+  `UWH_PORTAL_URL_OVERRIDE=https://api.dev.uwhportal.com WAYLAND_DISPLAY= ./target/debug/refbox`
+
+Put a curly quote into the saved key in `~/.config/refbox/config.toml` — the real character `’`, not an escape:
+
+```toml
+[uwhportal]
+token = "abc’123"
+```
+
+Then, from a separate checkout at `origin/master`, `cargo build -p refbox` and launch as above. The event list loads (that call carries no authorization header, so it survives) — then **select an event**, which requests the schedule. That is an authenticated call, and it is built synchronously on the UI thread.
+
+Expected on master: the refbox dies the moment the event is selected. Capture the exit code and the panic line. Exit 101 at startup can also mean "no audio device" — confirm the panic message names `HeaderValue`, not audio.
+
+- [ ] **Step 5: Run the fixed binary against the same config**
+
+Same config, same launch line, this branch's build.
+
+Expected:
+- The refbox starts and stays up. Selecting an event is impossible because there is no client, which is the point: nothing is sent, and nothing is sent unauthenticated either.
+- The log contains `Failed to start the client for ...` naming the character `'\u{2019}'` — that message comes from `UnsendableAccessKey`'s `Display` through the existing `build_site_client` error path, which needed no code change.
+- The portal indicator is red.
+- Everything unrelated to the portal works normally.
+
+Then repair the key in the config (remove the curly quote), relaunch, and confirm the refbox connects and lists events as usual — proving the refusal is specific to the bad key and not a general breakage.
+
+Kill it with `pkill -x refbox`. Restore the backed-up config afterwards.
+
+- [ ] **Step 6: Record what was and was not proven live**
+
+The config-file route exercises the startup path, so the live run proves the crash is gone but does **not** display the new dialog. State this plainly in the PR: the dialog reason is covered by test and code reading only. Proving it live needs the mock portal server to answer a link-code exchange with a bad `accessKey`, which was deliberately deferred.
+
+- [ ] **Step 7: Code review, then ask about the PR**
+
+Run `superpowers:requesting-code-review` for the whole branch. Then write the PR body in the project's four-section format (What changed / Why / Scope / How to verify) and **ask the human before pushing or opening it**.
+
+---
+
+## Deviations
+
+Record anything that diverged from this plan here, and fold the note into the
+relevant code commit rather than making a standalone commit for it.
+
+- (none yet)

--- a/docs/superpowers/plans/2026-08-14-access-key-header-panic.md
+++ b/docs/superpowers/plans/2026-08-14-access-key-header-panic.md
@@ -751,12 +751,14 @@ Ask the human before launching — they drive the refbox UI. Two things matter a
 - **Never launch bare.** Without the override the refbox talks to the *production* portal and rewrites `portal_link.json`. Always:
   `UWH_PORTAL_URL_OVERRIDE=https://api.dev.uwhportal.com WAYLAND_DISPLAY= ./target/debug/refbox`
 
-Put a curly quote into the saved key in `~/.config/refbox/config.toml` — the real character `’`, not an escape:
+Put a **newline** into the saved key in `~/.config/refbox/config.toml`. TOML turns the `\n` escape into a real newline:
 
 ```toml
 [uwhportal]
-token = "abc’123"
+token = "abc\n123"
 ```
+
+**Use a newline, not a curly quote.** Measured with a `reqwest` probe over `Bearer <key>`: `HeaderValue::from_str` rejects a newline, a carriage return, NUL and DEL — and *accepts* a curly quote, `é` and a tab. Only the control characters ever panicked. A curly quote here would produce a false "master didn't crash". A trailing newline is the likeliest bad character in real life anyway: it is what copying a key out of a web page gives you.
 
 Then, from a separate checkout at `origin/master`, `cargo build -p refbox` and launch as above. The event list loads (that call carries no authorization header, so it survives) — then **select an event**, which requests the schedule. That is an authenticated call, and it is built synchronously on the UI thread.
 
@@ -768,7 +770,7 @@ Same config, same launch line, this branch's build.
 
 Expected:
 - The refbox starts and stays up. Selecting an event is impossible because there is no client, which is the point: nothing is sent, and nothing is sent unauthenticated either.
-- The log contains `Failed to start the client for ...` naming the character `'\u{2019}'` — that message comes from `UnsendableAccessKey`'s `Display` through the existing `build_site_client` error path, which needed no code change.
+- The log contains `Failed to start the client for ...` naming the character `'\n'` — that message comes from `UnsendableAccessKey`'s `Display` through the existing `build_site_client` error path, which needed no code change.
 - The portal indicator is red.
 - Everything unrelated to the portal works normally.
 
@@ -791,4 +793,8 @@ Run `superpowers:requesting-code-review` for the whole branch. Then write the PR
 Record anything that diverged from this plan here, and fold the note into the
 relevant code commit rather than making a standalone commit for it.
 
-- (none yet)
+- **The brief's three example characters were wrong in two of three cases.** Measured with a throwaway `reqwest` probe over `Bearer <key>`: `HeaderValue::from_str` **rejects** newline, carriage return, NUL and DEL; it **accepts** a curly quote (U+2019), `é` and a tab. Only the control characters ever panicked. Consequences, all folded into the tasks they affect rather than committed separately:
+  - The printable-ASCII rule is kept as specified, which makes it deliberately stricter than the panic set. An access key is base64 or a JWT and is ASCII by construction, so nothing legitimate is refused, and a curly-quoted key would otherwise come back as a mystifying permission error instead of a sentence naming the character. It is also the rule `schedule-processor` already ships and its tests assert.
+  - Task 2 gained a newline-based client test in fix round 1, so that deleting the guard reproduces the original panic rather than a plain assertion failure.
+  - Task 5's live run uses `token = "abc\n123"`, not a curly quote, which would otherwise have produced a false "master didn't crash".
+  - The spec was corrected in place with the measured table.

--- a/docs/superpowers/specs/2026-08-14-access-key-header-panic-design.md
+++ b/docs/superpowers/specs/2026-08-14-access-key-header-panic-design.md
@@ -14,10 +14,26 @@
 HeaderValue::from_str(&format!("Bearer {}", token)).unwrap()
 ```
 
-`HeaderValue::from_str` rejects any character an HTTP header cannot carry — a
-newline, a tab, a curly quote. The `unwrap` turns that rejection into a panic,
-which takes the whole refbox down mid-tournament with no message the operator
-can act on.
+`HeaderValue::from_str` rejects any character an HTTP header cannot carry. The
+`unwrap` turns that rejection into a panic, which takes the whole refbox down
+mid-tournament with no message the operator can act on.
+
+**Which characters actually panic** (measured, not assumed — a `reqwest` probe
+over `Bearer <key>`):
+
+| Character | `HeaderValue::from_str` |
+|---|---|
+| newline `\n` | **rejected — panics** |
+| carriage return `\r` | **rejected — panics** |
+| NUL, DEL | **rejected — panics** |
+| curly quote `’` (U+2019) | accepted |
+| `é` (U+00E9) | accepted |
+| tab | accepted |
+
+This corrects the original brief, which named a newline, a tab and a curly
+quote as equally fatal. Only the newline (and its control-character siblings)
+ever panicked — which is the likeliest of them anyway, since a key copied from
+a web page or a chat message carries a trailing newline.
 
 All 11 authenticated portal calls build their request through this one
 function, so every one of them inherits the panic.
@@ -83,9 +99,16 @@ A public check in `uwh-common::uwhportal` answers one question: *can this key be
 carried in a request header?* The rule is the one `schedule-processor` already
 uses — printable ASCII only (`' '..='~'`). Everything a real access key
 contains (letters, digits, and the punctuation used by base64 and JWTs) is in
-that range; everything outside it is what a header cannot carry. The failure
-names the offending character so the log line and the operator message can both
-be specific.
+that range. The failure names the offending character so the log line and the
+operator message can both be specific.
+
+This rule is deliberately **stricter** than the set of characters that actually
+panic. It refuses a curly quote and an accented letter too, which `HeaderValue`
+would have carried. That is kept on purpose: an access key is base64 or a JWT
+and is ASCII by construction, so nothing legitimate is refused, and a key with a
+curly quote in it would otherwise be sent and come back as a mystifying
+permission error rather than a sentence naming the character. It is also the
+rule `schedule-processor` already ships and its tests already assert.
 
 `schedule-processor::site::validate_access_key` keeps its own operator-facing
 wording, its own trimming, and its own `Ok(None)` "no key is fine" behaviour,
@@ -149,8 +172,9 @@ refbox UI.
 
 ## Acceptance criteria
 
-1. A refbox launched with a curly quote in its saved access key **does not
-   crash**. On master it does.
+1. A refbox launched with a newline in its saved access key **does not crash**.
+   On master it does. (A curly quote is refused too, but it never crashed —
+   see the table above.)
 2. The refbox with a bad key never sends an authenticated call without the
    header — it sends nothing at all and shows the red indicator.
 3. A key copied with a trailing newline is accepted, not refused.
@@ -173,10 +197,15 @@ goes red. No new test is trusted until it has been seen to fail.
 (`uwhportal` is already `std`-gated, so no-std is not expected to be affected —
 the check confirms it.)
 
-**Live, in the refbox:** put a key containing `U+2019` into
-`~/.config/refbox/config.toml`, launch, and trigger a portal call. On master:
-panic. With the fix: a log line naming the character, red indicator, refbox
-still running.
+**Live, in the refbox:** put a key containing a newline into
+`~/.config/refbox/config.toml` (`token = "abc\n123"` — TOML turns that escape
+into a real newline), launch, and trigger an authenticated portal call. On
+master: panic. With the fix: a log line naming the character, red indicator,
+refbox still running.
+
+The event-list request at startup is **unauthenticated**, so it does not
+trigger the crash. Selecting an event does — that requests the schedule, which
+is authenticated and is built on the UI thread.
 
 **Known limit:** the config-file route exercises the *startup* path, so the
 live run proves the crash is gone but does not display the new dialog. The

--- a/docs/superpowers/specs/2026-08-14-access-key-header-panic-design.md
+++ b/docs/superpowers/specs/2026-08-14-access-key-header-panic-design.md
@@ -35,7 +35,7 @@ quote as equally fatal. Only the newline (and its control-character siblings)
 ever panicked — which is the likeliest of them anyway, since a key copied from
 a web page or a chat message carries a trailing newline.
 
-All 11 authenticated portal calls build their request through this one
+All 10 authenticated portal calls build their request through this one
 function, so every one of them inherits the panic.
 
 ## Why it is reachable
@@ -74,15 +74,15 @@ wrong answer. Not an option at any layer of this design.
 ## Approach
 
 Refuse an unusable key **once, where the key arrives**, rather than at each of
-the 11 places it is used.
+the 10 places it is used.
 
 Considered and rejected:
 
 - *Check at every call* — `authenticated_request` returns a result and each of
-  the 11 methods propagates it. The refbox survives, but the operator gets the
+  the 10 methods propagates it. The refbox survives, but the operator gets the
   same failure repeatedly and forever (retrying can never fix a bad key), and
   the message arrives detached from the thing that caused it. It also leaves
-  eleven places that must each remember to handle the fault.
+  ten places that must each remember to handle the fault.
 - *Let reqwest carry the error* — hand the header value to reqwest as text and
   let it report a build error at send time. One line, no signature changes, but
   the message is generic ("builder error"), it still fails on every call
@@ -134,8 +134,8 @@ arrives**, and store the finished header value.
   caller anything.
 
 The point of this shape: after it, `authenticated_request` performs no
-conversion at all, so the 11 calls *cannot* fail this way again. This is a
-structural guarantee, not eleven remembered checks.
+conversion at all, so the 10 calls *cannot* fail this way again. This is a
+structural guarantee, not ten remembered checks.
 
 ### 3. What the operator sees
 

--- a/docs/superpowers/specs/2026-08-14-access-key-header-panic-design.md
+++ b/docs/superpowers/specs/2026-08-14-access-key-header-panic-design.md
@@ -1,0 +1,185 @@
+# Access key header panic — design
+
+**Date:** 2026-08-14
+**Branch:** `fix/uwh-common/access-key-header-panic`
+**Crates touched:** `uwh-common` (primary), `schedule-processor`, `refbox`
+
+---
+
+## The defect
+
+`uwh-common/src/uwhportal/mod.rs`, inside `authenticated_request`:
+
+```rust
+HeaderValue::from_str(&format!("Bearer {}", token)).unwrap()
+```
+
+`HeaderValue::from_str` rejects any character an HTTP header cannot carry — a
+newline, a tab, a curly quote. The `unwrap` turns that rejection into a panic,
+which takes the whole refbox down mid-tournament with no message the operator
+can act on.
+
+All 11 authenticated portal calls build their request through this one
+function, so every one of them inherits the panic.
+
+## Why it is reachable
+
+The original brief said an operator can paste an access key into the refbox's
+custom-site screen. **That is not what master does.** The custom-site page has
+exactly one text box — the site address
+(`refbox/src/app/view_builders/configuration.rs`, the `custom-site-placeholder`
+input) — and it is the only text input in the whole settings UI. The phrase
+"access key" appears nowhere in refbox's source or its English text.
+
+`custom_site.token` is written in exactly one place, `refbox/src/app/mod.rs`
+(`Message::RecvPortalToken` → `PortalTokenResponse::Success`), and the value
+comes from the site's own server answering the link-code exchange (the
+`accessKey` field of its reply).
+
+So the panic is reachable by two routes, neither of which is a paste box:
+
+1. **The site's server returns a header-hostile key.** A *custom* site is a
+   third party's server. Refbox trusts whatever string it returns and puts it
+   straight into the header.
+2. **A hand-edited `config.toml`.** `~/.config/refbox/config.toml` holds
+   `[custom_site] token = "..."` as plain text. Pasting a key into a config
+   file from a chat app or a word processor is exactly how a curly quote or a
+   trailing newline gets in.
+
+Both routes end at the same `unwrap`.
+
+## Rejected outright
+
+**Dropping the authorization header when it fails to build.** That would send
+the request unauthenticated: reads would quietly succeed with public data and
+writes would fail with a permission error, turning a loud crash into a silent
+wrong answer. Not an option at any layer of this design.
+
+## Approach
+
+Refuse an unusable key **once, where the key arrives**, rather than at each of
+the 11 places it is used.
+
+Considered and rejected:
+
+- *Check at every call* — `authenticated_request` returns a result and each of
+  the 11 methods propagates it. The refbox survives, but the operator gets the
+  same failure repeatedly and forever (retrying can never fix a bad key), and
+  the message arrives detached from the thing that caused it. It also leaves
+  eleven places that must each remember to handle the fault.
+- *Let reqwest carry the error* — hand the header value to reqwest as text and
+  let it report a build error at send time. One line, no signature changes, but
+  the message is generic ("builder error"), it still fails on every call
+  forever, and nothing in the code records that the key was ever checked.
+
+The chosen shape makes the bad state unrepresentable inside the client: the
+client only ever holds a key it has already proved it can send.
+
+## Design
+
+### 1. One shared rule, in `uwh-common`
+
+A public check in `uwh-common::uwhportal` answers one question: *can this key be
+carried in a request header?* The rule is the one `schedule-processor` already
+uses — printable ASCII only (`' '..='~'`). Everything a real access key
+contains (letters, digits, and the punctuation used by base64 and JWTs) is in
+that range; everything outside it is what a header cannot carry. The failure
+names the offending character so the log line and the operator message can both
+be specific.
+
+`schedule-processor::site::validate_access_key` keeps its own operator-facing
+wording, its own trimming, and its own `Ok(None)` "no key is fine" behaviour,
+but delegates the character question to this shared rule so the two cannot
+drift apart. Its comment claiming the panic is unfixed becomes false with this
+branch and is corrected in the same edit.
+
+### 2. The client stores a finished header, not raw text
+
+`UwhPortalClient` currently stores the key as `Option<String>` and converts it
+to a header on every call. It will instead convert **once, when the key
+arrives**, and store the finished header value.
+
+- Surrounding whitespace is trimmed before the check, so a key copied with a
+  trailing newline works — matching what `schedule-processor` already does for
+  a pasted key.
+- `UwhPortalClient::new` already returns a pass/fail result, so **its signature
+  does not change**; it gains a failure case for an unusable key.
+- `set_token` gains a result. On failure the client keeps whatever key it had
+  before rather than half-updating.
+- `has_token` and `clear_token` are unchanged. Nothing outside the client reads
+  the raw key back, so storing the header instead of the string costs no
+  caller anything.
+
+The point of this shape: after it, `authenticated_request` performs no
+conversion at all, so the 11 calls *cannot* fail this way again. This is a
+structural guarantee, not eleven remembered checks.
+
+### 3. What the operator sees
+
+| Route | Behaviour |
+|---|---|
+| Bad key in `config.toml` at startup | The client is not built, which is the refbox's existing "no portal connection" state: red indicator, nothing sent, never sent unauthenticated. The log line names the bad character. The refbox otherwise runs normally. |
+| Site's server returns a bad key after a link code | The existing link-failed dialog appears with a third reason. The key is **not** saved to the config and the token is **not** marked valid, so a bad key cannot lie dormant until the next launch. |
+
+The new English sentence, literal:
+
+```
+The site sent an access key this refbox cannot use. Ask the site for the key again.
+```
+
+It is added to all 15 locales. The dialog reason is a new refbox-side
+confirmation variant rather than a new `PortalTokenResponse` variant: the
+server never says "unusable key", the refbox concludes it, and the response
+type should keep meaning "what the server replied".
+
+## Files to change
+
+| File | Why |
+|---|---|
+| `uwh-common/src/uwhportal/mod.rs` | the shared check, the stored header, `set_token` result, tests |
+| `schedule-processor/src/site.rs` | delegate to the shared rule; correct the stale comment |
+| `schedule-processor/src/main.rs` | the 5 places that set a key now handle a refusal |
+| `refbox/src/app/mod.rs` | link-reply handling; new dialog reason; the debug-only key setter; build-failure log wording |
+| `refbox/src/app/view_builders/confirmation.rs` | render the new reason |
+| `refbox/translations/<15 locales>/refbox.ftl` | one new sentence in each |
+
+Out of scope: the login/token-refresh flow, any other `unwrap` in
+`uwhportal/mod.rs` not on this path, and adding an access-key entry box to the
+refbox UI.
+
+## Acceptance criteria
+
+1. A refbox launched with a curly quote in its saved access key **does not
+   crash**. On master it does.
+2. The refbox with a bad key never sends an authenticated call without the
+   header — it sends nothing at all and shows the red indicator.
+3. A key copied with a trailing newline is accepted, not refused.
+4. A good key still produces exactly the header `Bearer <key>`.
+5. `schedule-processor` still refuses a bad pasted key with its own sentence,
+   with its existing tests unchanged and passing.
+
+## How this is verified
+
+**Tests (`uwh-common`):** a curly quote, a newline and a tab are each refused;
+the client's existing key survives a refused update; a trailing newline is
+trimmed and accepted; a good key produces exactly `Bearer <key>`.
+
+**Mutation check:** delete the line the check lives on and confirm a named test
+goes red. No new test is trusted until it has been seen to fail.
+
+**Downstream:** `just check`, plus `cargo check` for `refbox`,
+`schedule-processor`, `overlay` and `led-panel-sim`, plus
+`cargo build -p uwh-common --no-default-features` for the no-std guarantee.
+(`uwhportal` is already `std`-gated, so no-std is not expected to be affected —
+the check confirms it.)
+
+**Live, in the refbox:** put a key containing `U+2019` into
+`~/.config/refbox/config.toml`, launch, and trigger a portal call. On master:
+panic. With the fix: a log line naming the character, red indicator, refbox
+still running.
+
+**Known limit:** the config-file route exercises the *startup* path, so the
+live run proves the crash is gone but does not display the new dialog. The
+dialog reason is covered by test and code reading only. Proving it live would
+need the mock portal server to answer a link-code exchange with a bad
+`accessKey`, which was deliberately deferred.

--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -40,7 +40,7 @@ use uwh_common::{
     drawing_support::*,
     game_snapshot::{GamePeriod, GameSnapshot, Infraction, TimeoutSnapshot},
     uwhportal::{
-        PortalTokenResponse, RosterPlayer, UwhPortalClient,
+        PortalTokenResponse, RosterPlayer, UwhPortalClient, check_access_key,
         schedule::{DateRange, Event, EventId, GameNumber, Schedule, TeamId},
     },
 };
@@ -357,6 +357,11 @@ pub enum BeepTestConfigPage {
 enum ConfirmationKind {
     Error(String),
     UwhPortalLinkFailed(PortalTokenResponse),
+    // Raised when the site's reply carried an access key this refbox cannot
+    // put in a header. Not a `PortalTokenResponse` variant: the server never
+    // says this, the refbox concludes it, and that type should keep meaning
+    // "what the server replied".
+    UwhPortalKeyUnusable,
     // The *FromApply variants are raised by per-page Apply on Game Options. They
     // commit only the Game slice and navigate back to settings (not out to MainPage).
     GameNumberChangedFromApply,
@@ -1482,7 +1487,9 @@ impl RefBoxApp {
                 let mut guard = client
                     .lock()
                     .unwrap_or_else(|poisoned| poisoned.into_inner());
-                guard.set_token("invalid-debug-token");
+                // A literal printable-ASCII key, so the check cannot refuse it;
+                // this is the debug scramble path, not an operator's key.
+                let _ = guard.set_token("invalid-debug-token");
                 warn!("UWH_PORTAL_SCRAMBLE_TOKEN: in-memory token replaced after event linked");
             }
             self.scramble_token_pending = false;
@@ -4774,7 +4781,8 @@ impl RefBoxApp {
 
                 // After ADR 009 Task 13 retired the global apply path, only
                 // `ConfirmationKind::Error` (which offers DiscardChanges) and
-                // `ConfirmationKind::UwhPortalLinkFailed` (which offers GoBack)
+                // `ConfirmationKind::UwhPortalLinkFailed` /
+                // `ConfirmationKind::UwhPortalKeyUnusable` (which offer GoBack)
                 // reach this match. The Game-related and PortalTenantSwitch
                 // confirmations are dispatched to apply_game_confirmation above.
                 self.app_state = match selection {
@@ -5137,49 +5145,65 @@ impl RefBoxApp {
                 let mut task = Task::none();
                 self.app_state = match token_response {
                     PortalTokenResponse::Success(token) => {
-                        info!("Portal token request succeeded");
-                        if let Some(client) = self.uwhportal_client.as_ref() {
-                            // why this cannot panic: the guard is held only for a
-                            // synchronous `set_token()` call and dropped immediately.
-                            client.lock().unwrap().set_token(&token);
-                        }
-                        // Save it against the site it was issued by. Writing it
-                        // to the portal's slot regardless would both destroy the
-                        // operator's real Portal login and leave the custom site
-                        // with no saved credential for the next launch.
-                        match self.current_site.kind {
-                            SiteKind::Portal => self.config.uwhportal.token = token,
-                            SiteKind::Custom => self.config.custom_site.token = token,
-                        }
-                        if let Some(ref mut settings) = self.edited_settings {
-                            settings.uwhportal_token_valid = Some(true);
-                        }
+                        // The site's reply is not trusted text. A custom site is
+                        // somebody else's server, and a key carrying a character a
+                        // header cannot hold used to take the refbox down on the
+                        // next call. Refusing it here also keeps it out of the
+                        // config file, so it cannot come back at the next launch.
+                        let token = token.trim().to_string();
+                        if let Err(why) = check_access_key(&token) {
+                            warn!("The site returned an access key that cannot be sent: {why}");
+                            AppState::ConfirmationPage(ConfirmationKind::UwhPortalKeyUnusable)
+                        } else {
+                            info!("Portal token request succeeded");
+                            if let Some(client) = self.uwhportal_client.as_ref() {
+                                // why this cannot panic: the guard is held only for a
+                                // synchronous `set_token()` call and dropped immediately.
+                                if let Err(why) = client.lock().unwrap().set_token(&token) {
+                                    // Cannot happen: the key was just checked with the
+                                    // same rule `set_token` applies. Logged rather than
+                                    // ignored so a future divergence is not silent.
+                                    error!("Client refused a key that passed the check: {why}");
+                                }
+                            }
+                            // Save it against the site it was issued by. Writing it
+                            // to the portal's slot regardless would both destroy the
+                            // operator's real Portal login and leave the custom site
+                            // with no saved credential for the next launch.
+                            match self.current_site.kind {
+                                SiteKind::Portal => self.config.uwhportal.token = token,
+                                SiteKind::Custom => self.config.custom_site.token = token,
+                            }
+                            if let Some(ref mut settings) = self.edited_settings {
+                                settings.uwhportal_token_valid = Some(true);
+                            }
 
-                        // Tell the portal manager the token is healthy
-                        // again: clears the token-known-problem flag and
-                        // resets queue-item attempt counters so pending
-                        // items resume retrying on the next background
-                        // tick. Errors here are logged but not
-                        // propagated — the in-memory state is already
-                        // correct and the operator has no actionable
-                        // recovery from an I/O failure at this point.
-                        if let Err(e) = self.portal_manager.token_refreshed() {
-                            error!("portal_manager.token_refreshed failed: {e}");
-                        }
+                            // Tell the portal manager the token is healthy
+                            // again: clears the token-known-problem flag and
+                            // resets queue-item attempt counters so pending
+                            // items resume retrying on the next background
+                            // tick. Errors here are logged but not
+                            // propagated — the in-memory state is already
+                            // correct and the operator has no actionable
+                            // recovery from an I/O failure at this point.
+                            if let Err(e) = self.portal_manager.token_refreshed() {
+                                error!("portal_manager.token_refreshed failed: {e}");
+                            }
 
-                        if let Some(event_id) = self
-                            .edited_settings
-                            .as_ref()
-                            .and_then(|settings| settings.current_event_id.as_ref())
-                            .or(self.current_event_id.as_ref())
-                        {
-                            info!("Requesting schedule for event_id: {}", event_id.full());
-                            task = self.request_schedule(event_id.clone())
-                        }
+                            if let Some(event_id) = self
+                                .edited_settings
+                                .as_ref()
+                                .and_then(|settings| settings.current_event_id.as_ref())
+                                .or(self.current_event_id.as_ref())
+                            {
+                                info!("Requesting schedule for event_id: {}", event_id.full());
+                                task = self.request_schedule(event_id.clone())
+                            }
 
-                        // A successful re-login lands on the edit-config
-                        // Game page (the portal parameters page).
-                        AppState::EditGameConfig(ConfigPage::Game)
+                            // A successful re-login lands on the edit-config
+                            // Game page (the portal parameters page).
+                            AppState::EditGameConfig(ConfigPage::Game)
+                        }
                     }
                     r @ PortalTokenResponse::NoPendingLink
                     | r @ PortalTokenResponse::InvalidCode => {

--- a/refbox/src/app/mod.rs
+++ b/refbox/src/app/mod.rs
@@ -5148,24 +5148,27 @@ impl RefBoxApp {
                         // The site's reply is not trusted text. A custom site is
                         // somebody else's server, and a key carrying a character a
                         // header cannot hold used to take the refbox down on the
-                        // next call. Refusing it here also keeps it out of the
-                        // config file, so it cannot come back at the next launch.
+                        // next call. One decision point, not two: the client itself
+                        // refuses the key, so there is no way for the check and the
+                        // store to disagree and let a request go out with no
+                        // credential attached. Refusing here also keeps the key out
+                        // of the config file, so it cannot come back at the next
+                        // launch.
                         let token = token.trim().to_string();
-                        if let Err(why) = check_access_key(&token) {
+                        let refused = match self.uwhportal_client.as_ref() {
+                            // why this cannot panic: the guard is held only for a
+                            // synchronous `set_token()` call and dropped immediately.
+                            Some(client) => client.lock().unwrap().set_token(&token).err(),
+                            // No client to hold the key, so the same rule is applied
+                            // directly — a key that cannot be sent must never reach
+                            // the config file.
+                            None => check_access_key(&token).err(),
+                        };
+                        if let Some(why) = refused {
                             warn!("The site returned an access key that cannot be sent: {why}");
                             AppState::ConfirmationPage(ConfirmationKind::UwhPortalKeyUnusable)
                         } else {
                             info!("Portal token request succeeded");
-                            if let Some(client) = self.uwhportal_client.as_ref() {
-                                // why this cannot panic: the guard is held only for a
-                                // synchronous `set_token()` call and dropped immediately.
-                                if let Err(why) = client.lock().unwrap().set_token(&token) {
-                                    // Cannot happen: the key was just checked with the
-                                    // same rule `set_token` applies. Logged rather than
-                                    // ignored so a future divergence is not silent.
-                                    error!("Client refused a key that passed the check: {why}");
-                                }
-                            }
                             // Save it against the site it was issued by. Writing it
                             // to the portal's slot regardless would both destroy the
                             // operator's real Portal login and leave the custom site

--- a/refbox/src/app/view_builders/confirmation.rs
+++ b/refbox/src/app/view_builders/confirmation.rs
@@ -37,6 +37,7 @@ pub(in super::super) fn build_confirmation_page<'a>(
             fl!("uwhportal-token-no-pending-link")
         }
         ConfirmationKind::UwhPortalLinkFailed(PortalTokenResponse::Success(_)) => unreachable!(),
+        ConfirmationKind::UwhPortalKeyUnusable => fl!("uwhportal-token-unusable-key"),
         ConfirmationKind::SwitchToManualFromApply => fl!("apply-switch-to-manual"),
         // A custom site survives the restart with its address and token intact,
         // so it gets a message that says so rather than one promising a lost
@@ -115,7 +116,7 @@ pub(in super::super) fn build_confirmation_page<'a>(
                 ConfirmationOption::DiscardChanges,
             ),
         ],
-        ConfirmationKind::UwhPortalLinkFailed(_) => {
+        ConfirmationKind::UwhPortalLinkFailed(_) | ConfirmationKind::UwhPortalKeyUnusable => {
             vec![(fl!("ok"), green_button, ConfirmationOption::GoBack)]
         }
         ConfirmationKind::SwitchToManualFromApply => vec![

--- a/refbox/translations/de-DE/refbox.ftl
+++ b/refbox/translations/de-DE/refbox.ftl
@@ -198,6 +198,8 @@ uwhportal-token-invalid-code = Ungültiger Code eingegeben.
     Bitte erneut versuchen.
 uwhportal-token-no-pending-link = Die Verbindung erwartet keine Kommunikation.
     Bitte erneut versuchen.
+uwhportal-token-unusable-key = Die Website hat einen Zugangsschlüssel gesendet, den diese Refbox nicht verwenden kann.
+    Fordern Sie den Schlüssel erneut bei der Website an.
 go-back-to-editor = ZURÜCK ZUM EDITOR
 discard-changes = ÄNDERUNGEN VERWERFEN
 end-current-game-and-apply-changes = AKTUELLES SPIEL BEENDEN UND ÄNDERUNGEN ÜBERNEHMEN

--- a/refbox/translations/en-US/refbox.ftl
+++ b/refbox/translations/en-US/refbox.ftl
@@ -201,6 +201,8 @@ uwhportal-token-invalid-code = Invalid code entered.
     Please try again.
 uwhportal-token-no-pending-link = The connection is not expecting communication.
     Please try again.
+uwhportal-token-unusable-key = The site sent an access key this refbox cannot use.
+    Ask the site for the key again.
 go-back-to-editor = GO BACK TO EDITOR
 discard-changes = DISCARD CHANGES
 end-current-game-and-apply-changes = END CURRENT GAME AND APPLY CHANGES

--- a/refbox/translations/es/refbox.ftl
+++ b/refbox/translations/es/refbox.ftl
@@ -209,6 +209,8 @@ uwhportal-token-invalid-code = Código inválido.
 ### Check
 uwhportal-token-no-pending-link = La conexión no espera comunicación.
     Por favor, inténtelo de nuevo.
+uwhportal-token-unusable-key = El sitio envió una clave de acceso que esta Refbox no puede usar.
+    Solicite la clave al sitio de nuevo.
 go-back-to-editor = VOLVER AL EDITOR
 discard-changes = DESCARTAR CAMBIOS
 end-current-game-and-apply-changes = TERMINAR EL JUEGO ACTUAL Y APLICAR CAMBIOS

--- a/refbox/translations/fr/refbox.ftl
+++ b/refbox/translations/fr/refbox.ftl
@@ -202,6 +202,8 @@ uwhportal-token-invalid-code = Code invalide.
 ### Check
 uwhportal-token-no-pending-link = La connexion n'attend aucune communication.
     Veuillez réessayer.
+uwhportal-token-unusable-key = Le site a envoyé une clé d'accès que cette Refbox ne peut pas utiliser.
+    Demandez à nouveau la clé au site.
 go-back-to-editor = RETOURNER À L'ÉDITEUR
 discard-changes = ANNULER LES MODIFICATIONS
 end-current-game-and-apply-changes = TERMINER LE MATCH EN COURS ET APPLIQUER LES MODIFICATIONS

--- a/refbox/translations/id-ID/refbox.ftl
+++ b/refbox/translations/id-ID/refbox.ftl
@@ -198,6 +198,8 @@ uwhportal-token-invalid-code = Kode yang dimasukkan tidak valid.
     Silakan coba lagi.
 uwhportal-token-no-pending-link = Koneksi tidak mengharapkan komunikasi.
     Silakan coba lagi.
+uwhportal-token-unusable-key = Situs mengirim kunci akses yang tidak dapat digunakan Refbox ini.
+    Mintalah kunci itu lagi dari situs Anda.
 go-back-to-editor = KEMBALI KE EDITOR
 discard-changes = BUANG PERUBAHAN
 end-current-game-and-apply-changes = AKHIRI PERTANDINGAN DAN TERAPKAN PERUBAHAN

--- a/refbox/translations/it-IT/refbox.ftl
+++ b/refbox/translations/it-IT/refbox.ftl
@@ -198,6 +198,8 @@ uwhportal-token-invalid-code = Codice inserito non valido.
     Riprova.
 uwhportal-token-no-pending-link = La connessione non si aspetta comunicazioni.
     Riprova.
+uwhportal-token-unusable-key = Il sito ha inviato una chiave di accesso che questa Refbox non può usare.
+    Richiedi di nuovo la chiave al sito.
 go-back-to-editor = TORNA ALL'EDITOR
 discard-changes = SCARTA MODIFICHE
 end-current-game-and-apply-changes = TERMINA PARTITA E APPLICA MODIFICHE

--- a/refbox/translations/ja-JP/refbox.ftl
+++ b/refbox/translations/ja-JP/refbox.ftl
@@ -198,6 +198,8 @@ uwhportal-token-invalid-code = 無効なコードが入力されました。
     もう一度試してください。
 uwhportal-token-no-pending-link = 接続は通信を待っていません。
     もう一度試してください。
+uwhportal-token-unusable-key = サイトから送られたアクセスキーは、この Refbox では使用できません。
+    サイトにキーをもう一度要求してください。
 go-back-to-editor = 編集画面に戻る
 discard-changes = 変更を破棄
 end-current-game-and-apply-changes = 現在の試合を終了して変更を適用

--- a/refbox/translations/ko-KR/refbox.ftl
+++ b/refbox/translations/ko-KR/refbox.ftl
@@ -200,6 +200,8 @@ uwhportal-token-invalid-code = 잘못된 코드가 입력되었습니다.
     다시 시도하세요.
 uwhportal-token-no-pending-link = 연결이 통신을 기다리지 않습니다.
     다시 시도하세요.
+uwhportal-token-unusable-key = 사이트에서 보낸 액세스 키를 이 Refbox에서 사용할 수 없습니다.
+    사이트에 키를 다시 요청하세요.
 go-back-to-editor = 편집기로 돌아가기
 discard-changes = 변경 사항 버리기
 end-current-game-and-apply-changes = 현재 경기 종료 및 변경 사항 적용

--- a/refbox/translations/ms-MY/refbox.ftl
+++ b/refbox/translations/ms-MY/refbox.ftl
@@ -198,6 +198,8 @@ uwhportal-token-invalid-code = Kod yang dimasukkan tidak sah.
     Sila cuba lagi.
 uwhportal-token-no-pending-link = Sambungan tidak menjangka komunikasi.
     Sila cuba lagi.
+uwhportal-token-unusable-key = Tapak ini menghantar kunci akses yang tidak boleh digunakan oleh Refbox ini.
+    Minta kunci itu semula daripada tapak anda.
 go-back-to-editor = KEMBALI KE EDITOR
 discard-changes = BUANG PERUBAHAN
 end-current-game-and-apply-changes = TAMATKAN PERLAWANAN SEMASA DAN GUNA PERUBAHAN

--- a/refbox/translations/nl-NL/refbox.ftl
+++ b/refbox/translations/nl-NL/refbox.ftl
@@ -198,6 +198,8 @@ uwhportal-token-invalid-code = Ongeldige code ingevoerd.
     Probeer het opnieuw.
 uwhportal-token-no-pending-link = De verbinding verwacht geen communicatie.
     Probeer het opnieuw.
+uwhportal-token-unusable-key = De site heeft een toegangssleutel gestuurd die deze Refbox niet kan gebruiken.
+    Vraag de sleutel opnieuw op bij de site.
 go-back-to-editor = TERUG NAAR EDITOR
 discard-changes = WIJZIGINGEN VERWERPEN
 end-current-game-and-apply-changes = HUIDIGE WEDSTRIJD BEËINDIGEN EN WIJZIGINGEN TOEPASSEN

--- a/refbox/translations/pt-PT/refbox.ftl
+++ b/refbox/translations/pt-PT/refbox.ftl
@@ -198,6 +198,8 @@ uwhportal-token-invalid-code = Código introduzido inválido.
     Tente novamente.
 uwhportal-token-no-pending-link = A ligação não está à espera de comunicação.
     Tente novamente.
+uwhportal-token-unusable-key = O site enviou uma chave de acesso que esta Refbox não consegue usar.
+    Peça novamente a chave ao site.
 go-back-to-editor = VOLTAR AO EDITOR
 discard-changes = DESCARTAR ALTERAÇÕES
 end-current-game-and-apply-changes = TERMINAR JOGO ATUAL E APLICAR ALTERAÇÕES

--- a/refbox/translations/th-TH/refbox.ftl
+++ b/refbox/translations/th-TH/refbox.ftl
@@ -198,6 +198,8 @@ uwhportal-token-invalid-code = รหัสที่ป้อนไม่ถู�
     โปรดลองอีกครั้ง
 uwhportal-token-no-pending-link = การเชื่อมต่อไม่รอการสื่อสาร
     โปรดลองอีกครั้ง
+uwhportal-token-unusable-key = เว็บไซต์ส่งคีย์การเข้าถึงที่ Refbox นี้ใช้ไม่ได้
+    โปรดขอคีย์จากเว็บไซต์อีกครั้ง
 go-back-to-editor = กลับไปยังตัวแก้ไข
 discard-changes = ยกเลิกการเปลี่ยนแปลง
 end-current-game-and-apply-changes = สิ้นสุดเกมปัจจุบันและใช้การเปลี่ยนแปลง

--- a/refbox/translations/tl-PH/refbox.ftl
+++ b/refbox/translations/tl-PH/refbox.ftl
@@ -198,6 +198,8 @@ uwhportal-token-invalid-code = Maling code ang naipasok.
     Pakisubukan muli.
 uwhportal-token-no-pending-link = Hindi inaasahan ng koneksyon ang komunikasyon.
     Pakisubukan muli.
+uwhportal-token-unusable-key = Nagpadala ang site ng access key na hindi magagamit ng Refbox na ito.
+    Hilingin muli ang key sa site.
 go-back-to-editor = BUMALIK SA EDITOR
 discard-changes = ITAPON ANG MGA PAGBABAGO
 end-current-game-and-apply-changes = TAPUSIN ANG KASALUKUYANG LARO AT ILAPAT ANG MGA PAGBABAGO

--- a/refbox/translations/tr-TR/refbox.ftl
+++ b/refbox/translations/tr-TR/refbox.ftl
@@ -198,6 +198,8 @@ uwhportal-token-invalid-code = Geçersiz kod girildi.
     Lütfen tekrar deneyin.
 uwhportal-token-no-pending-link = Bağlantı iletişim beklemiyor.
     Lütfen tekrar deneyin.
+uwhportal-token-unusable-key = Site, bu Refbox'ın kullanamayacağı bir erişim anahtarı gönderdi.
+    Anahtarı siteden tekrar isteyin.
 go-back-to-editor = DÜZENLEYICIYE GERİ DÖN
 discard-changes = DEĞİŞİKLİKLERİ İPTAL ET
 end-current-game-and-apply-changes = MEVCUT OYUNU BİTİR VE DEĞİŞİKLİKLERİ UYGULA

--- a/refbox/translations/zh-CN/refbox.ftl
+++ b/refbox/translations/zh-CN/refbox.ftl
@@ -198,6 +198,8 @@ uwhportal-token-invalid-code = 输入的代码无效。
     请重试。
 uwhportal-token-no-pending-link = 连接未等待通信。
     请重试。
+uwhportal-token-unusable-key = 站点发送的访问密钥无法在此 Refbox 上使用。
+    请再次向站点索取密钥。
 go-back-to-editor = 返回编辑器
 discard-changes = 放弃更改
 end-current-game-and-apply-changes = 结束当前比赛并应用所有更改

--- a/schedule-processor/src/main.rs
+++ b/schedule-processor/src/main.rs
@@ -570,7 +570,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 // The client keeps the token from here on; the
                                 // startup key is not held separately, so a
                                 // later `clear_token` asks for it again.
-                                Ok(Some(key)) => portal_client.set_token(&key),
+                                Ok(Some(key)) => {
+                                    if let Err(why) = portal_client.set_token(&key) {
+                                        error!("{why}");
+                                        continue 'outer;
+                                    }
+                                }
                                 Ok(None) => {
                                     error!("An access key is needed for this step.");
                                     continue 'outer;
@@ -612,7 +617,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 }
                             };
 
-                            portal_client.set_token(&token);
+                            if let Err(why) = portal_client.set_token(&token) {
+                                error!(
+                                    "The site returned an access key that cannot be used: {why}"
+                                );
+                                continue 'outer;
+                            }
                         }
                     }
                 }
@@ -767,7 +777,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         .login_with_email_and_password(&emailOrusername, &password)
                         .await
                     {
-                        Ok(token) => portal_client.set_token(&token),
+                        Ok(token) => {
+                            if let Err(why) = portal_client.set_token(&token) {
+                                error!(
+                                    "The site returned an access key that cannot be used: {why}"
+                                );
+                                continue 'outer;
+                            }
+                        }
                         Err(e) => {
                             error!("uwhportal login failed. Please try again. Reason: {e}");
                             continue 'outer;
@@ -1077,7 +1094,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                     .login_with_email_and_password(&emailOrusername, &password)
                                     .await
                                 {
-                                    Ok(token) => portal_client.set_token(&token),
+                                    Ok(token) => {
+                                        if let Err(why) = portal_client.set_token(&token) {
+                                            error!(
+                                                "The site returned an access key that cannot be \
+                                                 used. Proceeding without login. Reason: {why}"
+                                            );
+                                        }
+                                    }
                                     Err(e) => error!(
                                         "uwhportal login failed. Proceeding without login. \
                                         Reason: {e}"
@@ -1127,7 +1151,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 .login_with_email_and_password(&emailOrusername, &password)
                                 .await
                             {
-                                Ok(token) => portal_client.set_token(&token),
+                                Ok(token) => {
+                                    if let Err(why) = portal_client.set_token(&token) {
+                                        error!(
+                                            "The site returned an access key that cannot be used: {why}"
+                                        );
+                                        continue 'outer;
+                                    }
+                                }
                                 Err(e) => {
                                     error!("Login failed: {e}");
                                     continue 'outer;

--- a/schedule-processor/src/site.rs
+++ b/schedule-processor/src/site.rs
@@ -67,23 +67,20 @@ pub fn custom_target(typed_url: &str) -> Result<SiteTarget, String> {
 /// `Ok(None)` means no key was given, which is allowed — an open site can be
 /// read without one, and anything that later needs a key asks for it then.
 ///
-/// This check is not decoration. `uwh-common` builds its authorization header
-/// with `HeaderValue::from_str(...).unwrap()`, which panics on any character a
-/// header cannot carry. Until that is fixed on its own branch, a pasted key is
-/// the one place a person's typing reaches it, so it is checked here first: a
-/// bad paste has to produce a sentence, never a crash.
+/// The character rule lives in `uwh-common`, which owns the header this key
+/// ends up in, so the two cannot drift apart. `uwh-common` refuses a bad key
+/// too; this check exists so the operator gets a sentence about their paste at
+/// the moment they paste it, rather than a failure later.
 pub fn validate_access_key(raw: &str) -> Result<Option<String>, String> {
     let key = raw.trim();
     if key.is_empty() {
         return Ok(None);
     }
-    // Printable ASCII only. Everything a key normally contains — letters,
-    // digits, and the punctuation used by base64 and JWTs — is in this range,
-    // and everything outside it is what a header cannot carry.
-    if let Some(bad) = key.chars().find(|c| !matches!(c, ' '..='~')) {
+    if let Err(why) = uwh_common::uwhportal::check_access_key(key) {
         return Err(format!(
-            "That access key contains a character that cannot be sent to the site ({bad:?}). \
-             Copy the key again, straight from where your site shows it."
+            "That access key contains a character that cannot be sent to the site \
+             ({:?}). Copy the key again, straight from where your site shows it.",
+            why.character
         ));
     }
     Ok(Some(key.to_string()))

--- a/uwh-common/src/uwhportal/mod.rs
+++ b/uwh-common/src/uwhportal/mod.rs
@@ -923,9 +923,14 @@ impl Error for UnsendableAccessKey {}
 /// Check that `key` can be carried in an `Authorization` header.
 ///
 /// Printable ASCII only. Everything a real access key contains — letters,
-/// digits, and the punctuation used by base64 and JWTs — is in this range, and
-/// everything outside it is what a header cannot carry: a newline, a tab, a
-/// curly quote left by a chat app or a word processor.
+/// digits, and the punctuation used by base64 and JWTs — is in this range.
+/// This rule is stricter than what a header actually rejects: headers refuse
+/// only control characters (newline, carriage return, NUL, and DEL), and would
+/// accept curly quotes and accented letters. But an access key is base64 or a
+/// JWT and must be ASCII. Rejecting anything outside printable ASCII means an
+/// invalid key is caught here with a clear message about the offending
+/// character, instead of being sent to the site and returning an unexplained
+/// permission error.
 ///
 /// Whitespace around the key is *not* trimmed here; callers that accept a
 /// pasted key trim first, so that this reports only characters that are

--- a/uwh-common/src/uwhportal/mod.rs
+++ b/uwh-common/src/uwhportal/mod.rs
@@ -874,6 +874,43 @@ impl std::fmt::Display for ApiError {
 
 impl Error for ApiError {}
 
+/// A character an access key must not contain, because an HTTP header cannot
+/// carry it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UnsendableAccessKey {
+    /// The first character in the key that cannot be sent.
+    pub character: char,
+}
+
+impl std::fmt::Display for UnsendableAccessKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "the access key contains a character that cannot be sent to the site ({:?})",
+            self.character
+        )
+    }
+}
+
+impl Error for UnsendableAccessKey {}
+
+/// Check that `key` can be carried in an `Authorization` header.
+///
+/// Printable ASCII only. Everything a real access key contains — letters,
+/// digits, and the punctuation used by base64 and JWTs — is in this range, and
+/// everything outside it is what a header cannot carry: a newline, a tab, a
+/// curly quote left by a chat app or a word processor.
+///
+/// Whitespace around the key is *not* trimmed here; callers that accept a
+/// pasted key trim first, so that this reports only characters that are
+/// genuinely part of the key.
+pub fn check_access_key(key: &str) -> Result<(), UnsendableAccessKey> {
+    match key.chars().find(|c| !matches!(c, ' '..='~')) {
+        Some(character) => Err(UnsendableAccessKey { character }),
+        None => Ok(()),
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum PortalTokenResponse {
     Success(String),
@@ -1019,5 +1056,31 @@ mod roster_tests {
             "managers, coaches and officials must not take up player rows, but a \
              player-manager and a captain must be kept"
         );
+    }
+}
+
+#[cfg(test)]
+mod access_key_tests {
+    use super::*;
+
+    #[test]
+    fn a_curly_quote_is_refused_and_named() {
+        // The case this exists for: a key copied through a chat app or a word
+        // processor, where a straight quote has been turned into a curly one.
+        let err = check_access_key("abc\u{2019}123").unwrap_err();
+        assert_eq!(err.character, '\u{2019}');
+    }
+
+    #[test]
+    fn a_newline_or_tab_is_refused() {
+        assert_eq!(check_access_key("abc\n123").unwrap_err().character, '\n');
+        assert_eq!(check_access_key("abc\t123").unwrap_err().character, '\t');
+    }
+
+    #[test]
+    fn a_normal_key_is_accepted() {
+        // Letters, digits, and the punctuation base64 and JWTs use.
+        let key = "eyJhbGciOiJI.UzI1NiIs-InR5cCI6_IkpXVCJ9~abc+/=";
+        assert_eq!(check_access_key(key), Ok(()));
     }
 }

--- a/uwh-common/src/uwhportal/mod.rs
+++ b/uwh-common/src/uwhportal/mod.rs
@@ -1138,7 +1138,8 @@ mod access_key_tests {
 
     #[test]
     fn a_client_cannot_be_built_with_a_key_that_cannot_be_sent() {
-        // On master this succeeded, and the panic waited until the first call.
+        // On master this succeeded and the key was stored unchecked; a control
+        // character in that position would then have panicked on the first call.
         assert!(test_client(Some("abc\u{2019}123")).is_err());
     }
 

--- a/uwh-common/src/uwhportal/mod.rs
+++ b/uwh-common/src/uwhportal/mod.rs
@@ -157,7 +157,9 @@ pub struct SetCoinFlipModel {
 
 pub struct UwhPortalClient {
     base_url: String,
-    access_token: Option<String>,
+    // The finished header, not the raw key. Building it here, once, is what
+    // keeps a key that cannot be sent out of the 11 calls that use it.
+    auth_header: Option<HeaderValue>,
     client: Client,
     id: OnceCell<u32>,
 }
@@ -176,24 +178,35 @@ impl UwhPortalClient {
 
         let base_url = base_url.trim_end_matches('/').to_string();
 
+        let auth_header = match access_token {
+            Some(token) => Some(build_auth_header(token)?),
+            None => None,
+        };
+
         Ok(Self {
             base_url,
-            access_token: access_token.map(|s| s.to_string()),
+            auth_header,
             client,
             id: OnceCell::new(),
         })
     }
 
-    pub fn set_token(&mut self, token: &str) {
-        self.access_token = Some(token.to_string());
+    /// Replace the access key.
+    ///
+    /// The key is checked and converted before it is stored, so a key that
+    /// cannot be sent is refused here — the previous key is kept and the
+    /// client is never left half-updated.
+    pub fn set_token(&mut self, token: &str) -> Result<(), UnsendableAccessKey> {
+        self.auth_header = Some(build_auth_header(token)?);
+        Ok(())
     }
 
     pub fn clear_token(&mut self) {
-        self.access_token = None;
+        self.auth_header = None;
     }
 
     pub fn has_token(&self) -> bool {
-        self.access_token.is_some()
+        self.auth_header.is_some()
     }
 
     pub fn id(&self) -> u32 {
@@ -306,7 +319,7 @@ impl UwhPortalClient {
             self.base_url,
             event.partial()
         );
-        let request = authenticated_request(&self.client, Method::GET, &url, &self.access_token);
+        let request = authenticated_request(&self.client, Method::GET, &url, &self.auth_header);
 
         async move {
             let response = request.send().await?;
@@ -330,7 +343,7 @@ impl UwhPortalClient {
     ) -> impl std::future::Future<Output = Result<(), Box<dyn Error>>> + use<> {
         let url = format!("{}/api/admin/events/stats", self.base_url);
 
-        let request = authenticated_request(&self.client, Method::POST, &url, &self.access_token)
+        let request = authenticated_request(&self.client, Method::POST, &url, &self.auth_header)
             .query(&[("eventId", event_id.full()), ("gameNumber", game_number)])
             .body(stats_json.clone())
             .header("Content-Type", "application/json")
@@ -363,7 +376,7 @@ impl UwhPortalClient {
             event_id.partial(),
         );
 
-        let request = authenticated_request(&self.client, Method::POST, &url, &self.access_token)
+        let request = authenticated_request(&self.client, Method::POST, &url, &self.auth_header)
             .query(&[("force", force)])
             .json(&serde_json::json!({
             "dark": {
@@ -407,7 +420,7 @@ impl UwhPortalClient {
         );
 
         let request =
-            authenticated_request(&self.client, Method::GET, &url, &self.access_token).send();
+            authenticated_request(&self.client, Method::GET, &url, &self.auth_header).send();
 
         async move {
             let response = request.await?;
@@ -586,7 +599,7 @@ impl UwhPortalClient {
         let url = format!("{}/api/events/{event_slug}/schedule", self.base_url);
 
         let mut request =
-            authenticated_request(&self.client, Method::POST, &url, &self.access_token)
+            authenticated_request(&self.client, Method::POST, &url, &self.auth_header)
                 .json(schedule);
 
         if force {
@@ -621,7 +634,7 @@ impl UwhPortalClient {
             self.base_url
         );
 
-        let request = authenticated_request(&self.client, Method::POST, &url, &self.access_token)
+        let request = authenticated_request(&self.client, Method::POST, &url, &self.auth_header)
             .json(&team_map);
 
         async move {
@@ -700,7 +713,7 @@ impl UwhPortalClient {
             self.base_url
         );
         let request =
-            authenticated_request(&self.client, Method::GET, &url, &self.access_token).send();
+            authenticated_request(&self.client, Method::GET, &url, &self.auth_header).send();
         async move {
             let response = request.await?;
             let status = response.status();
@@ -734,7 +747,7 @@ impl UwhPortalClient {
             event_id.partial()
         );
         let request =
-            authenticated_request(&self.client, Method::GET, &url, &self.access_token).send();
+            authenticated_request(&self.client, Method::GET, &url, &self.auth_header).send();
         async move {
             let response = request.await?;
             if response.status() != StatusCode::OK {
@@ -778,7 +791,7 @@ impl UwhPortalClient {
         let url = format!("{}/api/admin/events/game-referees", self.base_url);
         let event_id_full = event_id.full().to_string();
         let game_number = game_number.clone();
-        let request = authenticated_request(&self.client, Method::GET, &url, &self.access_token)
+        let request = authenticated_request(&self.client, Method::GET, &url, &self.auth_header)
             .query(&[("eventId", &event_id_full), ("gameNumber", &game_number)])
             .send();
         async move {
@@ -823,7 +836,7 @@ impl UwhPortalClient {
             "{}/api/events/{event_slug}/schedule/coin-flips",
             self.base_url
         );
-        let request = authenticated_request(&self.client, Method::POST, &url, &self.access_token)
+        let request = authenticated_request(&self.client, Method::POST, &url, &self.auth_header)
             .query(&[("force", force)])
             .json(model)
             .send();
@@ -843,16 +856,29 @@ fn authenticated_request(
     client: &Client,
     method: Method,
     url: &str,
-    access_token: &Option<String>,
+    auth_header: &Option<HeaderValue>,
 ) -> RequestBuilder {
     let mut request = client.request(method, url);
-    if let Some(token) = access_token {
-        request = request.header(
-            AUTHORIZATION,
-            HeaderValue::from_str(&format!("Bearer {}", token)).unwrap(),
-        );
+    if let Some(value) = auth_header {
+        request = request.header(AUTHORIZATION, value.clone());
     }
     request
+}
+
+/// Turn an access key into the `Authorization` header value, or say which
+/// character stops it.
+///
+/// Surrounding whitespace is dropped first: a key copied out of a web page
+/// arrives with a trailing newline, and that is worth accepting rather than
+/// refusing.
+fn build_auth_header(token: &str) -> Result<HeaderValue, UnsendableAccessKey> {
+    let token = token.trim();
+    check_access_key(token)?;
+    // why this cannot panic: `check_access_key` has just proved every
+    // character is in `' '..='~'` (0x20..=0x7E), which is exactly the range
+    // `from_str` accepts, and "Bearer " is itself in that range.
+    Ok(HeaderValue::from_str(&format!("Bearer {token}"))
+        .expect("a printable-ASCII key always makes a valid header value"))
 }
 
 #[derive(Debug)]
@@ -1082,5 +1108,68 @@ mod access_key_tests {
         // Letters, digits, and the punctuation base64 and JWTs use.
         let key = "eyJhbGciOiJI.UzI1NiIs-InR5cCI6_IkpXVCJ9~abc+/=";
         assert_eq!(check_access_key(key), Ok(()));
+    }
+
+    fn test_client(key: Option<&str>) -> Result<UwhPortalClient, Box<dyn Error>> {
+        UwhPortalClient::new("https://example.test", key, true, Duration::from_secs(5))
+    }
+
+    #[test]
+    fn a_good_key_becomes_exactly_one_bearer_header() {
+        let client = test_client(Some("good-key")).unwrap();
+        let request = authenticated_request(
+            &client.client,
+            Method::GET,
+            "https://example.test/thing",
+            &client.auth_header,
+        )
+        .build()
+        .unwrap();
+        assert_eq!(
+            request.headers().get(AUTHORIZATION).unwrap(),
+            "Bearer good-key"
+        );
+    }
+
+    #[test]
+    fn a_client_cannot_be_built_with_a_key_that_cannot_be_sent() {
+        // On master this succeeded, and the panic waited until the first call.
+        assert!(test_client(Some("abc\u{2019}123")).is_err());
+    }
+
+    #[test]
+    fn a_refused_key_leaves_the_previous_key_in_place() {
+        // A half-updated client would be worse than a refused one: it would
+        // start sending calls with no credential at all.
+        let mut client = test_client(Some("good-key")).unwrap();
+        assert!(client.set_token("abc\u{2019}123").is_err());
+        assert_eq!(
+            client.auth_header,
+            Some(HeaderValue::from_static("Bearer good-key"))
+        );
+        assert!(client.has_token());
+    }
+
+    #[test]
+    fn a_key_copied_with_a_trailing_newline_is_trimmed_not_refused() {
+        // Copying a key out of a web page is how the newline gets there.
+        let mut client = test_client(None).unwrap();
+        assert_eq!(client.set_token("  good-key \r\n"), Ok(()));
+        assert_eq!(
+            client.auth_header,
+            Some(HeaderValue::from_static("Bearer good-key"))
+        );
+    }
+
+    #[test]
+    fn a_key_with_a_newline_inside_it_is_refused() {
+        // THE original crash. A trailing newline is trimmed and forgiven, but
+        // one in the middle of the key is not, and this is the character
+        // `HeaderValue::from_str` actually rejects — a curly quote it would
+        // have carried. Delete the check in `build_auth_header` and this test
+        // panics rather than fails, which is the crash it exists to prevent.
+        let mut client = test_client(None).unwrap();
+        assert_eq!(client.set_token("abc\n123").unwrap_err().character, '\n');
+        assert!(!client.has_token());
     }
 }


### PR DESCRIPTION
## What changed

An access key that contains a character an HTTP header cannot carry no longer crashes the refbox.

Before this change, such a key reached the code that builds the request header, which refused it, and the refusal was treated as impossible — so the whole referee application died. Reproduced on master while writing this: a refbox with a saved event link asks for its schedule during startup, so it died **before the operator could touch anything**. At a tournament that is a refbox that will not open.

Now the key is checked once, at the moment it arrives — when the app starts and reads its saved key, or when a site hands one over after a link code. What the operator sees:

- **A bad key already saved:** the refbox starts normally and runs normally. The portal indicator is red, nothing is sent, and the log names the offending character. Nothing is ever sent without the key attached.
- **A site returns a bad key while linking:** a dialog says *"The site sent an access key this refbox cannot use. Ask the site for the key again."* — translated into all 15 languages. The bad key is not saved, so it cannot come back at the next launch.
- **A key copied with a trailing newline** — what you get copying out of a web page — is now tidied up and accepted rather than refused.

The `schedule-processor` already refused a bad pasted key with its own message. It keeps that message, but now asks the shared rule the character question, so the two cannot drift apart.

## Why

The crash used to be unreachable: keys only ever came from a login response. That is no longer true — a key can come from a *custom* site, which is somebody else's server, and it can be edited by hand into the config file. Every authenticated call to the portal went through the one piece of code that panicked, so every one of them could take the refbox down.

Worth stating plainly, because it is not obvious from the commits: the rule the code applies (printable ASCII only) is **deliberately stricter** than what actually crashes. Only a newline, a carriage return and two other invisible control characters ever panicked — a curly quote or an accented letter would have been sent quite happily. Those are refused anyway, because a real access key is machine-generated and never contains them, and a key with a curly quote in it would otherwise come back from the site as an unexplained permission error rather than a sentence naming the character.

## Scope

- `uwh-common/src/uwhportal/mod.rs` — the shared check, and the client now stores a finished header instead of raw text
- `schedule-processor/src/site.rs`, `src/main.rs` — uses the shared rule; handles a refused key at the five places it sets one
- `refbox/src/app/mod.rs`, `src/app/view_builders/confirmation.rs` — the refusal and the new dialog reason
- `refbox/translations/<15 locales>/refbox.ftl` — one new sentence each

No dependency changes, no wire-format changes, no change to the embedded firmware. `uwh-common` still builds without the standard library.

## How to verify

**By running it.** Put a key with a newline in it into `~/.config/refbox/config.toml` — in TOML, `token = "abc\n123"` gives a real newline — and launch the refbox against the dev portal:

```
UWH_PORTAL_URL_OVERRIDE=https://api.dev.uwhportal.com WAYLAND_DISPLAY= ./target/debug/refbox
```

On master the window never appears; the log ends in a panic at `uwh-common/src/uwhportal/mod.rs:852`. On this branch the refbox starts and stays up, the portal indicator is red, and the log reads:

```
Failed to start the client for https://api.dev.uwhportal.com:
the access key contains a character that cannot be sent to the site ('\n')
portal subsystem starting in degraded (red, not-sending) mode — no results will be uploaded this session
```

Put the real key back, relaunch, and it connects as usual — schedule and team rosters load. Both halves were run before this PR was opened.

**By the tests.** `cargo test -p uwh-common access_key_tests` covers a newline, a tab, a curly quote, a key trimmed of its trailing newline, and a good key producing exactly the header `Bearer <key>`. Each was watched failing before the fix existed: deleting the one line the fix lives on makes the newline test reproduce the original crash rather than fail politely.

`just check` is green.

**The dialog, seen live.** A stand-in server was stood up to answer the link-code exchange with `accessKey` = `abc\n123`, and the refbox was pointed at it as a custom site. Entering a link code produced exactly the intended dialog — *"The site sent an access key this refbox cannot use. / Ask the site for the key again."* with a single OK button — with the refbox still running behind it and no panic. Both sides are on the record:

```
site  --> POST /api/events/1234-B/access-keys/ref-box  body={"code":"1234","refBoxId":"437477"}
site  <-- 200 accessKey='abc\n123'
refbox    WARN The site returned an access key that cannot be sent:
               the access key contains a character that cannot be sent to the site ('\n')
```

Afterwards the custom site's key slot in the config was still **empty** — the bad key was not saved, so it cannot come back at the next launch. The stand-in server was a throwaway outside the repo; nothing was added to the source tree for it.

## Known limits

- One cosmetic wrinkle is left in place: a log line in the `schedule-processor` prints a lowercase sentence fragment. It sits on a path that cannot currently be reached at all.