### PR TITLE
refactor(uwh-common): drop the unusable public schedule call

### DIFF
--- a/schedule-processor/src/main.rs
+++ b/schedule-processor/src/main.rs
@@ -1126,7 +1126,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     Err(e) => {
                         let msg = e.to_string();
                         if msg.contains("authentication required for schedule") {
-                            info!("Public schedule not available; prompting for login...");
+                            info!(
+                                "A login is required to read the schedule; prompting for login..."
+                            );
                             #[allow(non_snake_case)]
                             let emailOrusername =
                                 match Text::new("Enter your uwhportal emailOrusername:").prompt() {

--- a/schedule-processor/src/scoresheets.rs
+++ b/schedule-processor/src/scoresheets.rs
@@ -89,16 +89,15 @@ pub async fn generate_scoresheets_for_event(
     csv_schedule: Option<&uwh_common::uwhportal::schedule::Schedule>,
     ref_csv_path: Option<&Path>,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    // The schedule is only available to a logged-in caller. The portal does serve an
+    // unauthenticated schedule on the same path, but in a different shape that this
+    // crate has never been able to read, so there is nothing to fall back to.
     let schedule = if portal_client.has_token() {
-        // Prefer privileged schedule when we can; it includes referee assignments
         portal_client
             .get_event_schedule_privileged(&event.id)
             .await?
     } else {
-        match portal_client.get_event_schedule_public(&event.id).await {
-            Ok(s) => s,
-            Err(_) => return Err(Box::new(AuthRequiredError)),
-        }
+        return Err(Box::new(AuthRequiredError));
     };
     let teams = portal_client.get_event_teams(&event.id).await?;
 

--- a/uwh-common/src/uwhportal/mod.rs
+++ b/uwh-common/src/uwhportal/mod.rs
@@ -653,34 +653,6 @@ impl UwhPortalClient {
 
     // --- Scoresheet generation portal calls (schedule / roster / referees / coin-flip) ---
 
-    /// Public (unauthenticated) event schedule. NOTE: for some events the public
-    /// endpoint returns games as a JSON array rather than the object `GameList`
-    /// expects; if this fails to parse for real data, use
-    /// `get_event_schedule_privileged` instead.
-    pub fn get_event_schedule_public(
-        &self,
-        event_id: &EventId,
-    ) -> impl std::future::Future<Output = Result<schedule::Schedule, Box<dyn Error>>> + use<> {
-        let url = format!(
-            "{}/api/events/{}/schedule",
-            self.base_url,
-            event_id.partial()
-        );
-        let request = self.client.get(&url).send();
-        async move {
-            let response = request.await?;
-            if response.status() == StatusCode::OK {
-                let body = response.text().await?;
-                let schedule: schedule::Schedule = serde_json::from_str(&body)?;
-                Ok(schedule)
-            } else {
-                warn!("uwhportal get public event schedule failed, response: {response:?}");
-                let body = response.text().await?;
-                Err(Box::new(ApiError::new(body)))?
-            }
-        }
-    }
-
     pub fn get_team_roster(
         &self,
         team_id: &TeamId,


### PR DESCRIPTION
## What changed

`schedule-processor` no longer makes a request to the Portal that cannot succeed.

When generating scoresheets without being logged in, the tool asked the Portal for the
event schedule on the public, no-login address, and then treated the inevitable failure
as "you need to log in". It now simply asks for a login straight away. **Nothing an
operator sees or does changes** — the same prompt appears at the same moment.

The unused call is deleted from `uwh-common`, along with a comment claiming it works
for some events.

## Why

The call deserialised the response into the same shape the logged-in schedule uses. The
Portal's public schedule is a genuinely different shape: the games arrive as a plain list
rather than a lookup table keyed by game number, there is no event ID and no `groups`
section at the top level, and each game's teams sit one level deeper. Measured across 100
events on the production and dev APIs while documenting the Portal contract, **every one**
returned that shape — so this code path has never once worked against real data.

It was worth checking whether to make it work rather than remove it. The public response
does carry enough to build a scoresheet, including team referee assignments (present on
5 of the 10 recent production events I sampled that had games published), and the team-name
call is already unauthenticated. But the capability has never existed, nobody is relying
on it, and anyone who wants officials' names on the sheet is prompted to log in regardless.
Teaching the code a second payload shape — in the workspace's highest-blast-radius crate,
for a shape the Portal can change under us — buys a capability no one has asked for.

If it is ever wanted, the exact gap is now recorded: event ID, games shape, `groups`, and
the extra `assignment` nesting.

## Scope

- `uwh-common/src/uwhportal/mod.rs` — the deleted call
- `schedule-processor/src/scoresheets.rs` — goes straight to "login required"
- `schedule-processor/src/main.rs` — one log line now gives the real reason

Nothing in `refbox` or `overlay` is touched. Neither ever called this.

## How to verify

**Automated:** `just check` is green — formatting, linter, the full test suite, and the
security scan. Because this is `uwh-common`, I also confirmed each downstream crate still
compiles on its own (`refbox`, `schedule-processor`, `overlay`, `led-panel-sim`) and that
`uwh-common` still builds without the standard library, per that crate's own checklist.

**By eye:** run schedule-processor, pick an event, choose to generate scoresheets without
logging in first. You are asked to log in — as you were before this change. Logging in
produces the scoresheets as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
